### PR TITLE
docs: Fix `scfgr/w`'s immediate index

### DIFF
--- a/docs/rm/custom_instructions.md
+++ b/docs/rm/custom_instructions.md
@@ -9,7 +9,7 @@ The "Xssr" extension assigns stream semantics to a handful of the processor's re
 
 ### Configuration Register Operations
 
-| imm[11:4] | imm[4:0] | rs1   | funct3 | rd    | opcode     | operation |
+| imm[11:5] | imm[4:0] | rs1   | funct3 | rd    | opcode     | operation |
 |:---------:|:--------:|:-----:|:------:|:-----:|:----------:|:---------:|
 | 7         | 5        | 5     | 3      | 5     | 7          |           |
 | reg       | ssr      | 00000 | 001    | dest  | OP-CUSTOM1 | SCFGRI    |
@@ -23,7 +23,7 @@ SCFGRI and SCFGWI read and write a value from or to an SSR configuration registe
 | 0000000 | addr  | 00001 | 001    | dest  | OP-CUSTOM1 | SCFGR     |
 | 0000000 | addr  | value | 010    | 00001 | OP-CUSTOM1 | SCFGW     |
 
-SCFGR and SCFGW read and write a value from or to an SSR configuration register. The value in register *rs2* specifies specifies the address of the register as follows: bits 4 to 0 correspond to *ssr* and indicate the SSR to be used, and the bits 11 to 4 correspond to *reg* and indicate the index of the register. SCFGR places the read value in *rd*. SCFGW moves the value in *rs1* to the selected SSR configuration register.
+SCFGR and SCFGW read and write a value from or to an SSR configuration register. The value in register *rs2* specifies specifies the address of the register as follows: bits 4 to 0 correspond to *ssr* and indicate the SSR to be used, and the bits 11 to 5 correspond to *reg* and indicate the index of the register. SCFGR places the read value in *rd*. SCFGW moves the value in *rs1* to the selected SSR configuration register.
 
 ## "Xfrep" Extension for Floating-Point Repetition
 


### PR DESCRIPTION
A minor fix in the documentation related to issue #68. The indices in the immediate were overlapping. The issue was fixed in #70, #73, and #75, but the documentation not updated.