### PR TITLE
cluster-cfg: Consistent endianness in config, script, and template

### DIFF
--- a/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -18,7 +18,7 @@ ${c[prop]}${', ' if not loop.last else ''}\
 
 <%def name="core_cfg_flat(prop)">\
 ${cfg['nr_cores']}'b\
-  % for c in cfg['cores']:
+  % for c in reversed(cfg['cores']):
 ${int(c[prop])}\
   % endfor
 </%def>\

--- a/hw/system/occamy/src/occamy_cluster_cfg.hjson
+++ b/hw/system/occamy/src/occamy_cluster_cfg.hjson
@@ -60,15 +60,15 @@
                     cacheline: 128 // word size in bits
                 },
                 cores: [
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
                     { $ref: "#/dma_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
                 ]
             }
         ],

--- a/hw/system/occamy/src/occamy_cluster_wrapper.sv
+++ b/hw/system/occamy/src/occamy_cluster_wrapper.sv
@@ -111,10 +111,10 @@ module occamy_cluster_wrapper (
 );
 
   localparam int unsigned NumIntOutstandingLoads [9] = '{1, 1, 1, 1, 1, 1, 1, 1, 1};
-  localparam int unsigned NumIntOutstandingMem [9] = '{1, 4, 4, 4, 4, 4, 4, 4, 4};
+  localparam int unsigned NumIntOutstandingMem [9] = '{4, 4, 4, 4, 4, 4, 4, 4, 1};
   localparam int unsigned NumFPOutstandingLoads [9] = '{4, 4, 4, 4, 4, 4, 4, 4, 4};
-  localparam int unsigned NumFPOutstandingMem [9] = '{1, 4, 4, 4, 4, 4, 4, 4, 4};
-  localparam int unsigned NumDTLBEntries [9] = '{2, 1, 1, 1, 1, 1, 1, 1, 1};
+  localparam int unsigned NumFPOutstandingMem [9] = '{4, 4, 4, 4, 4, 4, 4, 4, 1};
+  localparam int unsigned NumDTLBEntries [9] = '{1, 1, 1, 1, 1, 1, 1, 1, 2};
   localparam int unsigned NumITLBEntries [9] = '{1, 1, 1, 1, 1, 1, 1, 1, 1};
   localparam int unsigned SSRNrCredits [9] = '{4, 4, 4, 4, 4, 4, 4, 4, 4};
   localparam int unsigned NumSequencerInstr [9] = '{16, 16, 16, 16, 16, 16, 16, 16, 16};

--- a/hw/system/snitch_cluster/cfg/cluster.default.hjson
+++ b/hw/system/snitch_cluster/cfg/cluster.default.hjson
@@ -34,21 +34,6 @@
             register_offload_rsp: true
         },
         hives: [
-            // Hive 1
-            {
-                icache: {
-                    size: 8, // total instruction cache size in kByte
-                    sets: 2, // number of ways
-                    cacheline: 128 // word size in bits
-                },
-                cores: [
-                    { $ref: "#/dma_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                    { $ref: "#/compute_core_template" },
-                ]
-            },
             // Hive 0
             {
                 cores: [
@@ -59,6 +44,21 @@
                     # { $ref: "#/compute_core_template" },
                 ]
             }
+            // Hive 1
+            {
+                icache: {
+                    size: 8, // total instruction cache size in kByte
+                    sets: 2, // number of ways
+                    cacheline: 128 // word size in bits
+                },
+                cores: [
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/dma_core_template" },
+                ]
+            },
         ]
     },
     dram: {


### PR DESCRIPTION
The generated cluster wrappers currently have inconsistent endianness for packed (flattened) and unpacked parameter arrays. 

Additionally, the existing cluster config files suggest little-endian hive and core lists, but the parsing scripts iterate through them in regular big-endian fashion.

This PR ensures consistency and correct wrappers by changing endianness in the existing configs to big-endian and reversing flattened parameter arrays.