### PR TITLE
Skip the cache line currently used in the eviction policy

### DIFF
--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -6,6 +6,7 @@
 // Description: Top-Level of Snitch Integer Core RV32E
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
 
 // `SNITCH_ENABLE_PERF Enables mcycle, minstret performance counters (read only)
 
@@ -2589,5 +2590,14 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     BGE,
     BGEU
   }) && (consec_pc[1:0] != 2'b0);
+
+  // ----------
+  // Assertions
+  // ----------
+  // Make sure the instruction interface is stable. Otherwise, Snitch might violate the protocol at
+  // the LSU or accelerator interface by withdrawing the valid signal.
+  `ASSERT(InstructionInterfaceStable,
+      (inst_valid_o && inst_ready_i) ##1 (inst_valid_o && $stable(inst_addr_o))
+      |-> inst_ready_i && $stable(inst_data_i), clk_i, rst_i)
 
 endmodule

--- a/hw/ip/snitch_icache/src/snitch_icache_l0.sv
+++ b/hw/ip/snitch_icache/src/snitch_icache_l0.sv
@@ -194,6 +194,10 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
     if (evict_req) begin
       evict_strb = 1 << cnt_q;
       cnt_d = cnt_q + 1;
+      if (evict_strb == hit_early) begin
+        evict_strb = 1 << cnt_d;
+        cnt_d = cnt_q + 2;
+      end
     end
   end
 


### PR DESCRIPTION
This PR addresses the implicit assumption in Snitch, that the instruction interface has to be stable once the instruction is ready. Snitch will violate the protocol at the output interface otherwise. 

For example, when we execute a load but the memory interface is not ready, Snitch will already have enabled the valid signal and has to hold this signal until it gets a ready. However, the current cache policy might replace the cache line holding this load instruction with the prefetched line, which would lead to the cache withdrawing the ready signal. This leads to Snitch violating the protocol on the memory interface.

This PR addresses this issue with:
- Updated cache eviction policy to make the interface stable.
- Added assertion in Snitch, checking for a stable instruction interface.

A fall-through register at the interface would be another option, but that would impact the critical path.