### PR TITLE
banshee: Fake uart to stderr with formatting and hartid

### DIFF
--- a/sw/banshee/Cargo.toml
+++ b/sw/banshee/Cargo.toml
@@ -23,6 +23,7 @@ pretty_env_logger = "0.4"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.63"
 serde_yaml = "0.8"
+termion = "*"
 
 [build-dependencies]
 cc = "1.0"

--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -5,6 +5,7 @@
 //! Engine for dynamic binary translation and execution
 
 use crate::{riscv, tran::ElfTranslator, util::SiUnit, Configuration};
+extern crate termion;
 use anyhow::{anyhow, bail, Result};
 use itertools::Itertools;
 use llvm_sys::{
@@ -18,6 +19,7 @@ use std::{
         Mutex,
     },
 };
+use termion::{color, style};
 
 pub use crate::runtime::{Cpu, CpuState, DmaState, SsrState};
 
@@ -539,7 +541,14 @@ impl<'a, 'b> Cpu<'a, 'b> {
                 let mut buffer = self.engine.putchar_buffer.lock().unwrap();
                 let buffer = buffer.entry(self.hartid).or_default();
                 if value == '\n' as u32 {
-                    println!("{}", String::from_utf8_lossy(buffer));
+                    eprintln!(
+                        "{}{} hart-{:03} {} {}",
+                        style::Invert,
+                        color::Fg(color::White),
+                        self.hartid,
+                        style::Reset,
+                        String::from_utf8_lossy(buffer)
+                    );
                     buffer.clear();
                 } else {
                     buffer.push(value as u8);


### PR DESCRIPTION
Allows to `--trace` at the same time as observing the output of the fake uart. Additionally, all printed lines are prepended with the source-hard-id

![image](https://user-images.githubusercontent.com/3391933/114867603-509dcf80-9df5-11eb-9fcc-763929e81782.png)
