### PR TITLE
occamy/fpga: Make ILA excludable

### DIFF
--- a/hw/system/occamy/fpga/Makefile
+++ b/hw/system/occamy/fpga/Makefile
@@ -7,6 +7,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MKFILE_DIR  := $(dir $(MKFILE_PATH))
 ROOT        := ${MKFILE_DIR}../../../..
+DEBUG       ?= 0
 
 VIVADO := vivado
 
@@ -19,7 +20,7 @@ bootrom/bootrom.coe:
 	${MAKE} -C bootrom bootrom.coe
 
 occamy_vcu128: vivado_ips/occamy_xilinx define_defines_includes_no_simset.tcl bootrom/bootrom.coe
-	${VIVADO} -source occamy_vcu128.tcl
+	${VIVADO} -source occamy_vcu128.tcl -tclargs $(DEBUG)
 
 define_defines_includes_no_simset.tcl: $(BENDER_FILES)
 	${BENDER} script vivado --only-defines --only-includes --no-simset > $@

--- a/hw/system/occamy/fpga/occamy_vcu128.tcl
+++ b/hw/system/occamy/fpga/occamy_vcu128.tcl
@@ -4,6 +4,15 @@
 #
 # Nils Wistoff <nwistoff@iis.ee.ethz.ch>
 
+# Parse arguments
+set DEBUG false
+if {$argc > 0} {
+    # Vivado's boolean properties are not compatible with all tcl boolean variables.
+    if {[lindex $argv 0]} {
+        set DEBUG true
+    }
+}
+
 # Create project
 set project occamy_vcu128
 
@@ -37,8 +46,10 @@ export_ip_user_files -of_objects [get_ips occamy_vcu128_occamy_xilinx_0_0] -no_s
 eval [exec sed {s/current_fileset/get_filesets occamy_vcu128_occamy_xilinx_0_0/} define_defines_includes_no_simset.tcl]
 
 # Debug settings
-add_files -fileset constrs_1 occamy_vcu128_debug.xdc
-set_property target_constrs_file occamy_vcu128_debug.xdc [current_fileset -constrset]
+if {$DEBUG} {
+    add_files -fileset constrs_1 occamy_vcu128_debug.xdc
+    set_property target_constrs_file occamy_vcu128_debug.xdc [current_fileset -constrset]
+}
 
 # Do NOT insert BUFGs on high-fanout nets (e.g. reset). This will backfire during placement.
 set_param logicopt.enableBUFGinsertHFN no

--- a/hw/system/occamy/fpga/occamy_vcu128_bd.tcl
+++ b/hw/system/occamy/fpga/occamy_vcu128_bd.tcl
@@ -174,7 +174,7 @@ if { $bCheckIPsPassed != 1 } {
 
 # Procedure to create entire design; Provide argument to make
 # procedure reusable. If parentCell is "", will use root.
-proc create_root_design { parentCell } {
+proc create_root_design { parentCell DEBUG } {
 
   variable script_folder
   variable design_name
@@ -483,7 +483,7 @@ proc create_root_design { parentCell } {
   connect_bd_intf_net -intf_net occamy_xilinx_0_m_axi_hbm_6 [get_bd_intf_pins occamy_xilinx_0/m_axi_hbm_6] [get_bd_intf_pins smartconnect_6/S00_AXI]
   connect_bd_intf_net -intf_net occamy_xilinx_0_m_axi_hbm_7 [get_bd_intf_pins occamy_xilinx_0/m_axi_hbm_7] [get_bd_intf_pins smartconnect_7/S00_AXI]
   connect_bd_intf_net -intf_net occamy_xilinx_0_m_axi_pcie [get_bd_intf_pins occamy_xilinx_0/m_axi_pcie] [get_bd_intf_pins smartconnect_8/S00_AXI]
-  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_intf_nets occamy_xilinx_0_m_axi_pcie]
+  set_property HDL_ATTRIBUTE.DEBUG $DEBUG [get_bd_intf_nets occamy_xilinx_0_m_axi_pcie]
   connect_bd_intf_net -intf_net smartconnect_0_M00_AXI [get_bd_intf_pins hbm_0/SAXI_00] [get_bd_intf_pins smartconnect_0/M00_AXI]
   connect_bd_intf_net -intf_net smartconnect_0_M01_AXI [get_bd_intf_pins hbm_0/SAXI_01] [get_bd_intf_pins smartconnect_0/M01_AXI]
   connect_bd_intf_net -intf_net smartconnect_1_M00_AXI [get_bd_intf_pins hbm_0/SAXI_04] [get_bd_intf_pins smartconnect_1/M00_AXI]
@@ -502,7 +502,7 @@ proc create_root_design { parentCell } {
   connect_bd_net -net axi_quad_spi_0_ip2intc_irpt [get_bd_pins axi_quad_spi_0/ip2intc_irpt] [get_bd_pins xlconcat_0/In1]
   connect_bd_net -net axi_uart16550_0_ip2intc_irpt [get_bd_pins axi_uart16550_0/ip2intc_irpt] [get_bd_pins xlconcat_0/In0]
   connect_bd_net -net blk_mem_gen_0_douta [get_bd_pins blk_mem_gen_0/douta] [get_bd_pins occamy_xilinx_0/bootrom_data_i]
-  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_nets blk_mem_gen_0_douta]
+  set_property HDL_ATTRIBUTE.DEBUG $DEBUG [get_bd_nets blk_mem_gen_0_douta]
   connect_bd_net -net clk_100MHz_n_1 [get_bd_ports clk_100MHz_n] [get_bd_pins clk_wiz/clk_in1_n]
   connect_bd_net -net clk_100MHz_p_1 [get_bd_ports clk_100MHz_p] [get_bd_pins clk_wiz/clk_in1_p]
   connect_bd_net -net clk_wiz_clk_out1 [get_bd_pins axi_quad_spi_0/ext_spi_clk] [get_bd_pins clk_wiz/clk_out1] [get_bd_pins hbm_0/AXI_00_ACLK] [get_bd_pins hbm_0/AXI_00_WDATA_PARITY] [get_bd_pins hbm_0/AXI_01_ACLK] [get_bd_pins hbm_0/AXI_04_ACLK] [get_bd_pins hbm_0/AXI_05_ACLK] [get_bd_pins hbm_0/AXI_08_ACLK] [get_bd_pins hbm_0/AXI_12_ACLK] [get_bd_pins hbm_0/AXI_16_ACLK] [get_bd_pins hbm_0/AXI_20_ACLK] [get_bd_pins hbm_0/AXI_24_ACLK] [get_bd_pins hbm_0/AXI_28_ACLK] [get_bd_pins hbm_0/HBM_REF_CLK_0] [get_bd_pins hbm_0/HBM_REF_CLK_1] [get_bd_pins smartconnect_0/aclk1] [get_bd_pins smartconnect_1/aclk1] [get_bd_pins smartconnect_2/aclk1] [get_bd_pins smartconnect_3/aclk1] [get_bd_pins smartconnect_4/aclk1] [get_bd_pins smartconnect_5/aclk1] [get_bd_pins smartconnect_6/aclk1] [get_bd_pins smartconnect_7/aclk1]
@@ -512,9 +512,9 @@ proc create_root_design { parentCell } {
   connect_bd_net -net const_low_dout [get_bd_pins axi_quad_spi_0/gsr] [get_bd_pins axi_quad_spi_0/gts] [get_bd_pins axi_quad_spi_0/usrcclkts] [get_bd_pins const_low/dout] [get_bd_pins xlconcat_0/In2] [get_bd_pins xlconcat_0/In3]
   connect_bd_net -net inv_Res [get_bd_pins axi_apb_bridge_0/s_axi_aresetn] [get_bd_pins axi_quad_spi_0/s_axi4_aresetn] [get_bd_pins axi_uart16550_0/s_axi_aresetn] [get_bd_pins hbm_0/APB_0_PRESET_N] [get_bd_pins hbm_0/APB_1_PRESET_N] [get_bd_pins hbm_0/AXI_00_ARESET_N] [get_bd_pins hbm_0/AXI_01_ARESET_N] [get_bd_pins hbm_0/AXI_04_ARESET_N] [get_bd_pins hbm_0/AXI_05_ARESET_N] [get_bd_pins hbm_0/AXI_08_ARESET_N] [get_bd_pins hbm_0/AXI_12_ARESET_N] [get_bd_pins hbm_0/AXI_16_ARESET_N] [get_bd_pins hbm_0/AXI_20_ARESET_N] [get_bd_pins hbm_0/AXI_24_ARESET_N] [get_bd_pins hbm_0/AXI_28_ARESET_N] [get_bd_pins inv/Res] [get_bd_pins occamy_xilinx_0/rst_ni] [get_bd_pins occamy_xilinx_0/rst_periph_ni] [get_bd_pins smartconnect_0/aresetn] [get_bd_pins smartconnect_1/aresetn] [get_bd_pins smartconnect_2/aresetn] [get_bd_pins smartconnect_3/aresetn] [get_bd_pins smartconnect_4/aresetn] [get_bd_pins smartconnect_5/aresetn] [get_bd_pins smartconnect_6/aresetn] [get_bd_pins smartconnect_7/aresetn] [get_bd_pins smartconnect_8/aresetn]
   connect_bd_net -net occamy_xilinx_0_bootrom_addr_o [get_bd_pins blk_mem_gen_0/addra] [get_bd_pins occamy_xilinx_0/bootrom_addr_o]
-  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_nets occamy_xilinx_0_bootrom_addr_o]
+  set_property HDL_ATTRIBUTE.DEBUG $DEBUG [get_bd_nets occamy_xilinx_0_bootrom_addr_o]
   connect_bd_net -net occamy_xilinx_0_bootrom_en_o [get_bd_pins blk_mem_gen_0/ena] [get_bd_pins occamy_xilinx_0/bootrom_en_o]
-  set_property HDL_ATTRIBUTE.DEBUG {true} [get_bd_nets occamy_xilinx_0_bootrom_en_o]
+  set_property HDL_ATTRIBUTE.DEBUG $DEBUG [get_bd_nets occamy_xilinx_0_bootrom_en_o]
   connect_bd_net -net occamy_xilinx_0_uart_tx_o [get_bd_ports uart_tx_o_0] [get_bd_pins occamy_xilinx_0/uart_tx_o]
   connect_bd_net -net reset_1 [get_bd_ports reset] [get_bd_pins clk_wiz/reset] [get_bd_pins inv/Op1]
   connect_bd_net -net uart_rx_i_0_1 [get_bd_ports uart_rx_i_0] [get_bd_pins occamy_xilinx_0/uart_rx_i]
@@ -865,6 +865,6 @@ proc create_root_design { parentCell } {
 # MAIN FLOW
 ##################################################################
 
-create_root_design ""
+create_root_design "" $DEBUG
 
 

--- a/hw/system/occamy/fpga/vivado_ips/Makefile
+++ b/hw/system/occamy/fpga/vivado_ips/Makefile
@@ -7,13 +7,14 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MKFILE_DIR  := $(dir $(MKFILE_PATH))
 ROOT        := ${MKFILE_DIR}../../../../..
+DEBUG       ?= 0
 
 VIVADO := vivado
 
 include $(ROOT)/util/Makefrag
 
 occamy_xilinx: define-sources.tcl
-	${VIVADO} -mode batch -source occamy_xilinx.tcl
+	${VIVADO} -mode batch -source occamy_xilinx.tcl -tclargs $(DEBUG)
 
 define-sources.tcl:
 	${BENDER} script vivado -t bscane > $@

--- a/hw/system/occamy/fpga/vivado_ips/occamy_xilinx.tcl
+++ b/hw/system/occamy/fpga/vivado_ips/occamy_xilinx.tcl
@@ -4,6 +4,15 @@
 #
 # Nils Wistoff <nwistoff@iis.ee.ethz.ch>
 
+# Parse arguments
+set DEBUG false
+if {$argc > 0} {
+    # Vivado's boolean properties are not compatible with all tcl boolean variables.
+    if {[lindex $argv 0]} {
+        set DEBUG true
+    }
+}
+
 # Create project
 set project occamy_xilinx
 
@@ -17,9 +26,11 @@ source define-sources.tcl
 set_property IS_ENABLED 0 [get_files $ROOT/../../vendor/pulp_platform_axi/src/axi_intf.sv]
 set_property IS_ENABLED 0 [get_files $ROOT/../../vendor/pulp_platform_register_interface/src/reg_intf.sv]
 
-# Add constraint files
-add_files -fileset constrs_1 -norecurse occamy_xilinx_debug.xdc
-import_files -fileset constrs_1 occamy_xilinx_debug.xdc
+# Add debug constraint files
+if {$DEBUG} {
+    add_files -fileset constrs_1 -norecurse occamy_xilinx_debug.xdc
+    import_files -fileset constrs_1 occamy_xilinx_debug.xdc
+}
 
 # Package IP
 set_property top occamy_xilinx [current_fileset]


### PR DESCRIPTION
The current ILA is pretty large, also because it probes an AXI bus with a 512 bit data width. Often, the ILA is not needed or usable, e.g. when the JTAG port is occupied by the debugger. Excluding the ILA accelerates compile time by ~1h and reduces BRAM usage by ~40%.

This excludes the ILA per default. It can be included using the `make` variable `DEBUG` (e.g. `make fpga DEBUG=1`).