### PR TITLE
Occamy: Increase cacheline size to 256 bit

### DIFF
--- a/hw/system/occamy/src/memories.json
+++ b/hw/system/occamy/src/memories.json
@@ -17,19 +17,6 @@
         "byte_width": 8,
         "density_optimized": false,
         "description": [
-            "icache data (hive 0)"
-        ],
-        "latency": 1,
-        "ports": 1,
-        "speed_optimized": true,
-        "width": 128,
-        "words": 256
-    },
-    {
-        "byte_enable": true,
-        "byte_width": 8,
-        "density_optimized": false,
-        "description": [
             "cva6 instruction cache tag"
         ],
         "latency": 1,
@@ -62,7 +49,7 @@
         "ports": 1,
         "speed_optimized": true,
         "width": 39,
-        "words": 256
+        "words": 128
     },
     {
         "byte_enable": true,
@@ -89,5 +76,18 @@
         "speed_optimized": true,
         "width": 44,
         "words": 256
+    },
+    {
+        "byte_enable": true,
+        "byte_width": 8,
+        "density_optimized": false,
+        "description": [
+            "icache data (hive 0)"
+        ],
+        "latency": 1,
+        "ports": 1,
+        "speed_optimized": true,
+        "width": 256,
+        "words": 128
     }
 ]

--- a/hw/system/occamy/src/occamy_cfg.hjson
+++ b/hw/system/occamy/src/occamy_cfg.hjson
@@ -61,7 +61,7 @@
                 icache: {
                     size: 8, // total instruction cache size in kByte
                     sets: 2, // number of ways
-                    cacheline: 128 // word size in bits
+                    cacheline: 256 // word size in bits
                 },
                 cores: [
                     { $ref: "#/compute_core_template" },

--- a/hw/system/occamy/src/occamy_cluster_wrapper.sv
+++ b/hw/system/occamy/src/occamy_cluster_wrapper.sv
@@ -34,10 +34,10 @@ package occamy_cluster_pkg;
   localparam int unsigned UserWidth = 1;
 
   localparam int unsigned ICacheLineWidth [NrHives] = '{
-    128
+    256
 };
   localparam int unsigned ICacheLineCount [NrHives] = '{
-    256
+    128
 };
   localparam int unsigned ICacheSets [NrHives] = '{
     2


### PR DESCRIPTION
FPU utilization is limited by instruction cache misses in some cases. Increasing the cacheline from 128bit to 256bit mitigates this issues to some extent.