### PR TITLE
snitch_cluster: Add missing include in Bender file

### DIFF
--- a/hw/system/snitch_cluster/Bender.yml
+++ b/hw/system/snitch_cluster/Bender.yml
@@ -14,9 +14,14 @@ dependencies:
 
 sources:
 # Level 0:
-- generated/snitch_cluster_wrapper.sv
+- include_dirs:
+  - ../../vendor/pulp_platform_axi/include
+  files:
+  - generated/snitch_cluster_wrapper.sv
 # Level 1:
 - target: any(simulation, verilator)
+  include_dirs:
+  - ../../vendor/pulp_platform_axi/include
   files:
   - test/tb_memory.sv
   - test/testharness.sv


### PR DESCRIPTION
Not sure about the correct fix but this helps me compile for modelsim

```
make bin/snitch_cluster.vsim
```

Else, the `axi/typedef.svh` is not foud