### PR TITLE
occamy: Add isolation signals to S1 quadrants

### DIFF
--- a/hw/system/occamy/src/occamy_quadrant_s1.sv
+++ b/hw/system/occamy/src/occamy_quadrant_s1.sv
@@ -20,6 +20,8 @@ module occamy_quadrant_s1
     input  logic                     [NrCoresS1Quadrant-1:0] meip_i,
     input  logic                     [NrCoresS1Quadrant-1:0] mtip_i,
     input  logic                     [NrCoresS1Quadrant-1:0] msip_i,
+    input  logic                     [                  3:0] isolate_i,
+    output logic                     [                  3:0] isolated_o,
     // HBI Connection
     output axi_a48_d512_i6_u0_req_t                          quadrant_hbi_out_req_o,
     input  axi_a48_d512_i6_u0_resp_t                         quadrant_hbi_out_rsp_i,
@@ -143,6 +145,23 @@ module occamy_quadrant_s1
   axi_a48_d64_i8_u0_req_t  narrow_cluster_in_iwc_req;
   axi_a48_d64_i8_u0_resp_t narrow_cluster_in_iwc_rsp;
 
+  axi_a48_d64_i8_u0_req_t  narrow_cluster_in_isolate_req;
+  axi_a48_d64_i8_u0_resp_t narrow_cluster_in_isolate_rsp;
+
+  axi_isolate #(
+      .NumPending(128),
+      .req_t(axi_a48_d64_i8_u0_req_t),
+      .resp_t(axi_a48_d64_i8_u0_resp_t)
+  ) i_narrow_cluster_in_isolate (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(narrow_cluster_in_iwc_req),
+      .slv_resp_o(narrow_cluster_in_iwc_rsp),
+      .mst_req_o(narrow_cluster_in_isolate_req),
+      .mst_resp_i(narrow_cluster_in_isolate_rsp),
+      .isolate_i(isolate_i[0]),
+      .isolated_o(isolated_o[0])
+  );
   axi_id_remap #(
       .AxiSlvPortIdWidth(8),
       .AxiSlvPortMaxUniqIds(4),
@@ -155,8 +174,8 @@ module occamy_quadrant_s1
   ) i_narrow_cluster_in_iwc (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(narrow_cluster_in_iwc_req),
-      .slv_resp_o(narrow_cluster_in_iwc_rsp),
+      .slv_req_i(narrow_cluster_in_isolate_req),
+      .slv_resp_o(narrow_cluster_in_isolate_rsp),
       .mst_req_o(narrow_xbar_quadrant_s1_in_req[NARROW_XBAR_QUADRANT_S1_IN_TOP]),
       .mst_resp_i(narrow_xbar_quadrant_s1_in_rsp[NARROW_XBAR_QUADRANT_S1_IN_TOP])
   );
@@ -187,10 +206,27 @@ module occamy_quadrant_s1
       .mst_req_o(narrow_cluster_out_iwc_req),
       .mst_resp_i(narrow_cluster_out_iwc_rsp)
   );
+  axi_a48_d64_i4_u0_req_t  narrow_cluster_out_isolate_req;
+  axi_a48_d64_i4_u0_resp_t narrow_cluster_out_isolate_rsp;
+
+  axi_isolate #(
+      .NumPending(128),
+      .req_t(axi_a48_d64_i4_u0_req_t),
+      .resp_t(axi_a48_d64_i4_u0_resp_t)
+  ) i_narrow_cluster_out_isolate (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(narrow_cluster_out_iwc_req),
+      .slv_resp_o(narrow_cluster_out_iwc_rsp),
+      .mst_req_o(narrow_cluster_out_isolate_req),
+      .mst_resp_i(narrow_cluster_out_isolate_rsp),
+      .isolate_i(isolate_i[1]),
+      .isolated_o(isolated_o[1])
+  );
 
 
-  assign quadrant_narrow_out_req_o  = narrow_cluster_out_iwc_req;
-  assign narrow_cluster_out_iwc_rsp = quadrant_narrow_out_rsp_i;
+  assign quadrant_narrow_out_req_o = narrow_cluster_out_isolate_req;
+  assign narrow_cluster_out_isolate_rsp = quadrant_narrow_out_rsp_i;
 
   ////////////////////////////////////////////
   // Wide Out + Const Cache + IW Converter  //
@@ -218,10 +254,27 @@ module occamy_quadrant_s1
       .mst_req_o(wide_cluster_out_iwc_req),
       .mst_resp_i(wide_cluster_out_iwc_rsp)
   );
+  axi_a48_d512_i3_u0_req_t  wide_cluster_out_isolate_req;
+  axi_a48_d512_i3_u0_resp_t wide_cluster_out_isolate_rsp;
+
+  axi_isolate #(
+      .NumPending(128),
+      .req_t(axi_a48_d512_i3_u0_req_t),
+      .resp_t(axi_a48_d512_i3_u0_resp_t)
+  ) i_wide_cluster_out_isolate (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(wide_cluster_out_iwc_req),
+      .slv_resp_o(wide_cluster_out_iwc_rsp),
+      .mst_req_o(wide_cluster_out_isolate_req),
+      .mst_resp_i(wide_cluster_out_isolate_rsp),
+      .isolate_i(isolate_i[3]),
+      .isolated_o(isolated_o[3])
+  );
 
 
-  assign quadrant_wide_out_req_o  = wide_cluster_out_iwc_req;
-  assign wide_cluster_out_iwc_rsp = quadrant_wide_out_rsp_i;
+  assign quadrant_wide_out_req_o = wide_cluster_out_isolate_req;
+  assign wide_cluster_out_isolate_rsp = quadrant_wide_out_rsp_i;
 
   ////////////////////
   // HBI Connection //
@@ -257,6 +310,23 @@ module occamy_quadrant_s1
   axi_a48_d512_i8_u0_req_t  wide_cluster_in_iwc_req;
   axi_a48_d512_i8_u0_resp_t wide_cluster_in_iwc_rsp;
 
+  axi_a48_d512_i8_u0_req_t  wide_cluster_in_isolate_req;
+  axi_a48_d512_i8_u0_resp_t wide_cluster_in_isolate_rsp;
+
+  axi_isolate #(
+      .NumPending(128),
+      .req_t(axi_a48_d512_i8_u0_req_t),
+      .resp_t(axi_a48_d512_i8_u0_resp_t)
+  ) i_wide_cluster_in_isolate (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(wide_cluster_in_iwc_req),
+      .slv_resp_o(wide_cluster_in_iwc_rsp),
+      .mst_req_o(wide_cluster_in_isolate_req),
+      .mst_resp_i(wide_cluster_in_isolate_rsp),
+      .isolate_i(isolate_i[2]),
+      .isolated_o(isolated_o[2])
+  );
   axi_id_remap #(
       .AxiSlvPortIdWidth(8),
       .AxiSlvPortMaxUniqIds(4),
@@ -269,8 +339,8 @@ module occamy_quadrant_s1
   ) i_wide_cluster_in_iwc (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(wide_cluster_in_iwc_req),
-      .slv_resp_o(wide_cluster_in_iwc_rsp),
+      .slv_req_i(wide_cluster_in_isolate_req),
+      .slv_resp_o(wide_cluster_in_isolate_rsp),
       .mst_req_o(wide_xbar_quadrant_s1_in_req[WIDE_XBAR_QUADRANT_S1_IN_TOP]),
       .mst_resp_i(wide_xbar_quadrant_s1_in_rsp[WIDE_XBAR_QUADRANT_S1_IN_TOP])
   );

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson
@@ -13,6 +13,11 @@
       type: "int",
       default: "31"
     },
+    { name: "NumIsolateRegs",
+      desc: "Number of Isolate Regs.",
+      type: "int",
+      default: "12"
+    },
   ],
   name: "Occamy SoC"
   clock_primary: "clk_i"
@@ -103,6 +108,59 @@
             name: "DRV"
             resval: "2"
             desc: "Drive strength."
+          }
+        ]
+      }
+    }
+    { multireg:
+      { name: "ISOLATE"
+        desc: "Isolate port of given quadrant."
+        swaccess: "rw"
+        hwaccess: "hro"
+        count: "NumIsolateRegs"
+        cname: "isolate"
+        fields: [
+          { bits: "3:0"
+            resval: "1"
+            name: "ISOLATE"
+            desc: '''
+                  Isolate S1 Quadrant. Four bits corresponding to:
+                    - Bit 0: Narrow In
+                    - Bit 1: Narrow Out
+                    - Bit 2: Wide In
+                    - Bit 3: Wide Out
+
+                  0: De-isolate request
+                  1: Isolate request
+                  '''
+          }
+        ]
+      }
+    }
+    { multireg:
+      { name: "ISOLATED"
+        desc: "Isolation status of S1 quadrant and port"
+        swaccess: "ro"
+        hwaccess: "hwo"
+        hwqe:     "true",
+        hwext:    "true",
+        count: "NumIsolateRegs"
+        cname: "isolated"
+        fields: [
+          { bits: "3:0"
+            resval: "1"
+            name: "ISOLATED"
+            desc: '''
+                  Isolate satus of S1 Quadrant. Four bits corresponding to:
+                    - Bit 0: Narrow In
+                    - Bit 1: Narrow Out
+                    - Bit 2: Wide In
+                    - Bit 3: Wide Out
+
+                  Isolation status:
+                    0: De-isolated
+                    1: Isolated
+                  '''
           }
         ]
       }

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_pkg.sv
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_pkg.sv
@@ -9,6 +9,7 @@ package occamy_soc_reg_pkg;
   // Param list
   parameter int NumScratchRegs = 4;
   parameter int NumPads = 31;
+  parameter int NumIsolateRegs = 12;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -54,6 +55,10 @@ package occamy_soc_reg_pkg;
     } drv;
   } occamy_soc_reg2hw_pad_mreg_t;
 
+  typedef struct packed {
+    logic [3:0]  q;
+  } occamy_soc_reg2hw_isolate_mreg_t;
+
 
   typedef struct packed {
     struct packed {
@@ -70,23 +75,29 @@ package occamy_soc_reg_pkg;
     logic [1:0]  d;
   } occamy_soc_hw2reg_boot_mode_reg_t;
 
+  typedef struct packed {
+    logic [3:0]  d;
+  } occamy_soc_hw2reg_isolated_mreg_t;
+
 
   ///////////////////////////////////////
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    occamy_soc_reg2hw_intr_state_reg_t intr_state; // [132:131]
-    occamy_soc_reg2hw_intr_enable_reg_t intr_enable; // [130:129]
-    occamy_soc_reg2hw_intr_test_reg_t intr_test; // [128:125]
-    occamy_soc_reg2hw_pad_mreg_t [30:0] pad; // [124:1]
+    occamy_soc_reg2hw_intr_state_reg_t intr_state; // [180:179]
+    occamy_soc_reg2hw_intr_enable_reg_t intr_enable; // [178:177]
+    occamy_soc_reg2hw_intr_test_reg_t intr_test; // [176:173]
+    occamy_soc_reg2hw_pad_mreg_t [30:0] pad; // [172:49]
+    occamy_soc_reg2hw_isolate_mreg_t [11:0] isolate; // [48:1]
   } occamy_soc_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    occamy_soc_hw2reg_intr_state_reg_t intr_state; // [6:5]
-    occamy_soc_hw2reg_boot_mode_reg_t boot_mode; // [4:5]
+    occamy_soc_hw2reg_intr_state_reg_t intr_state; // [54:53]
+    occamy_soc_hw2reg_boot_mode_reg_t boot_mode; // [52:53]
+    occamy_soc_hw2reg_isolated_mreg_t [11:0] isolated; // [52:5]
   } occamy_soc_hw2reg_t;
 
   // Register Address
@@ -130,6 +141,10 @@ package occamy_soc_reg_pkg;
   parameter logic [7:0] OCCAMY_SOC_PAD_28_OFFSET = 8'h 94;
   parameter logic [7:0] OCCAMY_SOC_PAD_29_OFFSET = 8'h 98;
   parameter logic [7:0] OCCAMY_SOC_PAD_30_OFFSET = 8'h 9c;
+  parameter logic [7:0] OCCAMY_SOC_ISOLATE_0_OFFSET = 8'h a0;
+  parameter logic [7:0] OCCAMY_SOC_ISOLATE_1_OFFSET = 8'h a4;
+  parameter logic [7:0] OCCAMY_SOC_ISOLATED_0_OFFSET = 8'h a8;
+  parameter logic [7:0] OCCAMY_SOC_ISOLATED_1_OFFSET = 8'h ac;
 
 
   // Register Index
@@ -173,11 +188,15 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_PAD_27,
     OCCAMY_SOC_PAD_28,
     OCCAMY_SOC_PAD_29,
-    OCCAMY_SOC_PAD_30
+    OCCAMY_SOC_PAD_30,
+    OCCAMY_SOC_ISOLATE_0,
+    OCCAMY_SOC_ISOLATE_1,
+    OCCAMY_SOC_ISOLATED_0,
+    OCCAMY_SOC_ISOLATED_1
   } occamy_soc_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] OCCAMY_SOC_PERMIT [40] = '{
+  parameter logic [3:0] OCCAMY_SOC_PERMIT [44] = '{
     4'b 0001, // index[ 0] OCCAMY_SOC_INTR_STATE
     4'b 0001, // index[ 1] OCCAMY_SOC_INTR_ENABLE
     4'b 0001, // index[ 2] OCCAMY_SOC_INTR_TEST
@@ -217,7 +236,11 @@ package occamy_soc_reg_pkg;
     4'b 0001, // index[36] OCCAMY_SOC_PAD_27
     4'b 0001, // index[37] OCCAMY_SOC_PAD_28
     4'b 0001, // index[38] OCCAMY_SOC_PAD_29
-    4'b 0001  // index[39] OCCAMY_SOC_PAD_30
+    4'b 0001, // index[39] OCCAMY_SOC_PAD_30
+    4'b 1111, // index[40] OCCAMY_SOC_ISOLATE_0
+    4'b 0011, // index[41] OCCAMY_SOC_ISOLATE_1
+    4'b 1111, // index[42] OCCAMY_SOC_ISOLATED_0
+    4'b 0011  // index[43] OCCAMY_SOC_ISOLATED_1
   };
 endpackage
 

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_top.sv
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_top.sv
@@ -374,6 +374,66 @@ module occamy_soc_reg_top #(
   logic [1:0] pad_30_drv_30_qs;
   logic [1:0] pad_30_drv_30_wd;
   logic pad_30_drv_30_we;
+  logic [3:0] isolate_0_isolate_0_qs;
+  logic [3:0] isolate_0_isolate_0_wd;
+  logic isolate_0_isolate_0_we;
+  logic [3:0] isolate_0_isolate_1_qs;
+  logic [3:0] isolate_0_isolate_1_wd;
+  logic isolate_0_isolate_1_we;
+  logic [3:0] isolate_0_isolate_2_qs;
+  logic [3:0] isolate_0_isolate_2_wd;
+  logic isolate_0_isolate_2_we;
+  logic [3:0] isolate_0_isolate_3_qs;
+  logic [3:0] isolate_0_isolate_3_wd;
+  logic isolate_0_isolate_3_we;
+  logic [3:0] isolate_0_isolate_4_qs;
+  logic [3:0] isolate_0_isolate_4_wd;
+  logic isolate_0_isolate_4_we;
+  logic [3:0] isolate_0_isolate_5_qs;
+  logic [3:0] isolate_0_isolate_5_wd;
+  logic isolate_0_isolate_5_we;
+  logic [3:0] isolate_0_isolate_6_qs;
+  logic [3:0] isolate_0_isolate_6_wd;
+  logic isolate_0_isolate_6_we;
+  logic [3:0] isolate_0_isolate_7_qs;
+  logic [3:0] isolate_0_isolate_7_wd;
+  logic isolate_0_isolate_7_we;
+  logic [3:0] isolate_1_isolate_8_qs;
+  logic [3:0] isolate_1_isolate_8_wd;
+  logic isolate_1_isolate_8_we;
+  logic [3:0] isolate_1_isolate_9_qs;
+  logic [3:0] isolate_1_isolate_9_wd;
+  logic isolate_1_isolate_9_we;
+  logic [3:0] isolate_1_isolate_10_qs;
+  logic [3:0] isolate_1_isolate_10_wd;
+  logic isolate_1_isolate_10_we;
+  logic [3:0] isolate_1_isolate_11_qs;
+  logic [3:0] isolate_1_isolate_11_wd;
+  logic isolate_1_isolate_11_we;
+  logic [3:0] isolated_0_isolated_0_qs;
+  logic isolated_0_isolated_0_re;
+  logic [3:0] isolated_0_isolated_1_qs;
+  logic isolated_0_isolated_1_re;
+  logic [3:0] isolated_0_isolated_2_qs;
+  logic isolated_0_isolated_2_re;
+  logic [3:0] isolated_0_isolated_3_qs;
+  logic isolated_0_isolated_3_re;
+  logic [3:0] isolated_0_isolated_4_qs;
+  logic isolated_0_isolated_4_re;
+  logic [3:0] isolated_0_isolated_5_qs;
+  logic isolated_0_isolated_5_re;
+  logic [3:0] isolated_0_isolated_6_qs;
+  logic isolated_0_isolated_6_re;
+  logic [3:0] isolated_0_isolated_7_qs;
+  logic isolated_0_isolated_7_re;
+  logic [3:0] isolated_1_isolated_8_qs;
+  logic isolated_1_isolated_8_re;
+  logic [3:0] isolated_1_isolated_9_qs;
+  logic isolated_1_isolated_9_re;
+  logic [3:0] isolated_1_isolated_10_qs;
+  logic isolated_1_isolated_10_re;
+  logic [3:0] isolated_1_isolated_11_qs;
+  logic isolated_1_isolated_11_re;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -3162,8 +3222,516 @@ module occamy_soc_reg_top #(
 
 
 
+  // Subregister 0 of Multireg isolate
+  // R[isolate_0]: V(False)
 
-  logic [39:0] addr_hit;
+  // F[isolate_0]: 3:0
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_0_isolate_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_0_isolate_0_we),
+    .wd     (isolate_0_isolate_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[0].q ),
+
+    // to register interface (read)
+    .qs     (isolate_0_isolate_0_qs)
+  );
+
+
+  // F[isolate_1]: 7:4
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_0_isolate_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_0_isolate_1_we),
+    .wd     (isolate_0_isolate_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[1].q ),
+
+    // to register interface (read)
+    .qs     (isolate_0_isolate_1_qs)
+  );
+
+
+  // F[isolate_2]: 11:8
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_0_isolate_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_0_isolate_2_we),
+    .wd     (isolate_0_isolate_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[2].q ),
+
+    // to register interface (read)
+    .qs     (isolate_0_isolate_2_qs)
+  );
+
+
+  // F[isolate_3]: 15:12
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_0_isolate_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_0_isolate_3_we),
+    .wd     (isolate_0_isolate_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[3].q ),
+
+    // to register interface (read)
+    .qs     (isolate_0_isolate_3_qs)
+  );
+
+
+  // F[isolate_4]: 19:16
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_0_isolate_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_0_isolate_4_we),
+    .wd     (isolate_0_isolate_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[4].q ),
+
+    // to register interface (read)
+    .qs     (isolate_0_isolate_4_qs)
+  );
+
+
+  // F[isolate_5]: 23:20
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_0_isolate_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_0_isolate_5_we),
+    .wd     (isolate_0_isolate_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[5].q ),
+
+    // to register interface (read)
+    .qs     (isolate_0_isolate_5_qs)
+  );
+
+
+  // F[isolate_6]: 27:24
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_0_isolate_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_0_isolate_6_we),
+    .wd     (isolate_0_isolate_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[6].q ),
+
+    // to register interface (read)
+    .qs     (isolate_0_isolate_6_qs)
+  );
+
+
+  // F[isolate_7]: 31:28
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_0_isolate_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_0_isolate_7_we),
+    .wd     (isolate_0_isolate_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[7].q ),
+
+    // to register interface (read)
+    .qs     (isolate_0_isolate_7_qs)
+  );
+
+
+  // Subregister 8 of Multireg isolate
+  // R[isolate_1]: V(False)
+
+  // F[isolate_8]: 3:0
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_1_isolate_8 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_1_isolate_8_we),
+    .wd     (isolate_1_isolate_8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[8].q ),
+
+    // to register interface (read)
+    .qs     (isolate_1_isolate_8_qs)
+  );
+
+
+  // F[isolate_9]: 7:4
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_1_isolate_9 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_1_isolate_9_we),
+    .wd     (isolate_1_isolate_9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[9].q ),
+
+    // to register interface (read)
+    .qs     (isolate_1_isolate_9_qs)
+  );
+
+
+  // F[isolate_10]: 11:8
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_1_isolate_10 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_1_isolate_10_we),
+    .wd     (isolate_1_isolate_10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[10].q ),
+
+    // to register interface (read)
+    .qs     (isolate_1_isolate_10_qs)
+  );
+
+
+  // F[isolate_11]: 15:12
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h1)
+  ) u_isolate_1_isolate_11 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (isolate_1_isolate_11_we),
+    .wd     (isolate_1_isolate_11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.isolate[11].q ),
+
+    // to register interface (read)
+    .qs     (isolate_1_isolate_11_qs)
+  );
+
+
+
+
+  // Subregister 0 of Multireg isolated
+  // R[isolated_0]: V(True)
+
+  // F[isolated_0]: 3:0
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_0_isolated_0 (
+    .re     (isolated_0_isolated_0_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[0].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_0_isolated_0_qs)
+  );
+
+
+  // F[isolated_1]: 7:4
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_0_isolated_1 (
+    .re     (isolated_0_isolated_1_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[1].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_0_isolated_1_qs)
+  );
+
+
+  // F[isolated_2]: 11:8
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_0_isolated_2 (
+    .re     (isolated_0_isolated_2_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[2].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_0_isolated_2_qs)
+  );
+
+
+  // F[isolated_3]: 15:12
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_0_isolated_3 (
+    .re     (isolated_0_isolated_3_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[3].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_0_isolated_3_qs)
+  );
+
+
+  // F[isolated_4]: 19:16
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_0_isolated_4 (
+    .re     (isolated_0_isolated_4_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[4].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_0_isolated_4_qs)
+  );
+
+
+  // F[isolated_5]: 23:20
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_0_isolated_5 (
+    .re     (isolated_0_isolated_5_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[5].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_0_isolated_5_qs)
+  );
+
+
+  // F[isolated_6]: 27:24
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_0_isolated_6 (
+    .re     (isolated_0_isolated_6_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[6].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_0_isolated_6_qs)
+  );
+
+
+  // F[isolated_7]: 31:28
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_0_isolated_7 (
+    .re     (isolated_0_isolated_7_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[7].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_0_isolated_7_qs)
+  );
+
+
+  // Subregister 8 of Multireg isolated
+  // R[isolated_1]: V(True)
+
+  // F[isolated_8]: 3:0
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_1_isolated_8 (
+    .re     (isolated_1_isolated_8_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[8].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_1_isolated_8_qs)
+  );
+
+
+  // F[isolated_9]: 7:4
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_1_isolated_9 (
+    .re     (isolated_1_isolated_9_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[9].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_1_isolated_9_qs)
+  );
+
+
+  // F[isolated_10]: 11:8
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_1_isolated_10 (
+    .re     (isolated_1_isolated_10_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[10].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_1_isolated_10_qs)
+  );
+
+
+  // F[isolated_11]: 15:12
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_isolated_1_isolated_11 (
+    .re     (isolated_1_isolated_11_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.isolated[11].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (isolated_1_isolated_11_qs)
+  );
+
+
+
+
+
+  logic [43:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == OCCAMY_SOC_INTR_STATE_OFFSET);
@@ -3206,6 +3774,10 @@ module occamy_soc_reg_top #(
     addr_hit[37] = (reg_addr == OCCAMY_SOC_PAD_28_OFFSET);
     addr_hit[38] = (reg_addr == OCCAMY_SOC_PAD_29_OFFSET);
     addr_hit[39] = (reg_addr == OCCAMY_SOC_PAD_30_OFFSET);
+    addr_hit[40] = (reg_addr == OCCAMY_SOC_ISOLATE_0_OFFSET);
+    addr_hit[41] = (reg_addr == OCCAMY_SOC_ISOLATE_1_OFFSET);
+    addr_hit[42] = (reg_addr == OCCAMY_SOC_ISOLATED_0_OFFSET);
+    addr_hit[43] = (reg_addr == OCCAMY_SOC_ISOLATED_1_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -3253,6 +3825,10 @@ module occamy_soc_reg_top #(
     if (addr_hit[37] && reg_we && (OCCAMY_SOC_PERMIT[37] != (OCCAMY_SOC_PERMIT[37] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[38] && reg_we && (OCCAMY_SOC_PERMIT[38] != (OCCAMY_SOC_PERMIT[38] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[39] && reg_we && (OCCAMY_SOC_PERMIT[39] != (OCCAMY_SOC_PERMIT[39] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[40] && reg_we && (OCCAMY_SOC_PERMIT[40] != (OCCAMY_SOC_PERMIT[40] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[41] && reg_we && (OCCAMY_SOC_PERMIT[41] != (OCCAMY_SOC_PERMIT[41] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[42] && reg_we && (OCCAMY_SOC_PERMIT[42] != (OCCAMY_SOC_PERMIT[42] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[43] && reg_we && (OCCAMY_SOC_PERMIT[43] != (OCCAMY_SOC_PERMIT[43] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_ecc_uncorrectable_we = addr_hit[0] & reg_we & ~wr_err;
@@ -3567,6 +4143,66 @@ module occamy_soc_reg_top #(
   assign pad_30_drv_30_we = addr_hit[39] & reg_we & ~wr_err;
   assign pad_30_drv_30_wd = reg_wdata[3:2];
 
+  assign isolate_0_isolate_0_we = addr_hit[40] & reg_we & ~wr_err;
+  assign isolate_0_isolate_0_wd = reg_wdata[3:0];
+
+  assign isolate_0_isolate_1_we = addr_hit[40] & reg_we & ~wr_err;
+  assign isolate_0_isolate_1_wd = reg_wdata[7:4];
+
+  assign isolate_0_isolate_2_we = addr_hit[40] & reg_we & ~wr_err;
+  assign isolate_0_isolate_2_wd = reg_wdata[11:8];
+
+  assign isolate_0_isolate_3_we = addr_hit[40] & reg_we & ~wr_err;
+  assign isolate_0_isolate_3_wd = reg_wdata[15:12];
+
+  assign isolate_0_isolate_4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign isolate_0_isolate_4_wd = reg_wdata[19:16];
+
+  assign isolate_0_isolate_5_we = addr_hit[40] & reg_we & ~wr_err;
+  assign isolate_0_isolate_5_wd = reg_wdata[23:20];
+
+  assign isolate_0_isolate_6_we = addr_hit[40] & reg_we & ~wr_err;
+  assign isolate_0_isolate_6_wd = reg_wdata[27:24];
+
+  assign isolate_0_isolate_7_we = addr_hit[40] & reg_we & ~wr_err;
+  assign isolate_0_isolate_7_wd = reg_wdata[31:28];
+
+  assign isolate_1_isolate_8_we = addr_hit[41] & reg_we & ~wr_err;
+  assign isolate_1_isolate_8_wd = reg_wdata[3:0];
+
+  assign isolate_1_isolate_9_we = addr_hit[41] & reg_we & ~wr_err;
+  assign isolate_1_isolate_9_wd = reg_wdata[7:4];
+
+  assign isolate_1_isolate_10_we = addr_hit[41] & reg_we & ~wr_err;
+  assign isolate_1_isolate_10_wd = reg_wdata[11:8];
+
+  assign isolate_1_isolate_11_we = addr_hit[41] & reg_we & ~wr_err;
+  assign isolate_1_isolate_11_wd = reg_wdata[15:12];
+
+  assign isolated_0_isolated_0_re = addr_hit[42] && reg_re;
+
+  assign isolated_0_isolated_1_re = addr_hit[42] && reg_re;
+
+  assign isolated_0_isolated_2_re = addr_hit[42] && reg_re;
+
+  assign isolated_0_isolated_3_re = addr_hit[42] && reg_re;
+
+  assign isolated_0_isolated_4_re = addr_hit[42] && reg_re;
+
+  assign isolated_0_isolated_5_re = addr_hit[42] && reg_re;
+
+  assign isolated_0_isolated_6_re = addr_hit[42] && reg_re;
+
+  assign isolated_0_isolated_7_re = addr_hit[42] && reg_re;
+
+  assign isolated_1_isolated_8_re = addr_hit[43] && reg_re;
+
+  assign isolated_1_isolated_9_re = addr_hit[43] && reg_re;
+
+  assign isolated_1_isolated_10_re = addr_hit[43] && reg_re;
+
+  assign isolated_1_isolated_11_re = addr_hit[43] && reg_re;
+
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
@@ -3794,6 +4430,42 @@ module occamy_soc_reg_top #(
         reg_rdata_next[0] = pad_30_slw_30_qs;
         reg_rdata_next[1] = pad_30_smt_30_qs;
         reg_rdata_next[3:2] = pad_30_drv_30_qs;
+      end
+
+      addr_hit[40]: begin
+        reg_rdata_next[3:0] = isolate_0_isolate_0_qs;
+        reg_rdata_next[7:4] = isolate_0_isolate_1_qs;
+        reg_rdata_next[11:8] = isolate_0_isolate_2_qs;
+        reg_rdata_next[15:12] = isolate_0_isolate_3_qs;
+        reg_rdata_next[19:16] = isolate_0_isolate_4_qs;
+        reg_rdata_next[23:20] = isolate_0_isolate_5_qs;
+        reg_rdata_next[27:24] = isolate_0_isolate_6_qs;
+        reg_rdata_next[31:28] = isolate_0_isolate_7_qs;
+      end
+
+      addr_hit[41]: begin
+        reg_rdata_next[3:0] = isolate_1_isolate_8_qs;
+        reg_rdata_next[7:4] = isolate_1_isolate_9_qs;
+        reg_rdata_next[11:8] = isolate_1_isolate_10_qs;
+        reg_rdata_next[15:12] = isolate_1_isolate_11_qs;
+      end
+
+      addr_hit[42]: begin
+        reg_rdata_next[3:0] = isolated_0_isolated_0_qs;
+        reg_rdata_next[7:4] = isolated_0_isolated_1_qs;
+        reg_rdata_next[11:8] = isolated_0_isolated_2_qs;
+        reg_rdata_next[15:12] = isolated_0_isolated_3_qs;
+        reg_rdata_next[19:16] = isolated_0_isolated_4_qs;
+        reg_rdata_next[23:20] = isolated_0_isolated_5_qs;
+        reg_rdata_next[27:24] = isolated_0_isolated_6_qs;
+        reg_rdata_next[31:28] = isolated_0_isolated_7_qs;
+      end
+
+      addr_hit[43]: begin
+        reg_rdata_next[3:0] = isolated_1_isolated_8_qs;
+        reg_rdata_next[7:4] = isolated_1_isolated_9_qs;
+        reg_rdata_next[11:8] = isolated_1_isolated_10_qs;
+        reg_rdata_next[15:12] = isolated_1_isolated_11_qs;
       end
 
       default: begin

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -143,7 +143,7 @@ module occamy_top
 
   occamy_soc_reg_pkg::occamy_soc_reg2hw_t soc_ctrl_out;
   occamy_soc_reg_pkg::occamy_soc_hw2reg_t soc_ctrl_in;
-  always_comb soc_ctrl_in = '0;
+  assign soc_ctrl_in.boot_mode.d = boot_mode_i;
 
 
 
@@ -661,6 +661,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .meip_i('0),
       .mtip_i('0),
       .msip_i('0),
+      .isolate_i(soc_ctrl_out.isolate[0].q),
+      .isolated_o(soc_ctrl_in.isolated[0].d),
       .quadrant_hbi_out_req_o(wide_hbi_out_cut_0_req),
       .quadrant_hbi_out_rsp_i(wide_hbi_out_cut_0_rsp),
       .quadrant_narrow_out_req_o(narrow_out_cut_0_req),
@@ -792,6 +794,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .meip_i('0),
       .mtip_i('0),
       .msip_i('0),
+      .isolate_i(soc_ctrl_out.isolate[1].q),
+      .isolated_o(soc_ctrl_in.isolated[1].d),
       .quadrant_hbi_out_req_o(wide_hbi_out_cut_1_req),
       .quadrant_hbi_out_rsp_i(wide_hbi_out_cut_1_rsp),
       .quadrant_narrow_out_req_o(narrow_out_cut_1_req),
@@ -923,6 +927,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .meip_i('0),
       .mtip_i('0),
       .msip_i('0),
+      .isolate_i(soc_ctrl_out.isolate[2].q),
+      .isolated_o(soc_ctrl_in.isolated[2].d),
       .quadrant_hbi_out_req_o(wide_hbi_out_cut_2_req),
       .quadrant_hbi_out_rsp_i(wide_hbi_out_cut_2_rsp),
       .quadrant_narrow_out_req_o(narrow_out_cut_2_req),
@@ -1054,6 +1060,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .meip_i('0),
       .mtip_i('0),
       .msip_i('0),
+      .isolate_i(soc_ctrl_out.isolate[3].q),
+      .isolated_o(soc_ctrl_in.isolated[3].d),
       .quadrant_hbi_out_req_o(wide_hbi_out_cut_3_req),
       .quadrant_hbi_out_rsp_i(wide_hbi_out_cut_3_rsp),
       .quadrant_narrow_out_req_o(narrow_out_cut_3_req),
@@ -1185,6 +1193,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .meip_i('0),
       .mtip_i('0),
       .msip_i('0),
+      .isolate_i(soc_ctrl_out.isolate[4].q),
+      .isolated_o(soc_ctrl_in.isolated[4].d),
       .quadrant_hbi_out_req_o(wide_hbi_out_cut_4_req),
       .quadrant_hbi_out_rsp_i(wide_hbi_out_cut_4_rsp),
       .quadrant_narrow_out_req_o(narrow_out_cut_4_req),
@@ -1316,6 +1326,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .meip_i('0),
       .mtip_i('0),
       .msip_i('0),
+      .isolate_i(soc_ctrl_out.isolate[5].q),
+      .isolated_o(soc_ctrl_in.isolated[5].d),
       .quadrant_hbi_out_req_o(wide_hbi_out_cut_5_req),
       .quadrant_hbi_out_rsp_i(wide_hbi_out_cut_5_rsp),
       .quadrant_narrow_out_req_o(narrow_out_cut_5_req),
@@ -1447,6 +1459,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .meip_i('0),
       .mtip_i('0),
       .msip_i('0),
+      .isolate_i(soc_ctrl_out.isolate[6].q),
+      .isolated_o(soc_ctrl_in.isolated[6].d),
       .quadrant_hbi_out_req_o(wide_hbi_out_cut_6_req),
       .quadrant_hbi_out_rsp_i(wide_hbi_out_cut_6_rsp),
       .quadrant_narrow_out_req_o(narrow_out_cut_6_req),
@@ -1578,6 +1592,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .meip_i('0),
       .mtip_i('0),
       .msip_i('0),
+      .isolate_i(soc_ctrl_out.isolate[7].q),
+      .isolated_o(soc_ctrl_in.isolated[7].d),
       .quadrant_hbi_out_req_o(wide_hbi_out_cut_7_req),
       .quadrant_hbi_out_rsp_i(wide_hbi_out_cut_7_rsp),
       .quadrant_narrow_out_req_o(narrow_out_cut_7_req),

--- a/hw/system/occamy/src/occamy_top.sv.tpl
+++ b/hw/system/occamy/src/occamy_top.sv.tpl
@@ -105,7 +105,7 @@ module occamy_top
 
   occamy_soc_reg_pkg::occamy_soc_reg2hw_t soc_ctrl_out;
   occamy_soc_reg_pkg::occamy_soc_hw2reg_t soc_ctrl_in;
-  always_comb soc_ctrl_in = '0;
+  assign soc_ctrl_in.boot_mode.d = boot_mode_i;
 
   <% spm_words = cfg["spm"]["size"]*1024//(soc_narrow_xbar.out_spm.dw//8) %>
 
@@ -197,6 +197,8 @@ module occamy_top
     .meip_i ('0),
     .mtip_i ('0),
     .msip_i ('0),
+    .isolate_i (soc_ctrl_out.isolate[${i}].q),
+    .isolated_o (soc_ctrl_in.isolated[${i}].d),
     .quadrant_hbi_out_req_o (${wide_hbi_out.req_name()}),
     .quadrant_hbi_out_rsp_i (${wide_hbi_out.rsp_name()}),
     .quadrant_narrow_out_req_o (${narrow_out.req_name()}),


### PR DESCRIPTION
Since the clusters will start issuing AXI transactions when they boot, we want to safeguard AXI transactions since - in case a given cluster isn't performing correctly - lock up the entire system.

Isolation is controlled via the SoC control register in the top level.