### PR TITLE
ci: Fix adobe/jsonschema2md version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '12'
-    - run: npm install -g @adobe/jsonschema2md
+    - run: npm install -g @adobe/jsonschema2md@v5.0.1
     - uses: actions/setup-python@v2
       with:
         python-version: 3.x


### PR DESCRIPTION
Fix schema generator to version v5.0.1 effectively preventing the CI to be broken by updates of the NPM package. This needs some more thoughts in the future.