### PR TITLE
occamy: Prevent duplicate address map entries for HBM

### DIFF
--- a/hw/system/occamy/src/occamy_pkg.sv
+++ b/hw/system/occamy/src/occamy_pkg.sv
@@ -224,7 +224,7 @@ package occamy_pkg;
     AxiIdUsedSlvPorts:  3,
     AxiAddrWidth:       48,
     AxiDataWidth:       512,
-    NoAddrRules:        19
+    NoAddrRules:        17
   };
 
   // AXI bus with 48 bit address, 512 bit data, 3 bit IDs, and 0 bit user data.

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -201,12 +201,10 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   );
 
   /// Address map of the `soc_wide_xbar` crossbar.
-  xbar_rule_48_t [18:0] SocWideXbarAddrmap;
+  xbar_rule_48_t [16:0] SocWideXbarAddrmap;
   assign SocWideXbarAddrmap = '{
     '{ idx: 8, start_addr: 48'h80000000, end_addr: 48'hc0000000 },
-    '{ idx: 8, start_addr: 48'h1000000000, end_addr: 48'h1040000000 },
     '{ idx: 9, start_addr: 48'hc0000000, end_addr: 48'h100000000 },
-    '{ idx: 9, start_addr: 48'h1040000000, end_addr: 48'h1080000000 },
     '{ idx: 10, start_addr: 48'h1080000000, end_addr: 48'h10c0000000 },
     '{ idx: 11, start_addr: 48'h10c0000000, end_addr: 48'h1100000000 },
     '{ idx: 12, start_addr: 48'h1100000000, end_addr: 48'h1140000000 },

--- a/util/occamygen.py
+++ b/util/occamygen.py
@@ -156,7 +156,8 @@ def main():
         bases = list()
         if i < 2:
             bases.append(HBM_BASE + i * HBM_CHANNEL_SIZE)
-        bases.append(0x1000000000 + i * HBM_CHANNEL_SIZE)
+        else:
+            bases.append(0x1000000000 + i * HBM_CHANNEL_SIZE)
         am_hbm.append(
             am.new_leaf("hbm_{}".format(i), HBM_CHANNEL_SIZE,
                         *bases).attach_to(am_soc_wide_xbar))


### PR DESCRIPTION
Do not create two address map entries for the first two HBM channels (unless this was intended).