### PR TITLE
banshee: Modify `num_sleep` only by the hart that enters/leaves wfi

### DIFF
--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -717,7 +717,12 @@ impl<'a, 'b> Cpu<'a, 'b> {
         let hartid = self.hartid - self.engine.base_hartid;
         while self.wake_up[hartid].load(Ordering::Relaxed) == 0 {
             // Check if everyone is sleeping
-            if self.num_sleep.load(Ordering::Relaxed) == self.wake_up.len() {
+            if self.num_sleep.load(Ordering::Relaxed) == self.wake_up.len()
+                && self
+                    .wake_up
+                    .into_iter()
+                    .all(|x| x.load(Ordering::Relaxed) == 0)
+            {
                 return 1;
             }
             std::thread::yield_now();


### PR DESCRIPTION
I suggest changing the `num_sleep` member only when entering/leaving the sleep state. The current implementation can cause underflow in `num_sleep` if a core is woken that is not at `wfi` resulting in `banshee` not exiting although all harts are sleeping. This also better reflects the hardware's behavior