### PR TITLE
verilator: Fixes for Linux and Docker

### DIFF
--- a/hw/system/snitch_cluster/Makefile
+++ b/hw/system/snitch_cluster/Makefile
@@ -22,7 +22,7 @@ VERILATOR_FLAGS += -Wno-fatal
 VERILATOR_FLAGS += --trace
 VERILATOR_FLAGS += --unroll-count 1024
 
-CFLAGS ?= -std=c++14 -I obj_dir -I $(VERILATOR_ROOT)/include -I $(VERILATOR_ROOT)/include/vltstd -I $(RISCV)/include
+CFLAGS ?= -std=c++14 -pthread -I obj_dir -I $(VERILATOR_ROOT)/include -I $(VERILATOR_ROOT)/include/vltstd -I $(RISCV)/include
 
 build:
 	$(CXX) $(CFLAGS) -c test/tb_lib.cc -o obj_dir/tb_lib.o
@@ -45,7 +45,7 @@ build:
 verilate:
 	mkdir -p obj_dir
 	bender script verilator -t rtl > obj_dir/files
-	verilator src/snitch_cfg.sv -f obj_dir/files $(VERILATOR_FLAGS) --cc --build --top-module testharness
+	verilator src/snitch_cfg.sv -f obj_dir/files $(VERILATOR_FLAGS) -j $(shell nproc) --cc --build --top-module testharness
 
 traces: $(shell ls trace_hart_*.dasm | sed 's/\.dasm/\.txt/')
 

--- a/hw/system/snitch_cluster/test/snitch_cluster.hh
+++ b/hw/system/snitch_cluster/test/snitch_cluster.hh
@@ -6,6 +6,7 @@
 #include <fesvr/context.h>
 #include <fesvr/htif.h>
 
+#include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <memory>

--- a/hw/system/snitch_cluster/test/tb_lib.cc
+++ b/hw/system/snitch_cluster/test/tb_lib.cc
@@ -32,7 +32,7 @@ void Sim::read_chunk(addr_t taddr, size_t len, void *dst) {
 }
 
 void Sim::write_chunk(addr_t taddr, size_t len, const void *src) {
-    uint8_t strb[8] = {[0 ... 7] = 1};
+    uint8_t strb[8] = {1, 1, 1, 1, 1, 1, 1, 1};
     MEM.write(taddr, len, reinterpret_cast<const uint8_t *>(src), strb);
 }
 

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -7,6 +7,8 @@
 # 1. Stage
 FROM ubuntu:18.04 AS builder
 
+ARG SPIKE_VERSION=641d7d03e6a8d822b720fcb1a19f261813c00c4a
+
 COPY apt-requirements.txt /tmp/apt-requirements.txt
 RUN apt-get update && \
     sed 's/#.*//' /tmp/apt-requirements.txt \


### PR DESCRIPTION
That concludes the Docker set-up. I could verify that the Docker image now runs and compiles without problem on AWS machines. 

There are four "fixes" necessary (which didn't show up on my OS X machine):

1. Include `pthread` with `-pthread`.
2. Add missing `chrono` header.
3. `{[0 ... 7] = 1};` array initialization was too fancy for the `gcc` version distributed with Ubutu 18.04.
4. Pin the `riscv-isa-sim` version to a particular version. The latest commits were breaking the `fesvr` library support.