### PR TITLE
snitch: Assert stability only stable on cacheable

### DIFF
--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -2596,8 +2596,9 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   // ----------
   // Make sure the instruction interface is stable. Otherwise, Snitch might violate the protocol at
   // the LSU or accelerator interface by withdrawing the valid signal.
+  // TODO: Remove cacheability attribute, that should hold true for all instruction fetch transacitons.
   `ASSERT(InstructionInterfaceStable,
-      (inst_valid_o && inst_ready_i) ##1 (inst_valid_o && $stable(inst_addr_o))
+      (inst_valid_o && inst_ready_i && inst_cacheable_o) ##1 (inst_valid_o && $stable(inst_addr_o))
       |-> inst_ready_i && $stable(inst_data_i), clk_i, rst_i)
 
 endmodule


### PR DESCRIPTION
Temporary "fix" for #72. I'll open an issue for a permanent fix.