### PR TITLE
banshee: Fix tcdm initialization by offsetting access

### DIFF
--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -318,7 +318,7 @@ impl Engine {
                 if (addr as u32) >= self.config.memory.tcdm.start
                     && (addr as u32) < self.config.memory.tcdm.end
                 {
-                    tcdm[(addr / 4) as usize] = value;
+                    tcdm[((addr - (self.config.memory.tcdm.start as u64)) / 4) as usize] = value;
                 }
             }
             (0..self.num_clusters).map(|_| tcdm.clone()).collect()


### PR DESCRIPTION
As described in #105, if a non-zero TCDM base is used, the memory initialization breaks