### PR TITLE
snitch_cluster: Add wide slave port

### DIFF
--- a/hw/ip/snitch/src/snitch_pkg.sv
+++ b/hw/ip/snitch/src/snitch_pkg.sv
@@ -146,12 +146,13 @@ package snitch_pkg;
 
   // Slaves on Cluster DMA AXI Bus
   typedef enum int unsigned {
-    TCDMDMA  = 32'd0,
-    SoCDMA   = 32'd1
+    TCDMDMA = 32'd0,
+    SoCDMAOut = 32'd1
   } cluster_slave_dma_e;
 
   typedef enum int unsigned {
-    SDMAMst  = 32'd0
+    SDMAMst = 32'd0,
+    SoCDMAIn = 32'd1
   } cluster_master_dma_e;
 
   /// Possible interconnect implementations.

--- a/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -118,7 +118,9 @@ module ${cfg['name']}_wrapper (
   output ${cfg['pkg_name']}::narrow_out_req_t    narrow_out_req_o,
   input  ${cfg['pkg_name']}::narrow_out_resp_t   narrow_out_resp_i,
   output ${cfg['pkg_name']}::wide_out_req_t      wide_out_req_o,
-  input  ${cfg['pkg_name']}::wide_out_resp_t     wide_out_resp_i
+  input  ${cfg['pkg_name']}::wide_out_resp_t     wide_out_resp_i,
+  input  ${cfg['pkg_name']}::wide_in_req_t       wide_in_req_i,
+  output ${cfg['pkg_name']}::wide_in_resp_t      wide_in_resp_o
 );
 
   localparam int unsigned NumIntOutstandingLoads [${cfg['nr_cores']}] = '{${core_cfg('num_int_outstanding_loads')}};
@@ -145,6 +147,8 @@ module ${cfg['name']}_wrapper (
     .narrow_out_resp_t (${cfg['pkg_name']}::narrow_out_resp_t),
     .wide_out_req_t (${cfg['pkg_name']}::wide_out_req_t),
     .wide_out_resp_t (${cfg['pkg_name']}::wide_out_resp_t),
+    .wide_in_req_t (${cfg['pkg_name']}::wide_in_req_t),
+    .wide_in_resp_t (${cfg['pkg_name']}::wide_in_resp_t),
     .NrHives (${cfg['nr_hives']}),
     .NrCores (${cfg['nr_cores']}),
     .TCDMDepth (${cfg['tcdm']['depth']}),
@@ -204,6 +208,8 @@ module ${cfg['name']}_wrapper (
     .narrow_out_req_o,
     .narrow_out_resp_i,
     .wide_out_req_o,
-    .wide_out_resp_i
+    .wide_out_resp_i,
+    .wide_in_req_i,
+    .wide_in_resp_o
   );
 endmodule

--- a/hw/system/snitch_cluster/test/testharness.sv
+++ b/hw/system/snitch_cluster/test/testharness.sv
@@ -19,6 +19,8 @@ module testharness import snitch_cluster_pkg::*; (
   narrow_out_resp_t narrow_out_resp;
   wide_out_req_t wide_out_req;
   wide_out_resp_t wide_out_resp;
+  wide_in_req_t wide_in_req;
+  wide_in_resp_t wide_in_resp;
 
   snitch_cluster_wrapper i_snitch_cluster (
     .clk_i,
@@ -32,12 +34,15 @@ module testharness import snitch_cluster_pkg::*; (
     .narrow_out_req_o (narrow_out_req),
     .narrow_out_resp_i (narrow_out_resp),
     .wide_out_req_o (wide_out_req),
-    .wide_out_resp_i (wide_out_resp)
+    .wide_out_resp_i (wide_out_resp),
+    .wide_in_req_i (wide_in_req),
+    .wide_in_resp_o (wide_in_resp)
   );
 
   // Tie-off unused ports.
   assign narrow_in_req = '0;
   assign wide_out_resp = '0;
+  assign wide_in_req = '0;
 
   // Simulation memory.
   tb_memory #(


### PR DESCRIPTION
For Occamy (and other multi-cluster systems) we are going to finally need the wide slave port. Added by this PR.