### PR TITLE
Add `known` assertion on regfile write port

### DIFF
--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -207,7 +207,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   } op_select_e;
   op_select_e opa_select, opb_select;
 
-  logic write_rd; // write desitnation this cycle
+  logic write_rd; // write destination this cycle
   logic uses_rd;
   typedef enum logic [2:0] {Consec, Alu, Exception, MRet, SRet, DRet} next_pc_e;
   next_pc_e next_pc;
@@ -2600,5 +2600,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   `ASSERT(InstructionInterfaceStable,
       (inst_valid_o && inst_ready_i && inst_cacheable_o) ##1 (inst_valid_o && $stable(inst_addr_o))
       |-> inst_ready_i && $stable(inst_data_i), clk_i, rst_i)
+
+  `ASSERT(RegWriteKnown, gpr_we |-> !$isunknown(gpr_wdata), clk_i, rst_i)
 
 endmodule

--- a/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
+++ b/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: SHL-0.51
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
 
 // Floating Point Subsystem
 module snitch_fp_ss import snitch_pkg::*; #(
@@ -2711,5 +2712,8 @@ module snitch_fp_ss import snitch_pkg::*; #(
   assign trace_port_o.fpr_waddr    = fpr_waddr[0];
   assign trace_port_o.fpr_wdata    = fpr_wdata[0];
   assign trace_port_o.fpr_we       = fpr_we[0];
-// pragma translate_on
+  // pragma translate_on
+
+  /// Assertions
+  `ASSERT(RegWriteKnown, fpr_we |-> !$isunknown(fpr_wdata), clk_i, rst_i)
 endmodule


### PR DESCRIPTION
X's have hunted us a couple of times already - this PR add assertions to check that we are not writing-back any X's on the floating or integer register file. That should at least track where we are introducing unknown values.