### PR TITLE
requirements: Update Python requirements

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+dataclasses
 editorconfig-checker
 flake8
 gitpython


### PR DESCRIPTION
`dataclasses` are packaged with newer versions of Python but need to be installed for any "older" versions.