### PR TITLE
hw/ip/snitch/src: LSU fix in the case of a full load queue

### DIFF
--- a/hw/ip/snitch/src/snitch_lsu.sv
+++ b/hw/ip/snitch/src/snitch_lsu.sv
@@ -123,7 +123,7 @@ module snitch_lsu import snitch_pkg::*; #(
   /* verilator lint_on WIDTH */
 
   // the interface didn't accept our request yet
-  assign lsu_qready_o = ~(data_qvalid_o & ~data_qready_i) & ~laq_full;
+  assign lsu_qready_o = ~(data_qvalid_o & ~data_qready_i) & (lsu_qwrite | ~laq_full);
   assign laq_push = ~lsu_qwrite & data_qready_i & data_qvalid_o & ~laq_full;
 
   // Return Path


### PR DESCRIPTION
Hi!
There seems to be an issue when the load queue is full in the Snitch LSU: in this case stores are not seen ready, which leads to multiple identical writes being sent instead of just one.
Here is what could happen in this case:
![lsu2](https://user-images.githubusercontent.com/28906668/104167817-4981b280-53fd-11eb-94fa-065ea9ba598c.png)