### PR TITLE
Use BSCANE2 tap for FPGA interaction

### DIFF
--- a/hw/system/occamy/fpga/.gitignore
+++ b/hw/system/occamy/fpga/.gitignore
@@ -1,4 +1,5 @@
 occamy_vcu128/
+vivado_ips/xgui
 .Xil/
 xgui/
 define_defines_includes_no_simset.tcl

--- a/hw/system/occamy/fpga/vcu128.cfg
+++ b/hw/system/occamy/fpga/vcu128.cfg
@@ -1,0 +1,26 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+adapter driver ftdi
+adapter speed 100
+transport select jtag
+
+# The VCU128 uses a FT4232H
+ftdi_vid_pid 0x0403 0x6011
+# If more than one FTDI is connected we
+# can use the serial to differentiate.
+ftdi_serial 091847100576
+ftdi_layout_init 0x0008 0x05eb
+
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 18 -expected-id 0x14B79093
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+
+riscv set_ir idcode 0x9249
+riscv set_ir dtmcs 0x22924
+riscv set_ir dmi 0x23924
+

--- a/hw/system/occamy/fpga/vivado_ips/Makefile
+++ b/hw/system/occamy/fpga/vivado_ips/Makefile
@@ -16,7 +16,7 @@ occamy_xilinx: define-sources.tcl
 	${VIVADO} -mode batch -source occamy_xilinx.tcl
 
 define-sources.tcl:
-	${BENDER} script vivado > $@
+	${BENDER} script vivado -t bscane > $@
 
 clean:
 	rm -rf .Xil occamy_xilinx vivado* define-sources.tcl component.xml

--- a/hw/vendor/patches/pulp_platform_riscv_dbg/0003-riscv-dbg-Update-Bender.yml.patch
+++ b/hw/vendor/patches/pulp_platform_riscv_dbg/0003-riscv-dbg-Update-Bender.yml.patch
@@ -1,0 +1,76 @@
+From 250902e585d319b95777acef8b7cd14b076812d9 Mon Sep 17 00:00:00 2001
+From: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+Date: Wed, 5 May 2021 16:33:58 +0200
+Subject: [PATCH] riscv-dbg: Update Bender.yml
+
+---
+ Bender.yml | 53 +++++++++++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 43 insertions(+), 10 deletions(-)
+
+diff --git a/Bender.yml b/Bender.yml
+index eb52d1d..7178d56 100644
+--- a/Bender.yml
++++ b/Bender.yml
+@@ -1,16 +1,49 @@
++# Copyright 2020-2021 ETH Zurich and University of Bologna.
++# Solderpad Hardware License, Version 0.51, see LICENSE for details.
++# SPDX-License-Identifier: SHL-0.51
++
+ package:
+   name: riscv-dbg
++  authors:
++  - Florian Zaruba <zarubaf@iis.ee.ethz.ch>
++  - Robert Balas <balasr@iis.ee.ethz.ch>
++
++dependencies:
++  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
++  common_cells: {git: https://github.com/pulp-platform/common_cells.git, version: 1.21.0}
+ 
+ sources:
+   files:
+-    - src/dm_pkg.sv
+-    - debug_rom/debug_rom.sv
+-    - debug_rom/debug_rom_one_scratch.sv
+-    - src/dm_csrs.sv
+-    - src/dm_mem.sv
+-    - src/dm_top.sv
+-    - src/dm_obi_top.sv
+-    - src/dmi_cdc.sv
+-    - src/dmi_jtag.sv
++  # Level 1:
++  - src/dm_pkg.sv
++  - debug_rom/debug_rom.sv
++  - debug_rom/debug_rom_one_scratch.sv
++  # Level 2:
++  - src/dm_csrs.sv
++  - src/dm_mem.sv
++  - src/dmi_cdc.sv
++  - target: not(all(xilinx, bscane))
++    files:
+     - src/dmi_jtag_tap.sv
+-    - src/dm_sba.sv
++  - target: all(xilinx, bscane)
++    files:
++    - src/dmi_bscane_tap.sv
++  # Level 3:
++  - src/dm_sba.sv
++  - src/dm_top.sv
++  - src/dmi_jtag.sv
++  # Level 4:
++  - src/dm_obi_top.sv
++
++  - target: simulation
++    files:
++    - src/dmi_test.sv
++
++  - target: test
++    files:
++    # Level 1
++    - src/dmi_intf.sv
++    - tb/jtag_dmi/jtag_intf.sv
++    - tb/jtag_dmi/jtag_test.sv
++    # Level 3
++    - tb/jtag_dmi/tb_jtag_dmi.sv
+-- 
+2.25.1.377.g2d2118b814
+

--- a/hw/vendor/pulp_platform_riscv_dbg/Bender.yml
+++ b/hw/vendor/pulp_platform_riscv_dbg/Bender.yml
@@ -1,16 +1,49 @@
+# Copyright 2020-2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
 package:
   name: riscv-dbg
+  authors:
+  - Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+  - Robert Balas <balasr@iis.ee.ethz.ch>
+
+dependencies:
+  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
+  common_cells: {git: https://github.com/pulp-platform/common_cells.git, version: 1.21.0}
 
 sources:
   files:
-    - src/dm_pkg.sv
-    - debug_rom/debug_rom.sv
-    - debug_rom/debug_rom_one_scratch.sv
-    - src/dm_csrs.sv
-    - src/dm_mem.sv
-    - src/dm_top.sv
-    - src/dm_obi_top.sv
-    - src/dmi_cdc.sv
-    - src/dmi_jtag.sv
+  # Level 1:
+  - src/dm_pkg.sv
+  - debug_rom/debug_rom.sv
+  - debug_rom/debug_rom_one_scratch.sv
+  # Level 2:
+  - src/dm_csrs.sv
+  - src/dm_mem.sv
+  - src/dmi_cdc.sv
+  - target: not(all(xilinx, bscane))
+    files:
     - src/dmi_jtag_tap.sv
-    - src/dm_sba.sv
+  - target: all(xilinx, bscane)
+    files:
+    - src/dmi_bscane_tap.sv
+  # Level 3:
+  - src/dm_sba.sv
+  - src/dm_top.sv
+  - src/dmi_jtag.sv
+  # Level 4:
+  - src/dm_obi_top.sv
+
+  - target: simulation
+    files:
+    - src/dmi_test.sv
+
+  - target: test
+    files:
+    # Level 1
+    - src/dmi_intf.sv
+    - tb/jtag_dmi/jtag_intf.sv
+    - tb/jtag_dmi/jtag_test.sv
+    # Level 3
+    - tb/jtag_dmi/tb_jtag_dmi.sv


### PR DESCRIPTION
This commit uses the `bscane_tap` from the `riscv-dbg` module to
faciliate debugging with OpenOCD.

The TAP is correctly identified on the VCU128 but the debugger is not
able to halt the core. Imho, this is due to the missing bootrom which
will just hang the FPGA.

Unfortunately, using the BSCANE2 primitives has the drawback of that the
Xilinx HW Server can not be connected at the same time (resource
conflict on the USB interface). That in turn means, that debugging with
GDB and ILA is mutual exclusive.

That is the current output I can produce with `OpenOCD` when connecting:

```
~$ openocd -f vcu128.cfg

Open On-Chip Debugger 0.11.0+dev-00117-gab337d05f-dirty
(2021-04-28-09:46)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
DEPRECATED! use 'adapter speed' not 'adapter_khz'
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Info : clock speed 100 kHz
Info : JTAG tap: riscv.cpu tap/device found: 0x14b79093 (mfg: 0x049
(Xilinx), part: 0x4b79, ver:
0x1)
Info : datacount=2 progbufsize=8
Error: unable to halt hart 0
Error:   dmcontrol=0x80000001
Error:   dmstatus =0x00000c82
Error: Fatal: Hart 0 failed to halt during examine()
Warn : target riscv.cpu examination failed
Info : starting gdb server for riscv.cpu on 3333
Info : Listening on port 3333 for gdb connections
```