### PR TITLE
ssr: Unpacking of SSR address according to ISA documentation

### DIFF
--- a/hw/ip/snitch_cluster/src/snitch_cc.sv
+++ b/hw/ip/snitch_cluster/src/snitch_cc.sv
@@ -591,7 +591,7 @@ module snitch_cc #(
       import riscv_instr::*;
       automatic logic [11:0] addr;
       automatic logic [4:0] addr_dm;
-      automatic logic [4:0] addr_reg;
+      automatic logic [6:0] addr_reg;
 
       ssr_cfg_req.id = acc_snitch_demux_q.id;
       ssr_cfg_req.data = acc_snitch_demux_q.data_arga[31:0];
@@ -610,7 +610,8 @@ module snitch_cc #(
         default: ;
       endcase
 
-      {addr_reg, addr_dm} = addr;
+      addr_reg = addr[11:5];
+      addr_dm = addr[4:0];
       ssr_cfg_req.word = {addr_dm, addr_reg};
 
       unique casez (acc_snitch_demux_q.data_op)

--- a/hw/ip/snitch_cluster/src/snitch_ssr_streamer.sv
+++ b/hw/ip/snitch_cluster/src/snitch_ssr_streamer.sv
@@ -47,6 +47,7 @@ module snitch_ssr_streamer import snitch_pkg::*; #(
   logic  [2:0] lane_ready;
 
   logic [4:0]       dmcfg_word;
+  logic [7:0]       dmcfg_upper_addr;
   logic [2:0][31:0] dmcfg_rdata;
   logic [2:0]       dmcfg_strobe; // which data mover is currently addressed
 
@@ -173,10 +174,10 @@ module snitch_ssr_streamer import snitch_pkg::*; #(
   // use the upper address bits to select one of the data movers, or select
   // all if the bits are all 1.
   always_comb begin
-    logic [11:4] upper_addr;
-    {upper_addr, dmcfg_word} = cfg_word_i;
-    dmcfg_strobe = (upper_addr == '1 ? '1 : (1 << upper_addr));
-    cfg_rdata_o = dmcfg_rdata[upper_addr];
+    dmcfg_word = cfg_word_i[4:0];
+    dmcfg_upper_addr = cfg_word_i[11:7];
+    dmcfg_strobe = (dmcfg_upper_addr == '1 ? '1 : (1 << dmcfg_upper_addr));
+    cfg_rdata_o = dmcfg_rdata[dmcfg_upper_addr];
   end
 
 endmodule


### PR DESCRIPTION
Configuring the SSR with the `scfgwi` instructions as [described in the documentation](https://github.com/pulp-platform/snitch/blob/master/docs/rm/custom_instructions.md#configuration-register-operations) is not working due to a wrong unpacking of `dm` and `reg` fields.

With these changes, the `scfgwi` instruction is correctly decoded according to this table

| imm[11:4] | imm[4:0] | rs1   | funct3 | rd    | opcode     | operation |
|:---------:|:--------:|:-----:|:------:|:-----:|:----------:|:---------:|
| 7         | 5        | 5     | 3      | 5     | 7          |           |
| reg       | ssr      | value | 010    | 00000 | OP-CUSTOM1 | SCFGWI    |

The immediate read `scfgri` doesn't work either. The problem here is that the `mem_resp_valid_i` signal is asserted a clock cycle delayed on the memory side of `i_stream_to_mem`. But this is topic of a new pr.
