### PR TITLE
Add: Read-modify-write (RMW) module

### DIFF
--- a/hw/ip/spm_interface/.gitignore
+++ b/hw/ip/spm_interface/.gitignore
@@ -1,0 +1,6 @@
+compile.tcl
+transcript
+*.log
+*.lock
+work
+Bender.lock

--- a/hw/ip/spm_interface/Bender.yml
+++ b/hw/ip/spm_interface/Bender.yml
@@ -7,6 +7,7 @@ package:
   - Tim Fischer <fischeti@iis.ee.ethz.ch>
 
 dependencies:
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
 
 export_include_dirs:
 - include

--- a/hw/ip/spm_interface/Bender.yml
+++ b/hw/ip/spm_interface/Bender.yml
@@ -1,0 +1,23 @@
+# Copyright 2020 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+package:
+  name: spm_interface
+  authors:
+  - Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+dependencies:
+
+export_include_dirs:
+- include
+
+sources:
+- src/spm_interface.sv
+- src/spm_rmw_adapter.sv
+- target: simulation
+  files:
+  - src/spm_test.sv
+- target: test
+  files:
+  # Level 0
+  - test/tb_spm_rmw_adapter.sv

--- a/hw/ip/spm_interface/include/spm_interface/assign.svh
+++ b/hw/ip/spm_interface/include/spm_interface/assign.svh
@@ -1,0 +1,28 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+// Macros to assign SPM Interfaces
+
+`ifndef SPM_ASSIGN_SVH_
+`define SPM_ASSIGN_SVH_
+
+`define SPM_ASSIGN_REQ_CHAN(dst, src) \
+  assign dst.addr  = src.addr;        \
+  assign dst.we    = src.we  ;        \
+  assign dst.wdata = src.wdata;       \
+  assign dst.strb  = src.strb;        \
+  assign dst.req   = src.req;
+
+`define SPM_ASSIGN_RSP_CHAN(dst, src) \
+  assign dst.gnt    = src.gnt;        \
+  assign dst.rvalid = src.rvalid;     \
+  assign dst.rdata  = src.rdata;
+
+`define SPM_ASSIGN(slv, mst)         \
+  `SPM_ASSIGN_REQ_CHAN(slv, mst)     \
+  `SPM_ASSIGN_RSP_CHAN(mst, slv)
+
+`endif

--- a/hw/ip/spm_interface/include/spm_interface/assign.svh
+++ b/hw/ip/spm_interface/include/spm_interface/assign.svh
@@ -14,10 +14,10 @@
   assign dst.we    = src.we  ;        \
   assign dst.wdata = src.wdata;       \
   assign dst.strb  = src.strb;        \
-  assign dst.req   = src.req;
+  assign dst.valid = src.valid;
 
 `define SPM_ASSIGN_RSP_CHAN(dst, src) \
-  assign dst.gnt    = src.gnt;        \
+  assign dst.ready  = src.ready;        \
   assign dst.rvalid = src.rvalid;     \
   assign dst.rdata  = src.rdata;
 

--- a/hw/ip/spm_interface/src/spm_interface.sv
+++ b/hw/ip/spm_interface/src/spm_interface.sv
@@ -19,26 +19,24 @@ interface SPM_BUS #(
   typedef logic [StrbWidth-1:0] strb_t;
   /// The request channel.
   addr_t   addr;
-  /// 0 = read, 1 = write, 1 = amo fetch-and-op
   logic    we;
   data_t   wdata;
-  /// Byte-wise strobe
   strb_t   strb;
-  logic    req;
+  logic    valid;
 
   /// The response channel.
-  logic    gnt;
+  logic    ready;
   logic    rvalid;
   data_t   rdata;
 
   modport in  (
-    input  addr, we, wdata, strb, req,
-    output gnt, rvalid, rdata
+    input  addr, we, wdata, strb, valid,
+    output ready, rvalid, rdata
   );
 
   modport out  (
-    output  addr, we, wdata, strb, req,
-    input gnt, rvalid, rdata
+    output  addr, we, wdata, strb, valid,
+    input ready, rvalid, rdata
   );
 
 endinterface
@@ -60,26 +58,24 @@ interface SPM_BUS_DV #(
   typedef logic [StrbWidth-1:0]  strb_t;
   /// The request channel.
   addr_t   addr;
-  /// 0 = read, 1 = write, 1 = amo fetch-and-op
   logic                          we;
   data_t   wdata;
-  /// Byte-wise strobe
   strb_t   strb;
-  logic                          req;
+  logic                          valid;
 
   /// The response channel.
-  logic                          gnt;
+  logic                          ready;
   logic                          rvalid;
   data_t   rdata;
 
   modport in  (
-               input  addr, we, wdata, strb, req,
-               output gnt, rvalid, rdata
+               input  addr, we, wdata, strb, valid,
+               output ready, rvalid, rdata
                );
 
   modport out  (
-                output addr, we, wdata, strb, req,
-                input  gnt, rvalid, rdata
+                output addr, we, wdata, strb, valid,
+                input  ready, rvalid, rdata
                 );
 
 endinterface

--- a/hw/ip/spm_interface/src/spm_interface.sv
+++ b/hw/ip/spm_interface/src/spm_interface.sv
@@ -81,9 +81,8 @@ interface SPM_BUS_DV #(
   // pragma translate_off
 `ifndef VERILATOR
   assert property (@(posedge clk_i) (valid && !ready |=> $stable(addr)));
-  // Does not hold for RMW requests
-  // assert property (@(posedge clk_i) (valid && !ready |=> $stable(we)));
-  assert property (@(posedge clk_i) (valid && !ready |=> $stable(wdata)));
+  assert property (@(posedge clk_i) (valid && !ready |=> $stable(we)));
+  assert property (@(posedge clk_i) (valid && !ready && we |=> $stable(wdata)));
   assert property (@(posedge clk_i) (valid && !ready |=> $stable(strb)));
   assert property (@(posedge clk_i) (valid && !ready |=> valid));
 `endif

--- a/hw/ip/spm_interface/src/spm_interface.sv
+++ b/hw/ip/spm_interface/src/spm_interface.sv
@@ -81,7 +81,8 @@ interface SPM_BUS_DV #(
   // pragma translate_off
 `ifndef VERILATOR
   assert property (@(posedge clk_i) (valid && !ready |=> $stable(addr)));
-  assert property (@(posedge clk_i) (valid && !ready |=> $stable(we)));
+  // Does not hold for RMW requests
+  // assert property (@(posedge clk_i) (valid && !ready |=> $stable(we)));
   assert property (@(posedge clk_i) (valid && !ready |=> $stable(wdata)));
   assert property (@(posedge clk_i) (valid && !ready |=> $stable(strb)));
   assert property (@(posedge clk_i) (valid && !ready |=> valid));

--- a/hw/ip/spm_interface/src/spm_interface.sv
+++ b/hw/ip/spm_interface/src/spm_interface.sv
@@ -1,0 +1,85 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+/// SPM Interface.
+interface SPM_BUS #(
+  /// The width of the address.
+  parameter int  ADDR_WIDTH = -1,
+  /// The width of the data.
+  parameter int  DATA_WIDTH = -1
+);
+
+  localparam int unsigned StrbWidth = DATA_WIDTH / 8;
+
+  typedef logic [ADDR_WIDTH-1:0] addr_t;
+  typedef logic [DATA_WIDTH-1:0] data_t;
+  typedef logic [StrbWidth-1:0] strb_t;
+  /// The request channel.
+  addr_t   addr;
+  /// 0 = read, 1 = write, 1 = amo fetch-and-op
+  logic    we;
+  data_t   wdata;
+  /// Byte-wise strobe
+  strb_t   strb;
+  logic    req;
+
+  /// The response channel.
+  logic    gnt;
+  logic    rvalid;
+  data_t   rdata;
+
+  modport in  (
+    input  addr, we, wdata, strb, req,
+    output gnt, rvalid, rdata
+  );
+
+  modport out  (
+    output  addr, we, wdata, strb, req,
+    input gnt, rvalid, rdata
+  );
+
+endinterface
+
+/// SPM Interface for verficiation purposes.
+interface SPM_BUS_DV #(
+  /// The width of the address.
+  parameter int  ADDR_WIDTH = -1,
+  /// The width of the data.
+  parameter int  DATA_WIDTH = -1
+) (
+  input logic clk_i
+);
+
+  localparam int unsigned StrbWidth = DATA_WIDTH / 8;
+
+  typedef logic [ADDR_WIDTH-1:0] addr_t;
+  typedef logic [DATA_WIDTH-1:0] data_t;
+  typedef logic [StrbWidth-1:0]  strb_t;
+  /// The request channel.
+  addr_t   addr;
+  /// 0 = read, 1 = write, 1 = amo fetch-and-op
+  logic                          we;
+  data_t   wdata;
+  /// Byte-wise strobe
+  strb_t   strb;
+  logic                          req;
+
+  /// The response channel.
+  logic                          gnt;
+  logic                          rvalid;
+  data_t   rdata;
+
+  modport in  (
+               input  addr, we, wdata, strb, req,
+               output gnt, rvalid, rdata
+               );
+
+  modport out  (
+                output addr, we, wdata, strb, req,
+                input  gnt, rvalid, rdata
+                );
+
+endinterface

--- a/hw/ip/spm_interface/src/spm_interface.sv
+++ b/hw/ip/spm_interface/src/spm_interface.sv
@@ -78,4 +78,14 @@ interface SPM_BUS_DV #(
                 input  ready, rvalid, rdata
                 );
 
+  // pragma translate_off
+`ifndef VERILATOR
+  assert property (@(posedge clk_i) (valid && !ready |=> $stable(addr)));
+  assert property (@(posedge clk_i) (valid && !ready |=> $stable(we)));
+  assert property (@(posedge clk_i) (valid && !ready |=> $stable(wdata)));
+  assert property (@(posedge clk_i) (valid && !ready |=> $stable(strb)));
+  assert property (@(posedge clk_i) (valid && !ready |=> valid));
+`endif
+  // pragma translate_on
+
 endinterface

--- a/hw/ip/spm_interface/src/spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/src/spm_rmw_adapter.sv
@@ -1,0 +1,225 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+module spm_rmw_adapter
+#(
+  parameter int unsigned AddrWidth = 0,
+  parameter int unsigned DataWidth = 0,
+  parameter int unsigned StrbWidth = AddrWidth / 8,
+
+  localparam type addr_t = logic [AddrWidth-1:0],
+  localparam type mem_data_t = logic [DataWidth-1:0],
+  localparam type mem_strb_t = logic [StrbWidth-1:0]
+) (
+   input logic  clk_i,
+   input logic  rst_ni,
+
+   // Request-side channel
+   input logic  mem_req_i,
+   output logic mem_gnt_o,
+   input        addr_t mem_addr_i,
+   input        mem_data_t mem_wdata_i,
+   input        mem_strb_t mem_strb_i,
+   input logic  mem_we_i,
+   output logic mem_rvalid_o,
+   output       mem_data_t mem_rdata_o,
+
+   // Mem-side channel
+   output logic mem_req_o,
+   input logic  mem_gnt_i,
+   output       addr_t mem_addr_o,
+   output       mem_data_t mem_wdata_o,
+   output       mem_strb_t mem_strb_o,
+   output logic mem_we_o,
+   input logic  mem_rvalid_i,
+   input        mem_data_t mem_rdata_i
+   );
+
+  typedef enum  {NORMAL, RMW_READ, RMW_MODIFY_WRITE, RMW_FINAL} state_t;
+
+  logic [DataWidth-1:0] mask_q, mask_d;
+  logic [DataWidth-1:0] masked_data_q, masked_data_d;
+
+  state_t req_state_q, req_state_d;
+
+  always_comb begin : mask_block
+    for (int i = 0; i < DataWidth; i++) begin
+      mask_d[i] = mem_strb_i[i/8];
+    end
+
+    masked_data_d = masked_data_q;
+    if (mem_rvalid_i && !(&mem_strb_i)) begin
+      masked_data_d = (mem_rdata_i & ~mask_q) | (mem_wdata_i & mask_q);
+    end
+
+  end
+
+  always_comb begin : next_state_block
+
+    req_state_d = req_state_q;
+
+    unique case (req_state_q)
+      NORMAL: begin
+        req_state_d = NORMAL;
+
+        // If partial memory access (read or write) is detected perform RMW_READ first
+        if (mem_req_i && !(&mem_strb_i)) begin
+          req_state_d = RMW_READ;
+        end
+      end
+
+      RMW_READ: begin
+
+        // Wait for full access read request to be granted
+        if (mem_gnt_i) begin
+          if (mem_we_i) begin
+            req_state_d = RMW_MODIFY_WRITE;
+          end else begin
+            req_state_d = RMW_FINAL;
+          end
+        end
+      end // case: RMW_READ
+
+      RMW_MODIFY_WRITE: begin
+        if (mem_gnt_i) begin
+          req_state_d = RMW_FINAL;
+        end
+      end
+
+      RMW_FINAL: begin
+        req_state_d = NORMAL;
+      end
+
+      default: begin
+        req_state_d = NORMAL;
+      end
+
+    endcase
+  end
+
+  always_comb begin : output_block
+
+    // Mem-side
+    mem_req_o = mem_req_i;
+    mem_addr_o = mem_addr_i;
+    mem_wdata_o = mem_wdata_i;
+    mem_strb_o = '1; // always perform full access
+    mem_we_o = mem_we_i;
+
+    // Request-side
+    mem_gnt_o = mem_gnt_i;
+    mem_rvalid_o = mem_rvalid_i;
+    mem_rdata_o = mem_rdata_i;
+
+    unique case (req_state_q)
+
+      NORMAL: begin
+
+        // If access is bitwise, generate RMW_READ request
+        if (mem_req_i && !(&mem_strb_i)) begin
+          // Mem-side
+          mem_req_o = 1'b1;
+          mem_addr_o = mem_addr_i;
+          mem_wdata_o = '0;
+          mem_strb_o = '1;
+          mem_we_o = '0;
+          // Request-side
+          mem_gnt_o = '0;
+          mem_rvalid_o = '0;
+          mem_rdata_o = '0;
+        end
+      end // case: NORMAL
+
+      RMW_READ: begin
+
+        // Wait and assert read request until granted
+        // Mem-side
+        mem_req_o = 1'b1;
+        mem_addr_o = mem_addr_i;
+        mem_wdata_o = '0;
+        // Request-side
+        mem_gnt_o = 1'b0;
+        mem_rvalid_o = 1'b0;
+        mem_rdata_o = '0;
+        mem_we_o = 1'b0;
+
+        // Once byte-wise read access is granted,
+        // (READ) grant original read request and send masked data next cycle
+        // (WRITE) wait for data arriving in the next cycle
+        if (!mem_we_i && mem_gnt_i) begin
+          mem_gnt_o = 1'b1;
+        end
+
+      end // case: RMW_READ
+
+      RMW_MODIFY_WRITE: begin
+
+        // Mem-side
+        mem_req_o = 1'b1;
+        mem_addr_o = mem_addr_i;
+        mem_wdata_o = '0;
+        mem_we_o = 1'b1;
+        // Request-side
+        mem_gnt_o = 1'b0;
+        mem_rvalid_o = 1'b0;
+        mem_rdata_o = '0;
+
+        // Data should have arrived, byte-wise modify read data
+        // and issue write request
+        if (mem_rvalid_i) begin
+          mem_wdata_o = (mem_rdata_i & ~mask_q) | (mem_wdata_i & mask_q);
+        end else begin
+          mem_wdata_o = masked_data_q;
+        end
+
+        // grant original request once write request is granted
+        if (mem_gnt_i) begin
+          mem_gnt_o = 1'b1;
+        end
+      end // case: RMW_MODIFY_WRITE
+
+      RMW_FINAL: begin
+
+        // Mem-side
+        mem_req_o = 1'b0;
+        mem_addr_o = '0;
+        mem_wdata_o = '0;
+        mem_we_o = 1'b0;
+        // Request-side
+        mem_gnt_o = 1'b0;
+        mem_rvalid_o = mem_rvalid_i;
+        mem_rdata_o = '0;
+
+        // (READ) forward masked data to original request
+        if (!mem_we_i && mem_rvalid_i) begin
+          mem_rdata_o = mem_rdata_i & mask_q;
+        end
+      end
+
+      default: ;
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      req_state_q <= NORMAL;
+      mask_q <= '0;
+      masked_data_q <= '0;
+    end else begin
+      req_state_q <= req_state_d;
+      mask_q <= mask_d;
+      masked_data_q <= masked_data_d;
+    end
+  end
+
+endmodule

--- a/hw/ip/spm_interface/src/spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/src/spm_rmw_adapter.sv
@@ -25,8 +25,8 @@ module spm_rmw_adapter
    input logic  rst_ni,
 
    // Request-side channel
-   input logic  mem_req_i,
-   output logic mem_gnt_o,
+   input logic  mem_valid_i,
+   output logic mem_ready_o,
    input        addr_t mem_addr_i,
    input        mem_data_t mem_wdata_i,
    input        mem_strb_t mem_strb_i,
@@ -35,8 +35,8 @@ module spm_rmw_adapter
    output       mem_data_t mem_rdata_o,
 
    // Mem-side channel
-   output logic mem_req_o,
-   input logic  mem_gnt_i,
+   output logic mem_valid_o,
+   input logic  mem_ready_i,
    output       addr_t mem_addr_o,
    output       mem_data_t mem_wdata_o,
    output       mem_strb_t mem_strb_o,
@@ -110,14 +110,14 @@ module spm_rmw_adapter
   always_comb begin : output_block
 
     // Mem-side
-    mem_req_o = mem_req_i;
+    mem_valid_o = mem_valid_i;
     mem_addr_o = mem_addr_i;
     mem_wdata_o = mem_wdata_i;
     mem_strb_o = '1; // always perform full access
     mem_we_o = mem_we_i;
 
     // Request-side
-    mem_gnt_o = mem_gnt_i;
+    mem_ready_o = mem_ready_i;
     mem_rvalid_o = mem_rvalid_i;
     mem_rdata_o = mem_rdata_i;
 

--- a/hw/ip/spm_interface/src/spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/src/spm_rmw_adapter.sv
@@ -1,15 +1,11 @@
 // Copyright 2020 ETH Zurich and University of Bologna.
-// Copyright and related rights are licensed under the Solderpad Hardware
-// License, Version 0.51 (the "License"); you may not use this file except in
-// compliance with the License. You may obtain a copy of the License at
-// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
-// or agreed to in writing, software, hardware and materials distributed under
-// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
 
 // Authors:
 // - Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
 
 module spm_rmw_adapter
 #(

--- a/hw/ip/spm_interface/src/spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/src/spm_rmw_adapter.sv
@@ -221,5 +221,9 @@ module spm_rmw_adapter
       masked_data_q <= masked_data_d;
     end
   end
+  `FF(req_state_q, req_state_d, state_e'('0))
+  `FF(mask_q, mask_d, '0)
+  `FF(masked_wdata_q, masked_wdata_d, '0)
+
 
 endmodule

--- a/hw/ip/spm_interface/src/spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/src/spm_rmw_adapter.sv
@@ -65,9 +65,10 @@ module spm_rmw_adapter
     req_state_d = req_state_q;
 
     unique case (req_state_q)
+
       NORMAL: begin
         // If partial memory access is detected perform RMW_READ
-        if (partial_write) begin
+        if (partial_write && mem_ready_i) begin
           req_state_d = RMW_READ;
         end
       end
@@ -109,7 +110,7 @@ module spm_rmw_adapter
       NORMAL: begin
 
         // If access is bitwise, generate RMW_READ request
-        if (partial_write) begin
+        if (partial_write && mem_ready_i) begin
           mem_we_o = '0;
         end
       end // case: NORMAL

--- a/hw/ip/spm_interface/src/spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/src/spm_rmw_adapter.sv
@@ -44,7 +44,8 @@ module spm_rmw_adapter
   typedef enum  {NORMAL, RMW_READ, RMW_MODIFY_WRITE} state_e;
 
   mem_data_t mask_q, mask_d;
-  mem_data_t masked_wdata_q, masked_wdata_d;
+  mem_data_t masked_wdata_q, masked_wdata_d, masked_data;
+  assign masked_data = (mem_wdata_i & mask_q) | (mem_rdata_i & ~mask_q);
 
   logic         partial_write;
   assign partial_write = mem_valid_i & mem_we_i & ~(&mem_strb_i);
@@ -56,7 +57,7 @@ module spm_rmw_adapter
       mask_d[i] = mem_strb_i[i/8];
     end
 
-    masked_wdata_d = (mem_rvalid_i)? (mem_wdata_i & mask_q) | (mem_rdata_i & ~mask_q) : masked_wdata_q;
+    masked_wdata_d = (mem_rvalid_i)? masked_data : masked_wdata_q;
   end
 
   always_comb begin

--- a/hw/ip/spm_interface/src/spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/src/spm_rmw_adapter.sv
@@ -9,13 +9,16 @@
 
 module spm_rmw_adapter
 #(
-  parameter int unsigned AddrWidth = 0,
-  parameter int unsigned DataWidth = 0,
-  parameter int unsigned StrbWidth = AddrWidth / 8,
+  parameter int unsigned  AddrWidth = 0,
+  parameter int unsigned  DataWidth = 0,
+  parameter int unsigned  StrbWidth = AddrWidth / 8,
+  parameter int unsigned  MaxTxns = 32'd3,
 
   localparam type addr_t = logic [AddrWidth-1:0],
   localparam type mem_data_t = logic [DataWidth-1:0],
-  localparam type mem_strb_t = logic [StrbWidth-1:0]
+  localparam type mem_strb_t = logic [StrbWidth-1:0],
+  localparam type cnt_t = logic [$clog2(MaxTxns)-1:0]
+
 ) (
    input logic  clk_i,
    input logic  rst_ni,
@@ -52,6 +55,21 @@ module spm_rmw_adapter
 
   state_e req_state_q, req_state_d;
 
+  cnt_t cnt_q, cnt_d;
+  logic         rmw_ready, txns_ready;
+  assign rmw_ready = (cnt_q == '0);
+  assign txns_ready = cnt_q < MaxTxns;
+
+  always_comb begin
+    cnt_d = cnt_q;
+    if (mem_valid_o && mem_ready_i) begin
+      cnt_d++;
+    end
+     if (mem_rvalid_i) begin
+       cnt_d--;
+     end
+  end
+
   always_comb begin
     for (int i = 0; i < DataWidth; i++) begin
       mask_d[i] = mem_strb_i[i/8];
@@ -68,7 +86,7 @@ module spm_rmw_adapter
 
       NORMAL: begin
         // If partial memory access is detected perform RMW_READ
-        if (partial_write && mem_ready_i) begin
+        if (partial_write && mem_ready_i && rmw_ready) begin
           req_state_d = RMW_READ;
         end
       end
@@ -94,14 +112,14 @@ module spm_rmw_adapter
   always_comb begin
 
     // Mem-side
-    mem_valid_o = mem_valid_i;
+    mem_valid_o = mem_valid_i && txns_ready;
     mem_addr_o = mem_addr_i;
     mem_wdata_o = mem_wdata_i;
     mem_strb_o = '1; // always perform full access
     mem_we_o = mem_we_i;
 
     // Request-side
-    mem_ready_o = mem_ready_i;
+    mem_ready_o = mem_ready_i && txns_ready && rmw_ready;
     mem_rvalid_o = mem_rvalid_i;
     mem_rdata_o = mem_rdata_i;
 
@@ -110,7 +128,7 @@ module spm_rmw_adapter
       NORMAL: begin
 
         // If access is bitwise, generate RMW_READ request
-        if (partial_write && mem_ready_i) begin
+        if (partial_write && mem_ready_i && rmw_ready) begin
           mem_we_o = '0;
         end
       end // case: NORMAL
@@ -120,6 +138,7 @@ module spm_rmw_adapter
         mem_rvalid_o = 1'b0;
         mem_rdata_o = '0;
         mem_we_o = 1'b0;
+        mem_ready_o = 1'b0;
 
         if (mem_rvalid_i) begin
           mem_valid_o = 1'b1;
@@ -131,8 +150,16 @@ module spm_rmw_adapter
 
       RMW_MODIFY_WRITE: begin
 
+        mem_rvalid_o = 1'b0;
+        mem_ready_o = 1'b0;
+
+        mem_valid_o = 1'b1;
         mem_wdata_o = masked_wdata_q;
-        mem_we_o = 1'b1;
+
+        if (mem_rvalid_i) begin
+          mem_valid_o = 1'b0;
+          mem_rvalid_o = 1'b1;
+        end
 
       end // case: RMW_MODIFY_WRITE
 
@@ -143,6 +170,6 @@ module spm_rmw_adapter
   `FF(req_state_q, req_state_d, state_e'('0))
   `FF(mask_q, mask_d, '0)
   `FF(masked_wdata_q, masked_wdata_d, '0)
-
+  `FF(cnt_q, cnt_d, '0)
 
 endmodule

--- a/hw/ip/spm_interface/src/spm_test.sv
+++ b/hw/ip/spm_interface/src/spm_test.sv
@@ -87,7 +87,7 @@ package spm_test;
     /// Send a request.
     task send_req (input req_t req);
       bus.addr    <= #TA req.addr;
-      bus.we      <= #TA 1;
+      bus.we      <= #TA req.we;
       bus.wdata   <= #TA req.wdata;
       bus.strb    <= #TA req.strb;
       bus.valid   <= #TA 1;
@@ -99,7 +99,7 @@ package spm_test;
       while (bus.rvalid != 1) begin cycle_end(); cycle_start(); end
       cycle_end();
       bus.addr    <= #TA '0;
-      bus.we      <= #TA 0;
+      bus.we      <= #TA '0;
       bus.wdata   <= #TA '0;
       bus.strb    <= #TA '0;
 
@@ -214,6 +214,7 @@ package spm_test;
       repeat (n) begin
         automatic spm_driver_t::req_t r = new;
         assert(r.randomize());
+        r.we = (r.strb != '1)? 1'b1 : r.we;
         rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
         this.drv.send_req(r);
       end

--- a/hw/ip/spm_interface/src/spm_test.sv
+++ b/hw/ip/spm_interface/src/spm_test.sv
@@ -1,0 +1,338 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+/// A set of testbench utlities for the SPM interface.
+package spm_test;
+
+  class req_t #(
+    parameter int AW = 32,
+    parameter int DW = 32
+  );
+    rand logic [AW-1:0]       addr;
+    rand logic                we;
+    rand logic [DW-1:0]       wdata;
+    rand logic [DW/8-1:0]     strb;
+
+    /// Compare objects of same type.
+    function do_compare(req_t rhs);
+      return addr == rhs.addr &
+             we == rhs.we &
+             wdata == rhs.wdata &
+             strb == rhs.strb;
+    endfunction
+
+  endclass
+
+  class rsp_t #(
+    parameter int DW = 32
+  );
+    rand logic [DW-1:0]   rdata;
+
+    /// Compare objects of same type.
+    function do_compare(rsp_t rhs);
+      return rdata == rhs.rdata;
+    endfunction
+
+  endclass
+
+  class spm_driver #(
+    parameter int  AW = -1,
+    parameter int  DW = -1,
+    /// Stimuli application time
+    parameter time TA = 0,
+    /// Stimuli test time
+    parameter time TT = 0
+  );
+
+    typedef req_t #(.AW(AW), .DW(DW)) req_t;
+    typedef rsp_t #(.DW(DW)) rsp_t;
+
+    virtual SPM_BUS_DV #(
+      .ADDR_WIDTH(AW),
+      .DATA_WIDTH(DW)
+    ) bus;
+
+    function new(
+      virtual SPM_BUS_DV #(
+        .ADDR_WIDTH(AW),
+        .DATA_WIDTH(DW)
+      ) bus
+    );
+      this.bus = bus;
+    endfunction
+
+    task reset_master;
+      bus.addr    <= '0;
+      bus.we      <= '0;
+      bus.wdata   <= '0;
+      bus.strb    <= '0;
+      bus.req     <= '0;
+    endtask
+
+    task reset_slave;
+      bus.gnt     <= '0;
+      bus.rvalid  <= '0;
+      bus.rdata  <= '0;
+    endtask
+
+    task cycle_start;
+      #TT;
+    endtask
+
+    task cycle_end;
+      @(posedge bus.clk_i);
+    endtask
+
+    /// Send a request.
+    task send_req (input req_t req);
+      bus.addr    <= #TA req.addr;
+      bus.we      <= #TA req.we;
+      bus.wdata   <= #TA req.wdata;
+      bus.strb    <= #TA req.strb;
+      bus.req     <= #TA 1;
+      cycle_start();
+      while (bus.gnt != 1) begin cycle_end(); cycle_start(); end
+      cycle_end();
+      bus.addr    <= #TA '0;
+      bus.we      <= #TA '0;
+      bus.wdata   <= #TA '0;
+      bus.strb    <= #TA '0;
+      bus.req     <= #TA 0;
+    endtask
+
+    /// Send a response.
+    task send_rsp (input rsp_t rsp);
+      bus.rdata   <= #TA rsp.rdata;
+      bus.rvalid  <= #TA 1;
+      cycle_start();
+      cycle_end();
+      bus.rdata   <= #TA '0;
+      bus.rvalid  <= #TA 0;
+    endtask
+
+    /// Receive a request.
+    task recv_req (output req_t req);
+      bus.gnt     <= #TA 1'b0;
+      cycle_start();
+      while (bus.req != 1) begin cycle_end(); cycle_start(); end
+      cycle_end();
+      req = new;
+      req.addr   = bus.addr;
+      req.we     = bus.we;
+      req.wdata  = bus.wdata;
+      req.strb   = bus.strb;
+      bus.gnt    <= #TA 1'b1;
+      cycle_end();
+    endtask
+
+    /// Receive a response.
+    task recv_rsp (output rsp_t rsp);
+      cycle_start();
+      rsp = new;
+      rsp.rdata  = bus.rdata;
+      cycle_end();
+    endtask
+
+    // /// Monitor request.
+    // task mon_req (output req_t req);
+    //   cycle_start();
+    //   while (!(bus.q_valid && bus.q_ready)) begin cycle_end(); cycle_start(); end
+    //   req = new;
+    //   req.addr  = bus.q_addr;
+    //   req.write = bus.q_write;
+    //   req.amo   = bus.q_amo;
+    //   req.data  = bus.q_data;
+    //   req.strb  = bus.q_strb;
+    //   req.user  = bus.q_user;
+    //   cycle_end();
+    // endtask
+
+    // /// Monitor response.
+    // task mon_rsp (output rsp_t rsp);
+    //   cycle_start();
+    //   rsp = new;
+    //   rsp.data  = bus.p_data;
+    //   cycle_end();
+    // endtask
+
+  endclass
+
+// Super classs for random spm drivers.
+  virtual class rand_spm #(
+    // spm interface parameters
+    parameter int   AW = 32,
+    parameter int   DW = 32,
+    // Stimuli application and test time
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps
+  );
+
+    typedef spm_test::spm_driver #(
+      // spm bus interface paramaters;
+      .AW ( AW ),
+      .DW ( DW ),
+      // Stimuli application and test time
+      .TA ( TA ),
+      .TT ( TT )
+    ) spm_driver_t;
+
+    spm_driver_t drv;
+
+    typedef spm_driver_t::req_t req_t;
+    typedef spm_driver_t::rsp_t rsp_t;
+
+    function new(virtual SPM_BUS_DV #(
+      .ADDR_WIDTH (AW),
+      .DATA_WIDTH (DW)
+    ) bus);
+      this.drv = new (bus);
+    endfunction
+
+    task automatic rand_wait(input int unsigned min, input int unsigned max);
+      int unsigned rand_success, cycles;
+      rand_success = std::randomize(cycles) with {
+        cycles >= min;
+        cycles <= max;
+        // Weigh the distribution so that the minimum cycle time is the common
+        // case.
+        cycles dist {min := 10, [min:max] := 1};
+      };
+      assert (rand_success) else $error("Failed to randomize wait cycles!");
+      repeat (cycles) @(posedge this.drv.bus.clk_i);
+    endtask
+
+  endclass
+
+  /// Generate random requests as a master device.
+  class rand_spm_master #(
+    // spm interface parameters
+    parameter int   AW = 32,
+    parameter int   DW = 32,
+    // Stimuli application and test time
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps,
+    parameter int unsigned REQ_MIN_WAIT_CYCLES = 1,
+    parameter int unsigned REQ_MAX_WAIT_CYCLES = 20
+  ) extends rand_spm #(.AW(AW), .DW(DW), .TA(TA), .TT(TT));
+
+    /// Reset the driver.
+    task reset();
+      drv.reset_master();
+    endtask
+
+    /// Constructor.
+    function new(virtual SPM_BUS_DV #(
+      .ADDR_WIDTH (AW),
+      .DATA_WIDTH (DW)
+    ) bus);
+      super.new(bus);
+    endfunction
+
+    task run(input int n);
+      repeat (n) begin
+        automatic spm_driver_t::req_t r = new;
+        assert(r.randomize());
+        rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
+        this.drv.send_req(r);
+      end
+    endtask
+  endclass
+
+  class rand_spm_slave #(
+    // spm interface parameters
+    parameter int   AW = 32,
+    parameter int   DW = 32,
+    parameter int unsigned RespLatency = 1,
+    // Stimuli application and test time
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps,
+    parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,
+    parameter int unsigned REQ_MAX_WAIT_CYCLES = 10
+  ) extends rand_spm #(.AW(AW), .DW(DW), .TA(TA), .TT(TT));
+
+    mailbox req_mbx = new();
+
+    /// Reset the driver.
+    task reset();
+      drv.reset_slave();
+    endtask
+
+    task run();
+      fork
+        recv_requests();
+        send_responses();
+      join
+    endtask
+
+    /// Constructor.
+    function new(virtual SPM_BUS_DV #(
+      .ADDR_WIDTH (AW),
+      .DATA_WIDTH (DW)
+    ) bus);
+      super.new(bus);
+    endfunction
+
+    task recv_requests();
+      forever begin
+        automatic spm_driver_t::req_t req;
+        rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
+        this.drv.recv_req(req);
+        req_mbx.put(req);
+      end
+    endtask
+
+    task send_responses();
+      automatic spm_driver_t::rsp_t rsp = new;
+      automatic spm_driver_t::req_t req;
+      forever begin
+        req_mbx.get(req);
+        assert(rsp.randomize());
+        repeat (RespLatency-1) @(posedge this.drv.bus.clk_i);
+        this.drv.send_rsp(rsp);
+      end
+    endtask
+  endclass
+
+  // class spm_monitor #(
+  //   // spm interface parameters
+  //   parameter int   AW = 32,
+  //   parameter int   DW = 32,
+  //   parameter type  user_t = logic,
+  //   parameter int unsigned RespLatency = 1,
+  //   // Stimuli application and test time
+  //   parameter time  TA = 0ps,
+  //   parameter time  TT = 0ps
+  // ) extends rand_mem #(.AW(AW), .DW(DW), .user_t (user_t), .TA(TA), .TT(TT));
+
+  //   mailbox req_mbx = new, rsp_mbx = new;
+  //   typedef mem_driver_t::req_t req_t;
+  //   typedef mem_driver_t::rsp_t rsp_t;
+
+  //   /// Constructor.
+  //   function new(virtual MEM_BUS_DV #(
+  //     .ADDR_WIDTH (AW),
+  //     .DATA_WIDTH (DW),
+  //     .user_t (user_t)
+  //   ) bus);
+  //     super.new(bus);
+  //   endfunction
+
+  //   // mem Monitor.
+  //   task monitor;
+  //     forever begin
+  //       automatic mem_driver_t::req_t req;
+  //       this.drv.mon_req(req);
+  //       req_mbx.put(req);
+  //       fork
+  //         begin
+  //           automatic mem_driver_t::rsp_t rsp;
+  //           repeat (RespLatency-1) @(posedge this.drv.bus.clk_i);
+  //           this.drv.mon_rsp(rsp);
+  //           rsp_mbx.put(rsp);
+  //         end
+  //       join_none
+  //     end
+  //   endtask
+  // endclass
+endpackage

--- a/hw/ip/spm_interface/src/spm_test.sv
+++ b/hw/ip/spm_interface/src/spm_test.sv
@@ -95,9 +95,6 @@ package spm_test;
       while (bus.ready != 1) begin cycle_end(); cycle_start(); end
       cycle_end();
       bus.valid   <= #TA 0;
-      cycle_start();
-      while (bus.rvalid != 1) begin cycle_end(); cycle_start(); end
-      cycle_end();
       bus.addr    <= #TA '0;
       bus.we      <= #TA '0;
       bus.wdata   <= #TA '0;
@@ -234,6 +231,7 @@ package spm_test;
   ) extends rand_spm #(.AW(AW), .DW(DW), .TA(TA), .TT(TT));
 
     mailbox req_mbx = new();
+
 
     /// Reset the driver.
     task reset();

--- a/hw/ip/spm_interface/src/spm_test.sv
+++ b/hw/ip/spm_interface/src/spm_test.sv
@@ -67,13 +67,13 @@ package spm_test;
       bus.we      <= '0;
       bus.wdata   <= '0;
       bus.strb    <= '0;
-      bus.req     <= '0;
+      bus.valid   <= '0;
     endtask
 
     task reset_slave;
-      bus.gnt     <= '0;
+      bus.ready   <= '0;
       bus.rvalid  <= '0;
-      bus.rdata  <= '0;
+      bus.rdata   <= '0;
     endtask
 
     task cycle_start;
@@ -113,7 +113,7 @@ package spm_test;
 
     /// Receive a request.
     task recv_req (output req_t req);
-      bus.gnt     <= #TA 1'b0;
+      bus.ready   <= #TA 1'b1;
       cycle_start();
       while (bus.req != 1) begin cycle_end(); cycle_start(); end
       cycle_end();

--- a/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
@@ -74,7 +74,8 @@ module tb_spm_rmw_adapter
 
     spm_rand_master.reset();
     repeat(20) @(posedge clk);
-    spm_rand_master.run(4);
+    spm_rand_master.run(1);
+
 
   end // initial begin
 

--- a/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
@@ -64,8 +64,6 @@ module tb_spm_rmw_adapter
       .AW ( AddrWidth ),
       .DW ( DataWidth ),
       // Right now this module needs an immediate valid response.
-      .REQ_MIN_WAIT_CYCLES (0),
-      .REQ_MAX_WAIT_CYCLES (0),
       .TA ( ApplTime ),
       .TT ( TestTime )
       ) spm_rand_slave = new(spm_bus_slave_dv);
@@ -74,7 +72,7 @@ module tb_spm_rmw_adapter
 
     spm_rand_master.reset();
     repeat(20) @(posedge clk);
-    spm_rand_master.run(1);
+    spm_rand_master.run(10);
 
 
   end // initial begin

--- a/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
@@ -74,7 +74,7 @@ module tb_spm_rmw_adapter
 
     spm_rand_master.reset();
     repeat(20) @(posedge clk);
-    spm_rand_master.run(10);
+    spm_rand_master.run(5);
 
 
   end // initial begin

--- a/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
@@ -45,6 +45,8 @@ module tb_spm_rmw_adapter
                .DATA_WIDTH ( DataWidth )
                ) spm_bus_slave_dv ( clk );
 
+  assign spm_bus_slave.strb = '1;
+
   `SPM_ASSIGN(spm_bus_master, spm_bus_master_dv)
   `SPM_ASSIGN(spm_bus_slave_dv, spm_bus_slave)
 
@@ -112,7 +114,6 @@ module tb_spm_rmw_adapter
        .mem_ready_i(spm_bus_slave.ready),
        .mem_addr_o(spm_bus_slave.addr),
        .mem_wdata_o(spm_bus_slave.wdata),
-       .mem_strb_o(spm_bus_slave.strb),
        .mem_we_o(spm_bus_slave.we),
        .mem_rvalid_i(spm_bus_slave.rvalid),
        .mem_rdata_i(spm_bus_slave.rdata)

--- a/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
@@ -1,3 +1,10 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+// - Tim Fischer <fischeti@iis.ee.ethz.ch>
+
 `include "spm_interface/assign.svh"
 
 module tb_spm_rmw_adapter

--- a/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
@@ -1,0 +1,134 @@
+`include "spm_interface/assign.svh"
+
+module tb_spm_rmw_adapter
+  #(
+    parameter int unsigned AddrWidth = 32,
+    parameter int unsigned DataWidth = 32,
+    parameter int unsigned StrbWidth = AddrWidth / 8,
+
+    localparam type addr_t = logic [AddrWidth-1:0],
+    localparam type data_t = logic [DataWidth-1:0],
+    localparam type strb_t = logic [StrbWidth-1:0]
+    );
+
+
+  localparam time          ClkPeriod = 10ns;
+  localparam time          ApplTime =  0ns;
+  localparam time          TestTime =  10ns;
+
+  logic                  clk, rst_n;
+
+  SPM_BUS #(
+            .ADDR_WIDTH ( AddrWidth ),
+            .DATA_WIDTH ( DataWidth )
+            ) spm_bus_master ();
+
+  SPM_BUS_DV #(
+               .ADDR_WIDTH ( AddrWidth ),
+               .DATA_WIDTH ( DataWidth )
+               ) spm_bus_master_dv (clk);
+
+  SPM_BUS #(
+            .ADDR_WIDTH ( AddrWidth ),
+            .DATA_WIDTH ( DataWidth )
+            ) spm_bus_slave ();
+
+  SPM_BUS_DV #(
+               .ADDR_WIDTH ( AddrWidth ),
+               .DATA_WIDTH ( DataWidth )
+               ) spm_bus_slave_dv ( clk );
+
+  `SPM_ASSIGN(spm_bus_master, spm_bus_master_dv)
+  `SPM_ASSIGN(spm_bus_slave_dv, spm_bus_slave)
+
+  // ------
+  // Driver
+  // ------
+  spm_test::rand_spm_master
+    #(
+      .AW ( AddrWidth ),
+      .DW ( DataWidth ),
+      .TA ( ApplTime ),
+      .TT ( TestTime )
+      ) spm_rand_master = new(spm_bus_master_dv);
+
+  spm_test::rand_spm_slave
+    #(
+      .AW ( AddrWidth ),
+      .DW ( DataWidth ),
+      // Right now this module needs an immediate valid response.
+      .REQ_MIN_WAIT_CYCLES (0),
+      .REQ_MAX_WAIT_CYCLES (0),
+      .TA ( ApplTime ),
+      .TT ( TestTime )
+      ) spm_rand_slave = new(spm_bus_slave_dv);
+
+  initial begin
+
+    spm_rand_master.reset();
+    repeat(20) @(posedge clk);
+    spm_rand_master.run(4);
+
+  end // initial begin
+
+  initial begin
+
+    spm_rand_slave.reset();
+    repeat(20) @(posedge clk);
+    spm_rand_slave.run();
+
+  end // initial begin
+
+  // ----------
+  // DUT
+  // ----------
+
+  spm_rmw_adapter
+    #(
+      .AddrWidth(AddrWidth),
+      .DataWidth(DataWidth),
+      .StrbWidth(StrbWidth)
+      ) dut_i
+      (
+       .clk_i(clk),
+       .rst_ni(rst_n),
+
+       .mem_req_i(spm_bus_master.req),
+       .mem_gnt_o(spm_bus_master.gnt),
+       .mem_addr_i(spm_bus_master.addr),
+       .mem_wdata_i(spm_bus_master.wdata),
+       .mem_strb_i(spm_bus_master.strb),
+       .mem_we_i(spm_bus_master.we),
+       .mem_rvalid_o(spm_bus_master.rvalid),
+       .mem_rdata_o(spm_bus_master.rdata),
+
+       .mem_req_o(spm_bus_slave.req),
+       .mem_gnt_i(spm_bus_slave.gnt),
+       .mem_addr_o(spm_bus_slave.addr),
+       .mem_wdata_o(spm_bus_slave.wdata),
+       .mem_strb_o(spm_bus_slave.strb),
+       .mem_we_o(spm_bus_slave.we),
+       .mem_rvalid_i(spm_bus_slave.rvalid),
+       .mem_rdata_i(spm_bus_slave.rdata)
+       );
+
+
+  // ----------------
+  // Clock generation
+  // ----------------
+  initial begin
+    rst_n = 0;
+    repeat (5) begin
+      #(ClkPeriod/2) clk = 0;
+      #(ClkPeriod/2) clk = 1;
+    end
+    rst_n = 1;
+    forever begin
+      #(ClkPeriod/2) clk = 0;
+      #(ClkPeriod/2) clk = 1;
+    end
+  end
+
+
+
+endmodule

--- a/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
+++ b/hw/ip/spm_interface/test/tb_spm_rmw_adapter.sv
@@ -93,8 +93,8 @@ module tb_spm_rmw_adapter
        .clk_i(clk),
        .rst_ni(rst_n),
 
-       .mem_req_i(spm_bus_master.req),
-       .mem_gnt_o(spm_bus_master.gnt),
+       .mem_valid_i(spm_bus_master.valid),
+       .mem_ready_o(spm_bus_master.ready),
        .mem_addr_i(spm_bus_master.addr),
        .mem_wdata_i(spm_bus_master.wdata),
        .mem_strb_i(spm_bus_master.strb),
@@ -102,8 +102,8 @@ module tb_spm_rmw_adapter
        .mem_rvalid_o(spm_bus_master.rvalid),
        .mem_rdata_o(spm_bus_master.rdata),
 
-       .mem_req_o(spm_bus_slave.req),
-       .mem_gnt_i(spm_bus_slave.gnt),
+       .mem_valid_o(spm_bus_slave.valid),
+       .mem_ready_i(spm_bus_slave.ready),
        .mem_addr_o(spm_bus_slave.addr),
        .mem_wdata_o(spm_bus_slave.wdata),
        .mem_strb_o(spm_bus_slave.strb),


### PR DESCRIPTION
Read-modify-write adapter for byte-wise read and write accesses which addresses #152 . For byte-wise read accesses, the adapter just returns the masked data. For byte-wise write accesses, the adapter stalls the original request while performing a full-width read access followed by a masked modify and full-width write

The input and of the module consist of the following signals (the output signals are mirrored)
```sv 
   // Request-side channel
   input logic  mem_req_i,
   output logic mem_gnt_o,
   input        addr_t mem_addr_i,
   input        data_t mem_wdata_i,
   input        strb_t mem_strb_i,
   input logic  mem_we_i,
   output logic mem_rvalid_o,
   output       data_t mem_rdata_o
```

The protocol currently takes the following assumptions:
1. A valid handshake occurs when `req` and `gnt` are high. 
2. The data is read/written one cycle after a valid handshake and the `rvalid` signal is high for both read/write requests
3. A `gnt` is raised at the earliest one cycle after the `req` is raised

Open questions:
- Are the protocol assumptions correct? 
- Naming and location etc.: the module currently has its own folder `ip/spm_interface`. Could probably be placed somewhere else and maybe named differently. The interface is currently only used for testing purposes
- Which license header to use?
