### PR TITLE
ssr: Fix register interface to maximum of 4 loops

### DIFF
--- a/hw/ip/snitch_ssr/src/snitch_ssr_addr_gen.sv
+++ b/hw/ip/snitch_ssr/src/snitch_ssr_addr_gen.sv
@@ -15,7 +15,6 @@ module snitch_ssr_addr_gen import snitch_ssr_pkg::*; #(
   parameter type tcdm_rsp_t   = logic,
   parameter type tcdm_user_t  = logic,
   /// Derived parameters *Do not override*
-  parameter int unsigned DimWidth     = $clog2(Cfg.NumLoops),
   parameter int unsigned BytecntWidth = $clog2(DataWidth/8),
   parameter type addr_t     = logic [AddrWidth-1:0],
   parameter type data_t     = logic [DataWidth-1:0],
@@ -61,8 +60,8 @@ module snitch_ssr_addr_gen import snitch_ssr_pkg::*; #(
     logic idx_shift;
     logic idx_base;
     logic idx_size;
-    logic [Cfg.NumLoops-1:0] stride;
-    logic [Cfg.NumLoops-1:0] bound;
+    logic [3:0] stride;
+    logic [3:0] bound;
     logic rep;
     logic status;
   } write_strobe_t;
@@ -73,7 +72,7 @@ module snitch_ssr_addr_gen import snitch_ssr_pkg::*; #(
   typedef struct packed {
     logic done;
     logic write;
-    logic [DimWidth-1:0] dims;
+    logic [1:0] dims;
     logic indir;
   } config_t;
   config_t config_q, config_qn, config_sd, config_sq, config_sqn;
@@ -81,7 +80,7 @@ module snitch_ssr_addr_gen import snitch_ssr_pkg::*; #(
   typedef struct packed {
     logic no_indir;       // Inverted as aliases aligned at upper address edge
     logic write;
-    logic [DimWidth-1:0] dims;
+    logic [1:0] dims;
   } alias_fields_t;
 
   alias_fields_t alias_fields;
@@ -366,8 +365,8 @@ module snitch_ssr_addr_gen import snitch_ssr_pkg::*; #(
 
   typedef struct packed {
     indir_read_map_t indir_read_map;
-    logic [Cfg.NumLoops-1:0][31:0] stride;
-    logic [Cfg.NumLoops-1:0][31:0] bound;
+    logic [3:0][31:0] stride;
+    logic [3:0][31:0] bound;
     logic [31:0] rep;
     logic [31:0] status;
   } read_map_t;
@@ -380,6 +379,8 @@ module snitch_ssr_addr_gen import snitch_ssr_pkg::*; #(
     read_map.status = pointer_q;
     read_map.status[31-:$bits(config_q)] = config_q;
     read_map.rep = rep_q;
+    read_map.bound = '0;
+    read_map.stride = '0;
     for (int i = 0; i < Cfg.NumLoops; i++) begin
       read_map.bound[i] = bound_q[i];
       read_map.stride[i] = stride_q[i];


### PR DESCRIPTION
This change fixes the register layout for iteration loops in the SSR configuration interface to 4 loops, even if less loops are instantiated; this ensures a consistent configuration layout no matter the parameterization.

The hardware itself remains parameterizable in the same way as before.