### PR TITLE
ssr: Fix missing scoreboard and wrong timin in config reads

### DIFF
--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -1936,6 +1936,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
         if (Xssr) begin
           acc_qreq_o.addr = SSR_CFG;
           acc_qvalid_o = valid_instr;
+          acc_register_rd = 1'b1;
         end else illegal_inst = 1'b1;
       end
       SCFGWI: begin
@@ -1951,6 +1952,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
           acc_qreq_o.addr = SSR_CFG;
           opb_select = Reg;
           acc_qvalid_o = valid_instr;
+          acc_register_rd = 1'b1;
         end else illegal_inst = 1'b1;
       end
       SCFGW: begin

--- a/hw/ip/snitch_cluster/src/snitch_cc.sv
+++ b/hw/ip/snitch_cluster/src/snitch_cc.sv
@@ -591,9 +591,8 @@ module snitch_cc #(
     ssr_cfg_req_t ssr_cfg_req, cfg_req;
     ssr_cfg_rsp_t ssr_cfg_rsp, cfg_rsp;
 
-    logic cfg_req_valid, cfg_req_valid_q;
-    `FF(cfg_req_valid_q, cfg_req_valid, 0)
-    `FF(cfg_rsp.id, ssr_cfg_req.id, 0)
+    logic cfg_req_valid;
+    assign cfg_rsp.id = ssr_cfg_req.id;
 
     always_comb begin
       import riscv_instr::*;
@@ -656,7 +655,7 @@ module snitch_cc #(
       .mem_req_valid_o (cfg_req_valid),
       .mem_req_ready_i (1'b1),
       .mem_resp_i (cfg_rsp),
-      .mem_resp_valid_i (cfg_req_valid_q)
+      .mem_resp_valid_i (cfg_req_valid)
     );
 
     // TODO: Assert that NumSsrs is at least 1 in any case

--- a/hw/ip/snitch_cluster/src/snitch_cc.sv
+++ b/hw/ip/snitch_cluster/src/snitch_cc.sv
@@ -591,8 +591,11 @@ module snitch_cc #(
     ssr_cfg_req_t ssr_cfg_req, cfg_req;
     ssr_cfg_rsp_t ssr_cfg_rsp, cfg_rsp;
 
-    logic cfg_req_valid;
-    assign cfg_rsp.id = ssr_cfg_req.id;
+    logic cfg_req_valid, cfg_req_valid_q;
+    logic [31:0] cfg_rsp_data;
+    `FF(cfg_req_valid_q, cfg_req_valid, 0)
+    `FF(cfg_rsp.id, ssr_cfg_req.id, 0)
+    `FF(cfg_rsp.data, cfg_rsp_data, 0)
 
     always_comb begin
       import riscv_instr::*;
@@ -655,7 +658,7 @@ module snitch_cc #(
       .mem_req_valid_o (cfg_req_valid),
       .mem_req_ready_i (1'b1),
       .mem_resp_i (cfg_rsp),
-      .mem_resp_valid_i (cfg_req_valid)
+      .mem_resp_valid_i (cfg_req_valid_q)
     );
 
     // TODO: Assert that NumSsrs is at least 1 in any case
@@ -676,7 +679,7 @@ module snitch_cc #(
       .rst_ni         ( rst_ni    ),
       .cfg_word_i     ( cfg_req.word  ),
       .cfg_write_i    ( cfg_req.write & cfg_req_valid ),
-      .cfg_rdata_o    ( cfg_rsp.data  ),
+      .cfg_rdata_o    ( cfg_rsp_data ),
       .cfg_wdata_i    ( cfg_req.data ),
 
       .ssr_raddr_i    ( ssr_raddr  ),


### PR DESCRIPTION
Two bugs in the RTL prevented the use of the `scfgr`/`scfgri` instructions

- A missing scoreboard connection to keep track of the destination register value
- Timing in the `stream_to_mem` converter. The SSR respond with the read value in the same cycle as the request is made. Previously, the `id` and `valid` signals were delayed a cycle but not the `data`. This change removes the delay such that the response comes in the same cycle as the request

This now allows SSR barriers such as 
```c
  asm volatile(
    "1: \n"
    "scfgri t0, 0\n"        // reat status word
    "srli   t0, t0, 31\n"   // extract done bit 31
    "beqz   t0, 1b\n"       // repeat if done bit not set
    ::: "t0");
```

Is the timing ok like this or should we insert a cut on the response?