### PR TITLE
util/Makefrag: Catch failing dependency resolution

### DIFF
--- a/util/Makefrag
+++ b/util/Makefrag
@@ -95,4 +95,4 @@ work-vcs/compile.sh: ${VSIM_SOURCES} ${TB_SRCS}
 logs/trace_hart_%.txt: logs/trace_hart_%.dasm ${ROOT}/util/gen_trace.py
 	$(DASM) < $< | $(PYTHON) ${ROOT}/util/gen_trace.py > $@
 
-traces: $(shell ls logs/trace_hart_*.dasm | sed 's/\.dasm/\.txt/')
+traces: $((shell ls logs/trace_hart_*.dasm | sed 's/\.dasm/\.txt/') || echo "")


### PR DESCRIPTION
Catch the `no matches` error of `ls` when including the Makefrag in a directory without any trace files.