### PR TITLE
snitch_icache: Disable the prefetcher if there are multiple hits

### DIFF
--- a/hw/ip/snitch_icache/src/snitch_icache_l0.sv
+++ b/hw/ip/snitch_icache/src/snitch_icache_l0.sv
@@ -273,7 +273,7 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
   // pre-fetched the line yet and there is no other refill in progress.
   assign prefetcher_out.vld = enable_prefetching_i &
                               hit_any & ~hit_prefetch_any &
-                              ~pending_refill_q;
+                              hit_early_is_onehot & ~pending_refill_q;
 
   localparam int unsigned FetchPkts = CFG.LINE_WIDTH/32;
   logic [FetchPkts-1:0] is_branch_taken;


### PR DESCRIPTION
If we have multiple early hits, the [instruction data](https://github.com/pulp-platform/snitch/blob/master/hw/ip/snitch_icache/src/snitch_icache_l0.sv#L166) will be garbage. Therefore, the prefetcher might calculate a garbage address and create a fetch to invalid memory. This PR disables the prefetcher when we have multiple early hits.

Alternatively, we could also modify the prediction logic to not try to predict the branch but just prefetch the next block. E.g. setting [`is_branch_taken` & `is_jal`](https://github.com/pulp-platform/snitch/blob/master/hw/ip/snitch_icache/src/snitch_icache_l0.sv#L290) to zero. This might be the better option,  but I would appreciate your opinion.