### PR TITLE
tcdm-interface: Do not assert stable write data and strobe on reads

### DIFF
--- a/hw/ip/tcdm_interface/src/tcdm_interface.sv
+++ b/hw/ip/tcdm_interface/src/tcdm_interface.sv
@@ -105,8 +105,8 @@ interface TCDM_BUS_DV #(
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_addr)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_write)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_amo)));
-  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data)));
-  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_strb)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready && q_write |=> $stable(q_data)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready && q_write |=> $stable(q_strb)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_user)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> q_valid));
   `endif


### PR DESCRIPTION
In their current implementation, SSRs may violate the assertion in `hw/ip/tcdm_interface/tcdm_interface.sv:108` when their IO timings are nonzero.

This assertion checks that the request TCDM payload remains stable as long as it is valid, but the downstream is not yet ready. This includes write data, even if the request is a read.

However, SSRs directly connect the request write data to the bidirectional FIFO output and assert a request valid as long as an address is ready and there are credits. Since the cycle delay at which the FIFO changes its head contents is decoupled from the application delay of the ready signal at the IO interface, the lock-in assertion may be violated.

This PR masks the write data to `'0` on read, ensuring request stability on reads and writes with some logic overhead.