### PR TITLE
ci: Update schema doc

### DIFF
--- a/docs/schema-doc/snitch_cluster-properties-addr_width.md
+++ b/docs/schema-doc/snitch_cluster-properties-addr_width.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/addr_widt
 
 Length of the address, should be greater than 30. If the address is larger than 34 the data bus needs to be 64 bits in size.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## addr_width Type
 

--- a/docs/schema-doc/snitch_cluster-properties-boot_addr.md
+++ b/docs/schema-doc/snitch_cluster-properties-boot_addr.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/boot_addr
 
 Address from which all harts of the cluster start to boot. The default setting is `0x8000_0000`.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## boot_addr Type
 

--- a/docs/schema-doc/snitch_cluster-properties-cluster_base_addr.md
+++ b/docs/schema-doc/snitch_cluster-properties-cluster_base_addr.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster_b
 
 Base address of this cluster.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## cluster_base_addr Type
 

--- a/docs/schema-doc/snitch_cluster-properties-data_width.md
+++ b/docs/schema-doc/snitch_cluster-properties-data_width.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/data_widt
 
 Data bus size of the integer core (everything except the DMA), must be 32 or 64. A double precision FPU requires 64 bit data length.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## data_width Type
 

--- a/docs/schema-doc/snitch_cluster-properties-dma_axi_req_fifo_depth.md
+++ b/docs/schema-doc/snitch_cluster-properties-dma_axi_req_fifo_depth.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_axi_r
 
 Number of AXI FIFO entries of the DMA engine.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## dma_axi_req_fifo_depth Type
 

--- a/docs/schema-doc/snitch_cluster-properties-dma_data_width.md
+++ b/docs/schema-doc/snitch_cluster-properties-dma_data_width.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_data_
 
 Data bus size of DMA. Usually this is larger than the integer core as the DMA is used to efficiently transfer bulk of data.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## dma_data_width Type
 

--- a/docs/schema-doc/snitch_cluster-properties-dma_id_width_in.md
+++ b/docs/schema-doc/snitch_cluster-properties-dma_id_width_in.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_id_wi
 
 Id width of the wide AXI plug into the cluster.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## dma_id_width_in Type
 

--- a/docs/schema-doc/snitch_cluster-properties-dma_req_fifo_depth.md
+++ b/docs/schema-doc/snitch_cluster-properties-dma_req_fifo_depth.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_req_f
 
 Number of request entries the DMA can keep
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## dma_req_fifo_depth Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hart_base_id.md
+++ b/docs/schema-doc/snitch_cluster-properties-hart_base_id.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hart_base
 
 Base hart id of the cluster. All cores get the respective cluster id plus their cluster position as the final `hart_id`.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## hart_base_id Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xfrep-extension.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xfrep-extension.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Floating-point repetition buffer (Xfrep) custom extension.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## xfrep Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xssr-extension.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xssr-extension.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Stream Semantic Registers (Xssr) custom extension.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## xssr Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-isa-string-containing-risc-v-standard-extensions.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-isa-string-containing-risc-v-standard-extensions.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 ISA string as defined by the RISC-V standard. Only contain the standardized ISA extensions.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## isa Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_dtlb_entries.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_dtlb_entries.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Number of DTLB entries. Determines the core's size.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## num_dtlb_entries Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_loads.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_loads.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Number of outstanding floating-point loads. Determines the buffer size in the FPU's load/store unit.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## num_fp_outstanding_loads Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_mem.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_mem.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Number of outstanding memory operations. Determines the buffer size in the core's load/store unit.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## num_fp_outstanding_mem Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_loads.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_loads.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Number of outstanding integer loads. Determines the buffer size in the core's load/store unit.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## num_int_outstanding_loads Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_mem.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_mem.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Number of outstanding memory operations. Determines the buffer size in the core's load/store unit.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## num_int_outstanding_mem Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_itlb_entries.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_itlb_entries.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Number of ITLB entries. Determines the core's size.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## num_itlb_entries Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_sequencer_instructions.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_sequencer_instructions.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Amount of floating-point instruction the floating-point sequence buffer can hold.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## num_sequencer_instructions Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-ssr_nr_credits.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-ssr_nr_credits.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Number of credits and buffer depth of SSR FIFOs.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## ssr_nr_credits Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xdma-extension.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xdma-extension.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Direct memory access (Xdma) custom extension.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## xdma Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16-16-bit-float-extension.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16-16-bit-float-extension.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Enable Smallfloat Xf16 extension (IEEE 16-bit float).
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## xf16 Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16alt-16-bit-brain-float-extension.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16alt-16-bit-brain-float-extension.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Enable Smallfloat Xf16alt extension, also known as brain-float.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## xf16alt Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf8-16-bit-float-extension.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf8-16-bit-float-extension.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Enable Smallfloat Xf8 extension (IEEE 8-bit float).
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## xf8 Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xfvec-extension.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xfvec-extension.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Enable Smallfloat vector extension (SIMD).
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## xfvec Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores-core-description.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Description of a single core.
 
-
-| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ------------ | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## items Type
 
@@ -17,36 +16,38 @@ Description of a single core.
 
 # Core Description Properties
 
-| Property                                                  | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                                  |
-| :-------------------------------------------------------- | --------- | -------- | -------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [isa](#isa)                                               | `string`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-isa-string-containing-risc-v-standard-extensions.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/isa")  |
-| [xssr](#xssr)                                             | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xssr-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xssr")                            |
-| [xfrep](#xfrep)                                           | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xfrep-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xfrep")                          |
-| [xdma](#xdma)                                             | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xdma-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xdma")                                   |
-| [xf8](#xf8)                                               | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf8-16-bit-float-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf8")                        |
-| [xf16](#xf16)                                             | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16-16-bit-float-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf16")                      |
-| [xf16alt](#xf16alt)                                       | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16alt-16-bit-brain-float-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf16alt")          |
-| [xfvec](#xfvec)                                           | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xfvec-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xfvec")                                 |
-| [ssr_nr_credits](#ssr_nr_credits)                         | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-ssr_nr_credits.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/ssr_nr_credits")                         |
-| [num_int_outstanding_loads](#num_int_outstanding_loads)   | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_loads.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_int_outstanding_loads")   |
-| [num_int_outstanding_mem](#num_int_outstanding_mem)       | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_mem.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_int_outstanding_mem")       |
-| [num_fp_outstanding_loads](#num_fp_outstanding_loads)     | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_loads.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_fp_outstanding_loads")     |
-| [num_fp_outstanding_mem](#num_fp_outstanding_mem)         | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_mem.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_fp_outstanding_mem")         |
-| [num_sequencer_instructions](#num_sequencer_instructions) | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_sequencer_instructions.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_sequencer_instructions") |
-| [num_itlb_entries](#num_itlb_entries)                     | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_itlb_entries.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_itlb_entries")                     |
-| [num_dtlb_entries](#num_dtlb_entries)                     | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_dtlb_entries.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_dtlb_entries")                     |
+| Property                                                  | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                                             |
+| :-------------------------------------------------------- | :-------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [isa](#isa)                                               | `string`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-isa-string-containing-risc-v-standard-extensions.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/isa")  |
+| [xssr](#xssr)                                             | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xssr-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xssr")                            |
+| [xfrep](#xfrep)                                           | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xfrep-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xfrep")                          |
+| [xdma](#xdma)                                             | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xdma-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xdma")                                   |
+| [xf8](#xf8)                                               | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf8-16-bit-float-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf8")                        |
+| [xf16](#xf16)                                             | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16-16-bit-float-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf16")                      |
+| [xf16alt](#xf16alt)                                       | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16alt-16-bit-brain-float-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf16alt")          |
+| [xfvec](#xfvec)                                           | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xfvec-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xfvec")                                 |
+| [ssr_nr_credits](#ssr_nr_credits)                         | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-ssr_nr_credits.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/ssr_nr_credits")                         |
+| [num_int_outstanding_loads](#num_int_outstanding_loads)   | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_loads.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_int_outstanding_loads")   |
+| [num_int_outstanding_mem](#num_int_outstanding_mem)       | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_mem.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_int_outstanding_mem")       |
+| [num_fp_outstanding_loads](#num_fp_outstanding_loads)     | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_loads.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_fp_outstanding_loads")     |
+| [num_fp_outstanding_mem](#num_fp_outstanding_mem)         | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_mem.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_fp_outstanding_mem")         |
+| [num_sequencer_instructions](#num_sequencer_instructions) | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_sequencer_instructions.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_sequencer_instructions") |
+| [num_itlb_entries](#num_itlb_entries)                     | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_itlb_entries.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_itlb_entries")                     |
+| [num_dtlb_entries](#num_dtlb_entries)                     | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_dtlb_entries.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_dtlb_entries")                     |
 
 ## isa
 
 ISA string as defined by the RISC-V standard. Only contain the standardized ISA extensions.
 
-
 `isa`
 
--   is optional
--   Type: `string` ([ISA String containing RISC-V standard extensions.](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-isa-string-containing-risc-v-standard-extensions.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-isa-string-containing-risc-v-standard-extensions.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/isa")
+*   is optional
+
+*   Type: `string` ([ISA String containing RISC-V standard extensions.](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-isa-string-containing-risc-v-standard-extensions.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-isa-string-containing-risc-v-standard-extensions.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/isa")
 
 ### isa Type
 
@@ -70,13 +71,15 @@ The default value is:
 
 Stream Semantic Registers (Xssr) custom extension.
 
-
 `xssr`
 
--   is optional
--   Type: `boolean` ([Enable Xssr Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xssr-extension.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xssr-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xssr")
+*   is optional
+
+*   Type: `boolean` ([Enable Xssr Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xssr-extension.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xssr-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xssr")
 
 ### xssr Type
 
@@ -94,13 +97,15 @@ true
 
 Floating-point repetition buffer (Xfrep) custom extension.
 
-
 `xfrep`
 
--   is optional
--   Type: `boolean` ([Enable Xfrep Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xfrep-extension.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xfrep-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xfrep")
+*   is optional
+
+*   Type: `boolean` ([Enable Xfrep Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xfrep-extension.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-enable-xfrep-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xfrep")
 
 ### xfrep Type
 
@@ -118,13 +123,15 @@ true
 
 Direct memory access (Xdma) custom extension.
 
-
 `xdma`
 
--   is optional
--   Type: `boolean` ([Xdma Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xdma-extension.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xdma-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xdma")
+*   is optional
+
+*   Type: `boolean` ([Xdma Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xdma-extension.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xdma-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xdma")
 
 ### xdma Type
 
@@ -134,13 +141,15 @@ Direct memory access (Xdma) custom extension.
 
 Enable Smallfloat Xf8 extension (IEEE 8-bit float).
 
-
 `xf8`
 
--   is optional
--   Type: `boolean` ([Xf8 16-bit Float Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf8-16-bit-float-extension.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf8-16-bit-float-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf8")
+*   is optional
+
+*   Type: `boolean` ([Xf8 16-bit Float Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf8-16-bit-float-extension.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf8-16-bit-float-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf8")
 
 ### xf8 Type
 
@@ -150,13 +159,15 @@ Enable Smallfloat Xf8 extension (IEEE 8-bit float).
 
 Enable Smallfloat Xf16 extension (IEEE 16-bit float).
 
-
 `xf16`
 
--   is optional
--   Type: `boolean` ([Xf16 16-bit Float Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16-16-bit-float-extension.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16-16-bit-float-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf16")
+*   is optional
+
+*   Type: `boolean` ([Xf16 16-bit Float Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16-16-bit-float-extension.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16-16-bit-float-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf16")
 
 ### xf16 Type
 
@@ -166,13 +177,15 @@ Enable Smallfloat Xf16 extension (IEEE 16-bit float).
 
 Enable Smallfloat Xf16alt extension, also known as brain-float.
 
-
 `xf16alt`
 
--   is optional
--   Type: `boolean` ([Xf16alt 16-bit Brain-Float Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16alt-16-bit-brain-float-extension.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16alt-16-bit-brain-float-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf16alt")
+*   is optional
+
+*   Type: `boolean` ([Xf16alt 16-bit Brain-Float Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16alt-16-bit-brain-float-extension.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xf16alt-16-bit-brain-float-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xf16alt")
 
 ### xf16alt Type
 
@@ -182,13 +195,15 @@ Enable Smallfloat Xf16alt extension, also known as brain-float.
 
 Enable Smallfloat vector extension (SIMD).
 
-
 `xfvec`
 
--   is optional
--   Type: `boolean` ([Xfvec Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xfvec-extension.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xfvec-extension.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xfvec")
+*   is optional
+
+*   Type: `boolean` ([Xfvec Extension](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xfvec-extension.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-xfvec-extension.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/xfvec")
 
 ### xfvec Type
 
@@ -198,13 +213,15 @@ Enable Smallfloat vector extension (SIMD).
 
 Number of credits and buffer depth of SSR FIFOs.
 
-
 `ssr_nr_credits`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-ssr_nr_credits.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/ssr_nr_credits")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-ssr_nr_credits.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/ssr_nr_credits")
 
 ### ssr_nr_credits Type
 
@@ -222,13 +239,15 @@ The default value is:
 
 Number of outstanding integer loads. Determines the buffer size in the core's load/store unit.
 
-
 `num_int_outstanding_loads`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_loads.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_int_outstanding_loads")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_loads.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_int_outstanding_loads")
 
 ### num_int_outstanding_loads Type
 
@@ -246,13 +265,15 @@ The default value is:
 
 Number of outstanding memory operations. Determines the buffer size in the core's load/store unit.
 
-
 `num_int_outstanding_mem`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_mem.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_int_outstanding_mem")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_int_outstanding_mem.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_int_outstanding_mem")
 
 ### num_int_outstanding_mem Type
 
@@ -270,13 +291,15 @@ The default value is:
 
 Number of outstanding floating-point loads. Determines the buffer size in the FPU's load/store unit.
 
-
 `num_fp_outstanding_loads`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_loads.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_fp_outstanding_loads")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_loads.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_fp_outstanding_loads")
 
 ### num_fp_outstanding_loads Type
 
@@ -294,13 +317,15 @@ The default value is:
 
 Number of outstanding memory operations. Determines the buffer size in the core's load/store unit.
 
-
 `num_fp_outstanding_mem`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_mem.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_fp_outstanding_mem")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_fp_outstanding_mem.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_fp_outstanding_mem")
 
 ### num_fp_outstanding_mem Type
 
@@ -318,13 +343,15 @@ The default value is:
 
 Amount of floating-point instruction the floating-point sequence buffer can hold.
 
-
 `num_sequencer_instructions`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_sequencer_instructions.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_sequencer_instructions")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_sequencer_instructions.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_sequencer_instructions")
 
 ### num_sequencer_instructions Type
 
@@ -342,13 +369,15 @@ The default value is:
 
 Number of ITLB entries. Determines the core's size.
 
-
 `num_itlb_entries`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_itlb_entries.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_itlb_entries")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_itlb_entries.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_itlb_entries")
 
 ### num_itlb_entries Type
 
@@ -366,13 +395,15 @@ The default value is:
 
 Number of DTLB entries. Determines the core's size.
 
-
 `num_dtlb_entries`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_dtlb_entries.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_dtlb_entries")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores-core-description-properties-num_dtlb_entries.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores/items/properties/num_dtlb_entries")
 
 ### num_dtlb_entries Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-cores.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 List of all cores in the respective hive.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## cores Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-default.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-default.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## default Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-cacheline.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-cacheline.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Cacheline/Word size in bits.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## cacheline Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-sets.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-sets.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Number of ways.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## sets Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-size.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-size.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Total instruction cache size in KiByte.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## size Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Detailed configuration of the current Hive's instruction cache.
 
-
-| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ------------ | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## icache Type
 
@@ -29,23 +28,25 @@ The default value is:
 
 # Hive's instruction cache configuration. Properties
 
-| Property                | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                          |
-| :---------------------- | -------- | -------- | -------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [size](#size)           | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-size.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/size")           |
-| [sets](#sets)           | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-sets.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/sets")           |
-| [cacheline](#cacheline) | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-cacheline.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/cacheline") |
+| Property                | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                                                     |
+| :---------------------- | :------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [size](#size)           | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-size.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/size")           |
+| [sets](#sets)           | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-sets.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/sets")           |
+| [cacheline](#cacheline) | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-cacheline.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/cacheline") |
 
 ## size
 
 Total instruction cache size in KiByte.
 
-
 `size`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-size.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/size")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-size.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/size")
 
 ### size Type
 
@@ -55,13 +56,15 @@ Total instruction cache size in KiByte.
 
 Number of ways.
 
-
 `sets`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-sets.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/sets")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-sets.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/sets")
 
 ### sets Type
 
@@ -71,13 +74,15 @@ Number of ways.
 
 Cacheline/Word size in bits.
 
-
 `cacheline`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-cacheline.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/cacheline")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration-properties-cacheline.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache/properties/cacheline")
 
 ### cacheline Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives-hive-description.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives-hive-description.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/ite
 
 Configuration of a Hive
 
-
-| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ------------ | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## items Type
 
@@ -17,22 +16,24 @@ Configuration of a Hive
 
 # Hive Description Properties
 
-| Property          | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                |
-| :---------------- | -------- | -------- | -------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [icache](#icache) | `object` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache") |
-| [cores](#cores)   | `array`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores")                                  |
+| Property          | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                           |
+| :---------------- | :------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [icache](#icache) | `object` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache") |
+| [cores](#cores)   | `array`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores")                                  |
 
 ## icache
 
 Detailed configuration of the current Hive's instruction cache.
 
-
 `icache`
 
--   is optional
--   Type: `object` ([Hive's instruction cache configuration.](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache")
+*   is optional
+
+*   Type: `object` ([Hive's instruction cache configuration.](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-hives-instruction-cache-configuration.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/icache")
 
 ### icache Type
 
@@ -54,13 +55,15 @@ The default value is:
 
 List of all cores in the respective hive.
 
-
 `cores`
 
--   is optional
--   Type: `object[]` ([Core Description](snitch_cluster-properties-hives-hive-description-properties-cores-core-description.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores")
+*   is optional
+
+*   Type: `object[]` ([Core Description](snitch_cluster-properties-hives-hive-description-properties-cores-core-description.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives-hive-description-properties-cores.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives/items/properties/cores")
 
 ### cores Type
 

--- a/docs/schema-doc/snitch_cluster-properties-hives.md
+++ b/docs/schema-doc/snitch_cluster-properties-hives.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives
 
 Cores in a hive share an instruction cache and other shared infrastructure such as the PTW or the multiply/divide unit.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## hives Type
 

--- a/docs/schema-doc/snitch_cluster-properties-id_width_in.md
+++ b/docs/schema-doc/snitch_cluster-properties-id_width_in.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/id_width_
 
 Id width of the narrower AXI plug into the cluster.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## id_width_in Type
 

--- a/docs/schema-doc/snitch_cluster-properties-mode.md
+++ b/docs/schema-doc/snitch_cluster-properties-mode.md
@@ -6,13 +6,11 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/mode
 
 Supported mode by the processor, can be msu.
 
-
 > Currently ignored.
->
 
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## mode Type
 

--- a/docs/schema-doc/snitch_cluster-properties-name.md
+++ b/docs/schema-doc/snitch_cluster-properties-name.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/name
 
 Optional name for the generated wrapper.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## name Type
 

--- a/docs/schema-doc/snitch_cluster-properties-tcdm-default.md
+++ b/docs/schema-doc/snitch_cluster-properties-tcdm-default.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/defa
 
 
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## default Type
 

--- a/docs/schema-doc/snitch_cluster-properties-tcdm-properties-banks.md
+++ b/docs/schema-doc/snitch_cluster-properties-tcdm-properties-banks.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/prop
 
 Number of banks.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## banks Type
 

--- a/docs/schema-doc/snitch_cluster-properties-tcdm-properties-size.md
+++ b/docs/schema-doc/snitch_cluster-properties-tcdm-properties-size.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/prop
 
 Size of TCDM in KiByte. Divided in `n` banks. The total size must be divisible by the number of banks.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## size Type
 

--- a/docs/schema-doc/snitch_cluster-properties-tcdm.md
+++ b/docs/schema-doc/snitch_cluster-properties-tcdm.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm
 
 Configuration of the Tightly Coupled Data Memory of this cluster.
 
-
-| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ------------ | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## tcdm Type
 
@@ -28,22 +27,24 @@ The default value is:
 
 # undefined Properties
 
-| Property        | Type     | Required | Nullable       | Defined by                                                                                                                                                                      |
-| :-------------- | -------- | -------- | -------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [size](#size)   | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-tcdm-properties-size.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/properties/size")   |
-| [banks](#banks) | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-tcdm-properties-banks.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/properties/banks") |
+| Property        | Type     | Required | Nullable       | Defined by                                                                                                                                                                 |
+| :-------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [size](#size)   | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-tcdm-properties-size.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/properties/size")   |
+| [banks](#banks) | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-tcdm-properties-banks.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/properties/banks") |
 
 ## size
 
 Size of TCDM in KiByte. Divided in `n` banks. The total size must be divisible by the number of banks.
 
-
 `size`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-tcdm-properties-size.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/properties/size")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-tcdm-properties-size.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/properties/size")
 
 ### size Type
 
@@ -63,13 +64,15 @@ Size of TCDM in KiByte. Divided in `n` banks. The total size must be divisible b
 
 Number of banks.
 
-
 `banks`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-tcdm-properties-banks.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/properties/banks")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-tcdm-properties-banks.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm/properties/banks")
 
 ### banks Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-default.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-default.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/de
 
 
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## default Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-fpu_pipe_config.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-fpu_pipe_config.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Pipeline configuration (i.e., position of the registers) of the FPU.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## fpu_pipe_config Type
 
@@ -20,7 +19,7 @@ Pipeline configuration (i.e., position of the registers) of the FPU.
 **enum**: the value of this property must be equal to one of the following values:
 
 | Value           | Explanation |
-| :-------------- | ----------- |
+| :-------------- | :---------- |
 | `"BEFORE"`      |             |
 | `"AFTER"`       |             |
 | `"INSIDE"`      |             |

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-iso_crossings.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-iso_crossings.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Enable isochroous crossings, this clocks the integer core at half the speed of the rest of the system.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## iso_crossings Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency setting (number of pipeline stages) for FP16.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## lat_comp_fp16 Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16_alt.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16_alt.md
@@ -6,16 +6,15 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency setting (number of pipeline stages) for FP16alt (brainfloat).
 
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
-
-## lat_comp_fp16_alt Type
+## lat_comp_fp16\_alt Type
 
 `number`
 
-## lat_comp_fp16_alt Default Value
+## lat_comp_fp16\_alt Default Value
 
 The default value is:
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp32.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp32.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency setting (number of pipeline stages) for FP32.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## lat_comp_fp32 Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp64.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp64.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency setting (number of pipeline stages) for FP64.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## lat_comp_fp64 Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp8.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp8.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency setting (number of pipeline stages) for FP32 (fp8).
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## lat_comp_fp8 Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_conv.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_conv.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency setting (number of pipeline stages) for floating-point conversion instructions.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## lat_conv Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_noncomp.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_noncomp.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency setting (number of pipeline stages) for floating-point non-computational instructions (except conversions), i.e., `classify`, etc.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## lat_noncomp Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-narrow_xbar_latency.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-narrow_xbar_latency.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency mode of the cluster crossbar.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## narrow_xbar_latency Type
 
@@ -20,7 +19,7 @@ Latency mode of the cluster crossbar.
 **enum**: the value of this property must be equal to one of the following values:
 
 | Value             | Explanation |
-| :---------------- | ----------- |
+| :---------------- | :---------- |
 | `"NO_LATENCY"`    |             |
 | `"CUT_SLV_AX"`    |             |
 | `"CUT_MST_AX"`    |             |

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_narrow.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_narrow.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Decouple narrow external AXI plug.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## register_ext_narrow Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_wide.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_wide.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Decouple wide external AXI plug.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## register_ext_wide Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Insert Pipeline registers into off-loading path (request).
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## register_offload Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload_rsp.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload_rsp.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Insert Pipeline registers into off-loading path (response).
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## register_offload_rsp Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_sequencer.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_sequencer.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Insert Pipeline registers after sequencer.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## register_sequencer Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_cuts.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_cuts.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Insert Pipeline registers after each memory cut.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## register_tcdm_cuts Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_req.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_req.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Insert Pipeline registers into data memory request path.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## register_tcdm_req Type
 

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-wide_xbar_latency.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-wide_xbar_latency.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/pr
 
 Latency mode of the DMA crossbar.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## wide_xbar_latency Type
 
@@ -20,7 +19,7 @@ Latency mode of the DMA crossbar.
 **enum**: the value of this property must be equal to one of the following values:
 
 | Value             | Explanation |
-| :---------------- | ----------- |
+| :---------------- | :---------- |
 | `"NO_LATENCY"`    |             |
 | `"CUT_SLV_AX"`    |             |
 | `"CUT_MST_AX"`    |             |

--- a/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter.md
+++ b/docs/schema-doc/snitch_cluster-properties-timing-and-latency-tuning-parameter.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing
 
 
 
-
-| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ------------ | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## timing Type
 
@@ -36,38 +35,40 @@ The default value is:
 
 # Timing and Latency Tuning Parameter Properties
 
-| Property                                      | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                     |
-| :-------------------------------------------- | --------- | -------- | -------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [iso_crossings](#iso_crossings)               | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-iso_crossings.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/iso_crossings")               |
-| [narrow_xbar_latency](#narrow_xbar_latency)   | `string`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-narrow_xbar_latency.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/narrow_xbar_latency")   |
-| [wide_xbar_latency](#wide_xbar_latency)       | `string`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-wide_xbar_latency.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/wide_xbar_latency")       |
-| [register_offload](#register_offload)         | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_offload")         |
-| [register_offload_rsp](#register_offload_rsp) | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload_rsp.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_offload_rsp") |
-| [register_tcdm_req](#register_tcdm_req)       | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_req.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_tcdm_req")       |
-| [register_tcdm_cuts](#register_tcdm_cuts)     | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_cuts.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_tcdm_cuts")     |
-| [register_ext_wide](#register_ext_wide)       | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_wide.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_ext_wide")       |
-| [register_ext_narrow](#register_ext_narrow)   | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_narrow.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_ext_narrow")   |
-| [register_sequencer](#register_sequencer)     | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_sequencer.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_sequencer")     |
-| [lat_comp_fp32](#lat_comp_fp32)               | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp32.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp32")               |
-| [lat_comp_fp64](#lat_comp_fp64)               | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp64.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp64")               |
-| [lat_comp_fp16](#lat_comp_fp16)               | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp16")               |
-| [lat_comp_fp16_alt](#lat_comp_fp16_alt)       | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16_alt.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp16_alt")       |
-| [lat_comp_fp8](#lat_comp_fp8)                 | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp8.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp8")                 |
-| [lat_noncomp](#lat_noncomp)                   | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_noncomp.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_noncomp")                   |
-| [lat_conv](#lat_conv)                         | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_conv.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_conv")                         |
-| [fpu_pipe_config](#fpu_pipe_config)           | `string`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-fpu_pipe_config.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/fpu_pipe_config")           |
+| Property                                      | Type      | Required | Nullable       | Defined by                                                                                                                                                                                                                                |
+| :-------------------------------------------- | :-------- | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [iso_crossings](#iso_crossings)               | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-iso_crossings.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/iso_crossings")               |
+| [narrow_xbar_latency](#narrow_xbar_latency)   | `string`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-narrow_xbar_latency.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/narrow_xbar_latency")   |
+| [wide_xbar_latency](#wide_xbar_latency)       | `string`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-wide_xbar_latency.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/wide_xbar_latency")       |
+| [register_offload](#register_offload)         | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_offload")         |
+| [register_offload_rsp](#register_offload_rsp) | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload_rsp.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_offload_rsp") |
+| [register_tcdm_req](#register_tcdm_req)       | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_req.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_tcdm_req")       |
+| [register_tcdm_cuts](#register_tcdm_cuts)     | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_cuts.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_tcdm_cuts")     |
+| [register_ext_wide](#register_ext_wide)       | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_wide.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_ext_wide")       |
+| [register_ext_narrow](#register_ext_narrow)   | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_narrow.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_ext_narrow")   |
+| [register_sequencer](#register_sequencer)     | `boolean` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_sequencer.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_sequencer")     |
+| [lat_comp_fp32](#lat_comp_fp32)               | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp32.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp32")               |
+| [lat_comp_fp64](#lat_comp_fp64)               | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp64.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp64")               |
+| [lat_comp_fp16](#lat_comp_fp16)               | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp16")               |
+| [lat_comp_fp16_alt](#lat_comp_fp16_alt)       | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16_alt.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp16_alt")       |
+| [lat_comp_fp8](#lat_comp_fp8)                 | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp8.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp8")                 |
+| [lat_noncomp](#lat_noncomp)                   | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_noncomp.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_noncomp")                   |
+| [lat_conv](#lat_conv)                         | `number`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_conv.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_conv")                         |
+| [fpu_pipe_config](#fpu_pipe_config)           | `string`  | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-fpu_pipe_config.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/fpu_pipe_config")           |
 
 ## iso_crossings
 
 Enable isochroous crossings, this clocks the integer core at half the speed of the rest of the system.
 
-
 `iso_crossings`
 
--   is optional
--   Type: `boolean`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-iso_crossings.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/iso_crossings")
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-iso_crossings.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/iso_crossings")
 
 ### iso_crossings Type
 
@@ -77,13 +78,15 @@ Enable isochroous crossings, this clocks the integer core at half the speed of t
 
 Latency mode of the cluster crossbar.
 
-
 `narrow_xbar_latency`
 
--   is optional
--   Type: `string`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-narrow_xbar_latency.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/narrow_xbar_latency")
+*   is optional
+
+*   Type: `string`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-narrow_xbar_latency.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/narrow_xbar_latency")
 
 ### narrow_xbar_latency Type
 
@@ -94,7 +97,7 @@ Latency mode of the cluster crossbar.
 **enum**: the value of this property must be equal to one of the following values:
 
 | Value             | Explanation |
-| :---------------- | ----------- |
+| :---------------- | :---------- |
 | `"NO_LATENCY"`    |             |
 | `"CUT_SLV_AX"`    |             |
 | `"CUT_MST_AX"`    |             |
@@ -107,13 +110,15 @@ Latency mode of the cluster crossbar.
 
 Latency mode of the DMA crossbar.
 
-
 `wide_xbar_latency`
 
--   is optional
--   Type: `string`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-wide_xbar_latency.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/wide_xbar_latency")
+*   is optional
+
+*   Type: `string`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-wide_xbar_latency.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/wide_xbar_latency")
 
 ### wide_xbar_latency Type
 
@@ -124,7 +129,7 @@ Latency mode of the DMA crossbar.
 **enum**: the value of this property must be equal to one of the following values:
 
 | Value             | Explanation |
-| :---------------- | ----------- |
+| :---------------- | :---------- |
 | `"NO_LATENCY"`    |             |
 | `"CUT_SLV_AX"`    |             |
 | `"CUT_MST_AX"`    |             |
@@ -137,13 +142,15 @@ Latency mode of the DMA crossbar.
 
 Insert Pipeline registers into off-loading path (request).
 
-
 `register_offload`
 
--   is optional
--   Type: `boolean`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_offload")
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_offload")
 
 ### register_offload Type
 
@@ -153,13 +160,15 @@ Insert Pipeline registers into off-loading path (request).
 
 Insert Pipeline registers into off-loading path (response).
 
-
 `register_offload_rsp`
 
--   is optional
--   Type: `boolean`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload_rsp.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_offload_rsp")
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_offload_rsp.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_offload_rsp")
 
 ### register_offload_rsp Type
 
@@ -169,13 +178,15 @@ Insert Pipeline registers into off-loading path (response).
 
 Insert Pipeline registers into data memory request path.
 
-
 `register_tcdm_req`
 
--   is optional
--   Type: `boolean`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_req.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_tcdm_req")
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_req.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_tcdm_req")
 
 ### register_tcdm_req Type
 
@@ -185,13 +196,15 @@ Insert Pipeline registers into data memory request path.
 
 Insert Pipeline registers after each memory cut.
 
-
 `register_tcdm_cuts`
 
--   is optional
--   Type: `boolean`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_cuts.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_tcdm_cuts")
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_tcdm_cuts.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_tcdm_cuts")
 
 ### register_tcdm_cuts Type
 
@@ -201,13 +214,15 @@ Insert Pipeline registers after each memory cut.
 
 Decouple wide external AXI plug.
 
-
 `register_ext_wide`
 
--   is optional
--   Type: `boolean`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_wide.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_ext_wide")
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_wide.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_ext_wide")
 
 ### register_ext_wide Type
 
@@ -217,13 +232,15 @@ Decouple wide external AXI plug.
 
 Decouple narrow external AXI plug.
 
-
 `register_ext_narrow`
 
--   is optional
--   Type: `boolean`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_narrow.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_ext_narrow")
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_ext_narrow.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_ext_narrow")
 
 ### register_ext_narrow Type
 
@@ -233,13 +250,15 @@ Decouple narrow external AXI plug.
 
 Insert Pipeline registers after sequencer.
 
-
 `register_sequencer`
 
--   is optional
--   Type: `boolean`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_sequencer.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_sequencer")
+*   is optional
+
+*   Type: `boolean`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-register_sequencer.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/register_sequencer")
 
 ### register_sequencer Type
 
@@ -249,13 +268,15 @@ Insert Pipeline registers after sequencer.
 
 Latency setting (number of pipeline stages) for FP32.
 
-
 `lat_comp_fp32`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp32.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp32")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp32.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp32")
 
 ### lat_comp_fp32 Type
 
@@ -273,13 +294,15 @@ The default value is:
 
 Latency setting (number of pipeline stages) for FP64.
 
-
 `lat_comp_fp64`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp64.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp64")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp64.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp64")
 
 ### lat_comp_fp64 Type
 
@@ -297,13 +320,15 @@ The default value is:
 
 Latency setting (number of pipeline stages) for FP16.
 
-
 `lat_comp_fp16`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp16")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp16")
 
 ### lat_comp_fp16 Type
 
@@ -317,23 +342,25 @@ The default value is:
 1
 ```
 
-## lat_comp_fp16_alt
+## lat_comp_fp16\_alt
 
 Latency setting (number of pipeline stages) for FP16alt (brainfloat).
 
-
 `lat_comp_fp16_alt`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16_alt.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp16_alt")
+*   is optional
 
-### lat_comp_fp16_alt Type
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp16\_alt.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp16\_alt")
+
+### lat_comp_fp16\_alt Type
 
 `number`
 
-### lat_comp_fp16_alt Default Value
+### lat_comp_fp16\_alt Default Value
 
 The default value is:
 
@@ -345,13 +372,15 @@ The default value is:
 
 Latency setting (number of pipeline stages) for FP32 (fp8).
 
-
 `lat_comp_fp8`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp8.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp8")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_comp_fp8.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_comp_fp8")
 
 ### lat_comp_fp8 Type
 
@@ -369,13 +398,15 @@ The default value is:
 
 Latency setting (number of pipeline stages) for floating-point non-computational instructions (except conversions), i.e., `classify`, etc.
 
-
 `lat_noncomp`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_noncomp.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_noncomp")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_noncomp.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_noncomp")
 
 ### lat_noncomp Type
 
@@ -393,13 +424,15 @@ The default value is:
 
 Latency setting (number of pipeline stages) for floating-point conversion instructions.
 
-
 `lat_conv`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_conv.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_conv")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-lat_conv.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/lat_conv")
 
 ### lat_conv Type
 
@@ -417,13 +450,15 @@ The default value is:
 
 Pipeline configuration (i.e., position of the registers) of the FPU.
 
-
 `fpu_pipe_config`
 
--   is optional
--   Type: `string`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-fpu_pipe_config.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/fpu_pipe_config")
+*   is optional
+
+*   Type: `string`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter-properties-fpu_pipe_config.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing/properties/fpu_pipe_config")
 
 ### fpu_pipe_config Type
 
@@ -434,7 +469,7 @@ Pipeline configuration (i.e., position of the registers) of the FPU.
 **enum**: the value of this property must be equal to one of the following values:
 
 | Value           | Explanation |
-| :-------------- | ----------- |
+| :-------------- | :---------- |
 | `"BEFORE"`      |             |
 | `"AFTER"`       |             |
 | `"INSIDE"`      |             |

--- a/docs/schema-doc/snitch_cluster-properties-vm.md
+++ b/docs/schema-doc/snitch_cluster-properties-vm.md
@@ -6,13 +6,11 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/vm
 
 Supported virtual memory mode, can be XSv32.
 
-
 > Currently ignored.
->
 
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                        |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json\*](snitch_cluster.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                       |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json*](snitch_cluster.schema.json "open original schema") |
 
 ## vm Type
 
@@ -23,7 +21,7 @@ Supported virtual memory mode, can be XSv32.
 **enum**: the value of this property must be equal to one of the following values:
 
 | Value     | Explanation |
-| :-------- | ----------- |
+| :-------- | :---------- |
 | `"Sv32"`  |             |
 | `"XSv48"` |             |
 

--- a/docs/schema-doc/snitch_cluster.md
+++ b/docs/schema-doc/snitch_cluster.md
@@ -6,9 +6,8 @@ http://pulp-platform.org/snitch/snitch_cluster.schema.json
 
 Base description of a Snitch cluster and its internal structure and configuration.
 
-
 | Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                      |
-| :------------------ | ---------- | -------------- | ------------ | :---------------- | --------------------- | ------------------- | ------------------------------------------------------------------------------- |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------ |
 | Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster.schema.json](snitch_cluster.schema.json "open original schema") |
 
 ## Snitch Cluster Schema Type
@@ -17,36 +16,38 @@ Base description of a Snitch cluster and its internal structure and configuratio
 
 # Snitch Cluster Schema Properties
 
-| Property                                          | Type     | Required | Nullable       | Defined by                                                                                                                                                                        |
-| :------------------------------------------------ | -------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [name](#name)                                     | `string` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-name.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/name")                                     |
-| [boot_addr](#boot_addr)                           | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-boot_addr.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/boot_addr")                           |
-| [cluster_base_addr](#cluster_base_addr)           | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-cluster_base_addr.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster_base_addr")           |
-| [tcdm](#tcdm)                                     | `object` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-tcdm.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm")                                     |
-| [addr_width](#addr_width)                         | `number` | Required | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-addr_width.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/addr_width")                         |
-| [data_width](#data_width)                         | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-data_width.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/data_width")                         |
-| [dma_data_width](#dma_data_width)                 | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-dma_data_width.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_data_width")                 |
-| [id_width_in](#id_width_in)                       | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-id_width_in.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/id_width_in")                       |
-| [dma_id_width_in](#dma_id_width_in)               | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-dma_id_width_in.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_id_width_in")               |
-| [hart_base_id](#hart_base_id)                     | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hart_base_id.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hart_base_id")                     |
-| [mode](#mode)                                     | `string` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-mode.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/mode")                                     |
-| [vm](#vm)                                         | `string` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-vm.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/vm")                                         |
-| [dma_axi_req_fifo_depth](#dma_axi_req_fifo_depth) | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-dma_axi_req_fifo_depth.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_axi_req_fifo_depth") |
-| [dma_req_fifo_depth](#dma_req_fifo_depth)         | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-dma_req_fifo_depth.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_req_fifo_depth")         |
-| [timing](#timing)                                 | `object` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing")    |
-| [hives](#hives)                                   | `array`  | Required | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives")                                   |
+| Property                                          | Type     | Required | Nullable       | Defined by                                                                                                                                                                   |
+| :------------------------------------------------ | :------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [name](#name)                                     | `string` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-name.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/name")                                     |
+| [boot_addr](#boot_addr)                           | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-boot_addr.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/boot_addr")                           |
+| [cluster_base_addr](#cluster_base_addr)           | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-cluster_base_addr.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster_base_addr")           |
+| [tcdm](#tcdm)                                     | `object` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-tcdm.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm")                                     |
+| [addr_width](#addr_width)                         | `number` | Required | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-addr_width.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/addr_width")                         |
+| [data_width](#data_width)                         | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-data_width.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/data_width")                         |
+| [dma_data_width](#dma_data_width)                 | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-dma_data_width.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_data_width")                 |
+| [id_width_in](#id_width_in)                       | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-id_width_in.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/id_width_in")                       |
+| [dma_id_width_in](#dma_id_width_in)               | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-dma_id_width_in.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_id_width_in")               |
+| [hart_base_id](#hart_base_id)                     | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hart_base_id.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hart_base_id")                     |
+| [mode](#mode)                                     | `string` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-mode.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/mode")                                     |
+| [vm](#vm)                                         | `string` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-vm.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/vm")                                         |
+| [dma_axi_req_fifo_depth](#dma_axi_req_fifo_depth) | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-dma_axi_req_fifo_depth.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_axi_req_fifo_depth") |
+| [dma_req_fifo_depth](#dma_req_fifo_depth)         | `number` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-dma_req_fifo_depth.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_req_fifo_depth")         |
+| [timing](#timing)                                 | `object` | Optional | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing")    |
+| [hives](#hives)                                   | `array`  | Required | cannot be null | [Snitch Cluster Schema](snitch_cluster-properties-hives.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives")                                   |
 
 ## name
 
 Optional name for the generated wrapper.
 
-
 `name`
 
--   is optional
--   Type: `string`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-name.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/name")
+*   is optional
+
+*   Type: `string`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-name.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/name")
 
 ### name Type
 
@@ -64,13 +65,15 @@ The default value is:
 
 Address from which all harts of the cluster start to boot. The default setting is `0x8000_0000`.
 
-
 `boot_addr`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-boot_addr.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/boot_addr")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-boot_addr.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/boot_addr")
 
 ### boot_addr Type
 
@@ -88,13 +91,15 @@ The default value is:
 
 Base address of this cluster.
 
-
 `cluster_base_addr`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-cluster_base_addr.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster_base_addr")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-cluster_base_addr.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster_base_addr")
 
 ### cluster_base_addr Type
 
@@ -104,13 +109,15 @@ Base address of this cluster.
 
 Configuration of the Tightly Coupled Data Memory of this cluster.
 
-
 `tcdm`
 
--   is optional
--   Type: `object` ([Details](snitch_cluster-properties-tcdm.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-tcdm.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm")
+*   is optional
+
+*   Type: `object` ([Details](snitch_cluster-properties-tcdm.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-tcdm.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/tcdm")
 
 ### tcdm Type
 
@@ -131,13 +138,15 @@ The default value is:
 
 Length of the address, should be greater than 30. If the address is larger than 34 the data bus needs to be 64 bits in size.
 
-
 `addr_width`
 
--   is required
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-addr_width.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/addr_width")
+*   is required
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-addr_width.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/addr_width")
 
 ### addr_width Type
 
@@ -155,13 +164,15 @@ The default value is:
 
 Data bus size of the integer core (everything except the DMA), must be 32 or 64. A double precision FPU requires 64 bit data length.
 
-
 `data_width`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-data_width.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/data_width")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-data_width.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/data_width")
 
 ### data_width Type
 
@@ -179,13 +190,15 @@ The default value is:
 
 Data bus size of DMA. Usually this is larger than the integer core as the DMA is used to efficiently transfer bulk of data.
 
-
 `dma_data_width`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-dma_data_width.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_data_width")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-dma_data_width.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_data_width")
 
 ### dma_data_width Type
 
@@ -203,13 +216,15 @@ The default value is:
 
 Id width of the narrower AXI plug into the cluster.
 
-
 `id_width_in`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-id_width_in.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/id_width_in")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-id_width_in.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/id_width_in")
 
 ### id_width_in Type
 
@@ -227,13 +242,15 @@ The default value is:
 
 Id width of the wide AXI plug into the cluster.
 
-
 `dma_id_width_in`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-dma_id_width_in.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_id_width_in")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-dma_id_width_in.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_id_width_in")
 
 ### dma_id_width_in Type
 
@@ -251,13 +268,15 @@ The default value is:
 
 Base hart id of the cluster. All cores get the respective cluster id plus their cluster position as the final `hart_id`.
 
-
 `hart_base_id`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hart_base_id.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hart_base_id")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hart_base_id.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hart_base_id")
 
 ### hart_base_id Type
 
@@ -267,16 +286,17 @@ Base hart id of the cluster. All cores get the respective cluster id plus their 
 
 Supported mode by the processor, can be msu.
 
-
 > Currently ignored.
->
 
 `mode`
 
--   is optional
--   Type: `string`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-mode.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/mode")
+*   is optional
+
+*   Type: `string`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-mode.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/mode")
 
 ### mode Type
 
@@ -286,16 +306,17 @@ Supported mode by the processor, can be msu.
 
 Supported virtual memory mode, can be XSv32.
 
-
 > Currently ignored.
->
 
 `vm`
 
--   is optional
--   Type: `string`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-vm.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/vm")
+*   is optional
+
+*   Type: `string`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-vm.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/vm")
 
 ### vm Type
 
@@ -306,7 +327,7 @@ Supported virtual memory mode, can be XSv32.
 **enum**: the value of this property must be equal to one of the following values:
 
 | Value     | Explanation |
-| :-------- | ----------- |
+| :-------- | :---------- |
 | `"Sv32"`  |             |
 | `"XSv48"` |             |
 
@@ -322,13 +343,15 @@ The default value is:
 
 Number of AXI FIFO entries of the DMA engine.
 
-
 `dma_axi_req_fifo_depth`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-dma_axi_req_fifo_depth.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_axi_req_fifo_depth")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-dma_axi_req_fifo_depth.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_axi_req_fifo_depth")
 
 ### dma_axi_req_fifo_depth Type
 
@@ -346,13 +369,15 @@ The default value is:
 
 Number of request entries the DMA can keep
 
-
 `dma_req_fifo_depth`
 
--   is optional
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-dma_req_fifo_depth.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_req_fifo_depth")
+*   is optional
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-dma_req_fifo_depth.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/dma_req_fifo_depth")
 
 ### dma_req_fifo_depth Type
 
@@ -370,13 +395,15 @@ The default value is:
 
 
 
-
 `timing`
 
--   is optional
--   Type: `object` ([Timing and Latency Tuning Parameter](snitch_cluster-properties-timing-and-latency-tuning-parameter.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing")
+*   is optional
+
+*   Type: `object` ([Timing and Latency Tuning Parameter](snitch_cluster-properties-timing-and-latency-tuning-parameter.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-timing-and-latency-tuning-parameter.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/timing")
 
 ### timing Type
 
@@ -405,13 +432,15 @@ The default value is:
 
 Cores in a hive share an instruction cache and other shared infrastructure such as the PTW or the multiply/divide unit.
 
-
 `hives`
 
--   is required
--   Type: `object[]` ([Hive Description](snitch_cluster-properties-hives-hive-description.md))
--   cannot be null
--   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives")
+*   is required
+
+*   Type: `object[]` ([Hive Description](snitch_cluster-properties-hives-hive-description.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster Schema](snitch_cluster-properties-hives.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/hives")
 
 ### hives Type
 

--- a/docs/schema-doc/snitch_cluster_tb-properties-dram-properties-address.md
+++ b/docs/schema-doc/snitch_cluster_tb-properties-dram-properties-address.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/p
 
 Start address of DRAM.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                              |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster_tb.schema.json\*](snitch_cluster_tb.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                             |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster_tb.schema.json*](snitch_cluster_tb.schema.json "open original schema") |
 
 ## address Type
 

--- a/docs/schema-doc/snitch_cluster_tb-properties-dram-properties-length.md
+++ b/docs/schema-doc/snitch_cluster_tb-properties-dram-properties-length.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/p
 
 Total size of DRAM in bytes.
 
-
-| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                              |
-| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster_tb.schema.json\*](snitch_cluster_tb.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                             |
+| :------------------ | :--------- | :------------- | :---------------------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [snitch_cluster_tb.schema.json*](snitch_cluster_tb.schema.json "open original schema") |
 
 ## length Type
 

--- a/docs/schema-doc/snitch_cluster_tb-properties-dram.md
+++ b/docs/schema-doc/snitch_cluster_tb-properties-dram.md
@@ -6,10 +6,9 @@ http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram
 
 Main, off-chip DRAM.
 
-
-| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                              |
-| :------------------ | ---------- | -------------- | ------------ | :---------------- | --------------------- | ------------------- | --------------------------------------------------------------------------------------- |
-| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster_tb.schema.json\*](snitch_cluster_tb.schema.json "open original schema") |
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                             |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster_tb.schema.json*](snitch_cluster_tb.schema.json "open original schema") |
 
 ## dram Type
 
@@ -17,22 +16,24 @@ Main, off-chip DRAM.
 
 # DRAM Properties
 
-| Property            | Type     | Required | Nullable       | Defined by                                                                                                                                                                                   |
-| :------------------ | -------- | -------- | -------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [address](#address) | `number` | Required | cannot be null | [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram-properties-address.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/properties/address") |
-| [length](#length)   | `number` | Required | cannot be null | [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram-properties-length.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/properties/length")   |
+| Property            | Type     | Required | Nullable       | Defined by                                                                                                                                                                              |
+| :------------------ | :------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [address](#address) | `number` | Required | cannot be null | [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram-properties-address.md "http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/properties/address") |
+| [length](#length)   | `number` | Required | cannot be null | [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram-properties-length.md "http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/properties/length")   |
 
 ## address
 
 Start address of DRAM.
 
-
 `address`
 
--   is required
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram-properties-address.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/properties/address")
+*   is required
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram-properties-address.md "http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/properties/address")
 
 ### address Type
 
@@ -46,13 +47,15 @@ Start address of DRAM.
 
 Total size of DRAM in bytes.
 
-
 `length`
 
--   is required
--   Type: `number`
--   cannot be null
--   defined in: [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram-properties-length.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/properties/length")
+*   is required
+
+*   Type: `number`
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram-properties-length.md "http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram/properties/length")
 
 ### length Type
 

--- a/docs/schema-doc/snitch_cluster_tb.md
+++ b/docs/schema-doc/snitch_cluster_tb.md
@@ -6,9 +6,8 @@ http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json
 
 Description for a very simple single-cluster testbench. That is the most minimal system available. Most of the hardware is emulated by the testbench.
 
-
 | Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                                            |
-| :------------------ | ---------- | -------------- | ------------ | :---------------- | --------------------- | ------------------- | ------------------------------------------------------------------------------------- |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ | :------------------------------------------------------------------------------------ |
 | Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                | [snitch_cluster_tb.schema.json](snitch_cluster_tb.schema.json "open original schema") |
 
 ## Snitch Cluster TB Schema Type
@@ -17,22 +16,24 @@ Description for a very simple single-cluster testbench. That is the most minimal
 
 # Snitch Cluster TB Schema Properties
 
-| Property            | Type     | Required | Nullable       | Defined by                                                                                                                                                              |
-| :------------------ | -------- | -------- | -------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [cluster](#cluster) | `object` | Required | cannot be null | [Snitch Cluster TB Schema](snitch_cluster_tb-properties-snitch-cluster-schema.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster") |
-| [dram](#dram)       | `object` | Required | cannot be null | [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram")                  |
+| Property            | Type     | Required | Nullable       | Defined by                                                                                                                                                         |
+| :------------------ | :------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [cluster](#cluster) | `object` | Required | cannot be null | [Snitch Cluster TB Schema](snitch_cluster_tb-properties-snitch-cluster-schema.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster") |
+| [dram](#dram)       | `object` | Required | cannot be null | [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram.md "http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram")                  |
 
 ## cluster
 
 Base description of a Snitch cluster and its internal structure and configuration.
 
-
 `cluster`
 
--   is required
--   Type: `object` ([Snitch Cluster Schema](snitch_cluster_tb-properties-snitch-cluster-schema.md))
--   cannot be null
--   defined in: [Snitch Cluster TB Schema](snitch_cluster_tb-properties-snitch-cluster-schema.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster")
+*   is required
+
+*   Type: `object` ([Snitch Cluster Schema](snitch_cluster_tb-properties-snitch-cluster-schema.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster TB Schema](snitch_cluster_tb-properties-snitch-cluster-schema.md "http://pulp-platform.org/snitch/snitch_cluster.schema.json#/properties/cluster")
 
 ### cluster Type
 
@@ -42,13 +43,15 @@ Base description of a Snitch cluster and its internal structure and configuratio
 
 Main, off-chip DRAM.
 
-
 `dram`
 
--   is required
--   Type: `object` ([DRAM](snitch_cluster_tb-properties-dram.md))
--   cannot be null
--   defined in: [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram.md "http&#x3A;//pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram")
+*   is required
+
+*   Type: `object` ([DRAM](snitch_cluster_tb-properties-dram.md))
+
+*   cannot be null
+
+*   defined in: [Snitch Cluster TB Schema](snitch_cluster_tb-properties-dram.md "http://pulp-platform.org/snitch/snitch_cluster_tb.schema.json#/properties/dram")
 
 ### dram Type
 


### PR DESCRIPTION
Changes in the schema generation npm package seem to have changed the output. Here is an updated version for now. I think we either need to:

- Fix the version of the schema generator
- Generate the schema as part of the documentation artifact