### PR TITLE
testbench: Increase DMA memory transactions to omit DMA deadlock

### DIFF
--- a/hw/ip/test/src/tb_memory_axi.sv
+++ b/hw/ip/test/src/tb_memory_axi.sv
@@ -84,7 +84,9 @@ module tb_memory_axi #(
     .DATA_WIDTH ( AxiDataWidth ),
     .ID_WIDTH   ( AxiIdWidth   ),
     .USER_WIDTH ( AxiUserWidth ),
-    .DECOUPLE_W ( 1            )
+    .DECOUPLE_W ( 1            ),
+    .AXI_MAX_WRITE_TXNS ( 32'd4 ),
+    .AXI_MAX_READ_TXNS  ( 32'd4 )
   ) i_axi_to_reg (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
Transaction issued by the DMA larger than 4K might deadlock. Increasing the transaction buffer fixes this in my case.

@zarubaf @accuminium do you think we can leave it like that for now?