### PR TITLE
Instruction cache at wide cluster port

### DIFF
--- a/hw/ip/snitch/src/snitch_pkg.sv
+++ b/hw/ip/snitch/src/snitch_pkg.sv
@@ -128,14 +128,14 @@ package snitch_pkg;
   typedef enum integer {
     CoreReq = 0,
     AXISoC  = 1,
-    PTW     = 2,
-    ICache  = 3
+    PTW     = 2
   } cluster_master_e;
 
   // Slaves on Cluster DMA AXI Bus
   typedef enum int unsigned {
-    TCDMDMA = 32'd0,
-    SoCDMAOut = 32'd1
+    TCDMDMA   = 0,
+    SoCDMAOut = 1,
+    ICache    = 2
   } cluster_slave_dma_e;
 
   typedef enum int unsigned {

--- a/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -54,10 +54,10 @@ package ${cfg['pkg_name']};
   localparam int unsigned WideDataWidth = ${cfg['dma_data_width']};
 
   localparam int unsigned NarrowIdWidthIn = ${cfg['id_width_in']};
-  localparam int unsigned NrMasters = 3 + ${cfg['nr_hives']};
+  localparam int unsigned NrMasters = 3;
   localparam int unsigned NarrowIdWidthOut = $clog2(NrMasters) + NarrowIdWidthIn;
 
-  localparam int unsigned NrDmaMasters = 2;
+  localparam int unsigned NrDmaMasters = 2 + ${cfg['nr_hives']};
   localparam int unsigned WideIdWidthIn = ${cfg['dma_id_width_in']};
   localparam int unsigned WideIdWidthOut = $clog2(NrDmaMasters) + WideIdWidthIn;
 

--- a/hw/ip/snitch_cluster/src/snitch_hive.sv
+++ b/hw/ip/snitch_cluster/src/snitch_hive.sv
@@ -19,8 +19,9 @@ module snitch_hive #(
   parameter bit          IsoCrossing        = 1,
   /// Address width of the buses
   parameter int unsigned AddrWidth          = 0,
-  /// Data width of the buses.
-  parameter int unsigned DataWidth          = 0,
+  /// Data width of the Narrow bus.
+  parameter int unsigned NarrowDataWidth    = 0,
+  parameter int unsigned WideDataWidth      = 0,
   parameter type         dreq_t             = logic,
   parameter type         drsp_t             = logic,
   parameter type         axi_req_t          = logic,
@@ -29,7 +30,7 @@ module snitch_hive #(
   parameter type         hive_rsp_t         = logic,
   /// Derived parameter *Do not override*
   parameter type addr_t = logic [AddrWidth-1:0],
-  parameter type data_t = logic [DataWidth-1:0]
+  parameter type data_t = logic [NarrowDataWidth-1:0]
 ) (
   input  logic     clk_i,
   input  logic     clk_d2_i, // divide-by-two clock
@@ -77,15 +78,15 @@ module snitch_hive #(
   end
 
   snitch_icache #(
-    .NR_FETCH_PORTS    ( CoreCount        ),
-    .L0_LINE_COUNT     ( 8                ),
-    .LINE_WIDTH        ( ICacheLineWidth  ),
-    .LINE_COUNT        ( ICacheLineCount  ),
-    .SET_COUNT         ( ICacheSets       ),
-    .FETCH_AW          ( AddrWidth        ),
-    .FETCH_DW          ( 32               ),
-    .FILL_AW           ( AddrWidth        ),
-    .FILL_DW           ( DataWidth        ),
+    .NR_FETCH_PORTS     ( CoreCount        ),
+    .L0_LINE_COUNT      ( 8                ),
+    .LINE_WIDTH         ( ICacheLineWidth  ),
+    .LINE_COUNT         ( ICacheLineCount  ),
+    .SET_COUNT          ( ICacheSets       ),
+    .FETCH_AW           ( AddrWidth        ),
+    .FETCH_DW           ( 32               ),
+    .FILL_AW            ( AddrWidth        ),
+    .FILL_DW            ( WideDataWidth    ),
     .EARLY_LATCH        ( 0               ),
     .L0_EARLY_TAG_WIDTH ( snitch_pkg::PAGE_SHIFT - $clog2(ICacheLineWidth/8) ),
     .ISO_CROSSING       ( IsoCrossing     ),
@@ -165,7 +166,7 @@ module snitch_hive #(
 
   snitch_ptw #(
     .AddrWidth (AddrWidth),
-    .DataWidth (DataWidth),
+    .DataWidth (NarrowDataWidth),
     .pa_t (pa_t),
     .l0_pte_t (l0_pte_t),
     .pte_sv32_t (pte_sv32_t),
@@ -186,7 +187,7 @@ module snitch_hive #(
 
   reqrsp_iso #(
     .AddrWidth (AddrWidth),
-    .DataWidth (DataWidth),
+    .DataWidth (NarrowDataWidth),
     .req_t (dreq_t),
     .rsp_t (drsp_t),
     .BypassReq (1'b0),
@@ -307,7 +308,7 @@ module snitch_hive #(
   );
 
   snitch_shared_muldiv #(
-    .DataWidth (DataWidth),
+    .DataWidth (NarrowDataWidth),
     .IdWidth ( ExtendedIdWidth )
   ) i_snitch_shared_muldiv (
     .clk_i            ( clk_i                   ),

--- a/hw/system/occamy/src/occamy_cluster_wrapper.sv
+++ b/hw/system/occamy/src/occamy_cluster_wrapper.sv
@@ -24,10 +24,10 @@ package occamy_cluster_pkg;
   localparam int unsigned WideDataWidth = 512;
 
   localparam int unsigned NarrowIdWidthIn = 2;
-  localparam int unsigned NrMasters = 3 + 1;
+  localparam int unsigned NrMasters = 3;
   localparam int unsigned NarrowIdWidthOut = $clog2(NrMasters) + NarrowIdWidthIn;
 
-  localparam int unsigned NrDmaMasters = 2;
+  localparam int unsigned NrDmaMasters = 2 + 1;
   localparam int unsigned WideIdWidthIn = 2;
   localparam int unsigned WideIdWidthOut = $clog2(NrDmaMasters) + WideIdWidthIn;
 

--- a/hw/system/occamy/src/occamy_pkg.sv
+++ b/hw/system/occamy/src/occamy_pkg.sv
@@ -371,36 +371,40 @@ package occamy_pkg;
   MaxMstTrans:        4,
   FallThrough:        0,
   LatencyMode:        axi_pkg::CUT_ALL_PORTS,
-  AxiIdWidthSlvPorts: 3,
-  AxiIdUsedSlvPorts:  3,
+  AxiIdWidthSlvPorts: 4,
+  AxiIdUsedSlvPorts:  4,
   AxiAddrWidth:       48,
   AxiDataWidth:       512,
   NoAddrRules:        5
 };
 
-  // AXI bus with 48 bit address, 512 bit data, 6 bit IDs, and 0 bit user data.
-  `AXI_TYPEDEF_ALL(axi_a48_d512_i6_u0, logic [47:0], logic [5:0], logic [511:0], logic [63:0],
+  // AXI bus with 48 bit address, 512 bit data, 4 bit IDs, and 0 bit user data.
+  `AXI_TYPEDEF_ALL(axi_a48_d512_i4_u0, logic [47:0], logic [3:0], logic [511:0], logic [63:0],
                    logic [0:0])
 
-  typedef axi_a48_d512_i3_u0_req_t wide_xbar_quadrant_s1_in_req_t;
-  typedef axi_a48_d512_i6_u0_req_t wide_xbar_quadrant_s1_out_req_t;
-  typedef axi_a48_d512_i3_u0_resp_t wide_xbar_quadrant_s1_in_resp_t;
-  typedef axi_a48_d512_i6_u0_resp_t wide_xbar_quadrant_s1_out_resp_t;
-  typedef axi_a48_d512_i3_u0_aw_chan_t wide_xbar_quadrant_s1_in_aw_chan_t;
-  typedef axi_a48_d512_i6_u0_aw_chan_t wide_xbar_quadrant_s1_out_aw_chan_t;
-  typedef axi_a48_d512_i3_u0_w_chan_t wide_xbar_quadrant_s1_in_w_chan_t;
-  typedef axi_a48_d512_i6_u0_w_chan_t wide_xbar_quadrant_s1_out_w_chan_t;
-  typedef axi_a48_d512_i3_u0_b_chan_t wide_xbar_quadrant_s1_in_b_chan_t;
-  typedef axi_a48_d512_i6_u0_b_chan_t wide_xbar_quadrant_s1_out_b_chan_t;
-  typedef axi_a48_d512_i3_u0_ar_chan_t wide_xbar_quadrant_s1_in_ar_chan_t;
-  typedef axi_a48_d512_i6_u0_ar_chan_t wide_xbar_quadrant_s1_out_ar_chan_t;
-  typedef axi_a48_d512_i3_u0_r_chan_t wide_xbar_quadrant_s1_in_r_chan_t;
-  typedef axi_a48_d512_i6_u0_r_chan_t wide_xbar_quadrant_s1_out_r_chan_t;
+  // AXI bus with 48 bit address, 512 bit data, 7 bit IDs, and 0 bit user data.
+  `AXI_TYPEDEF_ALL(axi_a48_d512_i7_u0, logic [47:0], logic [6:0], logic [511:0], logic [63:0],
+                   logic [0:0])
+
+  typedef axi_a48_d512_i4_u0_req_t wide_xbar_quadrant_s1_in_req_t;
+  typedef axi_a48_d512_i7_u0_req_t wide_xbar_quadrant_s1_out_req_t;
+  typedef axi_a48_d512_i4_u0_resp_t wide_xbar_quadrant_s1_in_resp_t;
+  typedef axi_a48_d512_i7_u0_resp_t wide_xbar_quadrant_s1_out_resp_t;
+  typedef axi_a48_d512_i4_u0_aw_chan_t wide_xbar_quadrant_s1_in_aw_chan_t;
+  typedef axi_a48_d512_i7_u0_aw_chan_t wide_xbar_quadrant_s1_out_aw_chan_t;
+  typedef axi_a48_d512_i4_u0_w_chan_t wide_xbar_quadrant_s1_in_w_chan_t;
+  typedef axi_a48_d512_i7_u0_w_chan_t wide_xbar_quadrant_s1_out_w_chan_t;
+  typedef axi_a48_d512_i4_u0_b_chan_t wide_xbar_quadrant_s1_in_b_chan_t;
+  typedef axi_a48_d512_i7_u0_b_chan_t wide_xbar_quadrant_s1_out_b_chan_t;
+  typedef axi_a48_d512_i4_u0_ar_chan_t wide_xbar_quadrant_s1_in_ar_chan_t;
+  typedef axi_a48_d512_i7_u0_ar_chan_t wide_xbar_quadrant_s1_out_ar_chan_t;
+  typedef axi_a48_d512_i4_u0_r_chan_t wide_xbar_quadrant_s1_in_r_chan_t;
+  typedef axi_a48_d512_i7_u0_r_chan_t wide_xbar_quadrant_s1_out_r_chan_t;
 
   // verilog_lint: waive parameter-name-style
-  localparam int WIDE_XBAR_QUADRANT_S1_IW_IN = 3;
+  localparam int WIDE_XBAR_QUADRANT_S1_IW_IN = 4;
   // verilog_lint: waive parameter-name-style
-  localparam int WIDE_XBAR_QUADRANT_S1_IW_OUT = 6;
+  localparam int WIDE_XBAR_QUADRANT_S1_IW_OUT = 7;
 
   /// Inputs of the `narrow_xbar_quadrant_s1` crossbar.
   typedef enum int {

--- a/hw/system/occamy/src/occamy_quadrant_s1.sv
+++ b/hw/system/occamy/src/occamy_quadrant_s1.sv
@@ -23,8 +23,8 @@ module occamy_quadrant_s1
     input  logic                     [                  3:0] isolate_i,
     output logic                     [                  3:0] isolated_o,
     // HBI Connection
-    output axi_a48_d512_i6_u0_req_t                          quadrant_hbi_out_req_o,
-    input  axi_a48_d512_i6_u0_resp_t                         quadrant_hbi_out_rsp_i,
+    output axi_a48_d512_i7_u0_req_t                          quadrant_hbi_out_req_o,
+    input  axi_a48_d512_i7_u0_resp_t                         quadrant_hbi_out_rsp_i,
     // Next-Level
     output axi_a48_d64_i4_u0_req_t                           quadrant_narrow_out_req_o,
     input  axi_a48_d64_i4_u0_resp_t                          quadrant_narrow_out_rsp_i,
@@ -66,19 +66,19 @@ module occamy_quadrant_s1
       .Cfg          (WideXbarQuadrantS1Cfg),
       .Connectivity (30'b011111101111110111111011111110),
       .AtopSupport  (0),
-      .slv_aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .mst_aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t     (axi_a48_d512_i3_u0_w_chan_t),
-      .slv_b_chan_t (axi_a48_d512_i3_u0_b_chan_t),
-      .mst_b_chan_t (axi_a48_d512_i6_u0_b_chan_t),
-      .slv_ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .mst_ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .slv_r_chan_t (axi_a48_d512_i3_u0_r_chan_t),
-      .mst_r_chan_t (axi_a48_d512_i6_u0_r_chan_t),
-      .slv_req_t    (axi_a48_d512_i3_u0_req_t),
-      .slv_resp_t   (axi_a48_d512_i3_u0_resp_t),
-      .mst_req_t    (axi_a48_d512_i6_u0_req_t),
-      .mst_resp_t   (axi_a48_d512_i6_u0_resp_t),
+      .slv_aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .mst_aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t     (axi_a48_d512_i4_u0_w_chan_t),
+      .slv_b_chan_t (axi_a48_d512_i4_u0_b_chan_t),
+      .mst_b_chan_t (axi_a48_d512_i7_u0_b_chan_t),
+      .slv_ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .mst_ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .slv_r_chan_t (axi_a48_d512_i4_u0_r_chan_t),
+      .mst_r_chan_t (axi_a48_d512_i7_u0_r_chan_t),
+      .slv_req_t    (axi_a48_d512_i4_u0_req_t),
+      .slv_resp_t   (axi_a48_d512_i4_u0_resp_t),
+      .mst_req_t    (axi_a48_d512_i7_u0_req_t),
+      .mst_resp_t   (axi_a48_d512_i7_u0_resp_t),
       .rule_t       (xbar_rule_48_t)
   ) i_wide_xbar_quadrant_s1 (
       .clk_i                (clk_i),
@@ -238,12 +238,12 @@ module occamy_quadrant_s1
   axi_a48_d512_i3_u0_resp_t wide_cluster_out_iwc_rsp;
 
   axi_id_remap #(
-      .AxiSlvPortIdWidth(6),
+      .AxiSlvPortIdWidth(7),
       .AxiSlvPortMaxUniqIds(4),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(3),
-      .slv_req_t(axi_a48_d512_i6_u0_req_t),
-      .slv_resp_t(axi_a48_d512_i6_u0_resp_t),
+      .slv_req_t(axi_a48_d512_i7_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i7_u0_resp_t),
       .mst_req_t(axi_a48_d512_i3_u0_req_t),
       .mst_resp_t(axi_a48_d512_i3_u0_resp_t)
   ) i_wide_cluster_out_iwc (
@@ -279,18 +279,18 @@ module occamy_quadrant_s1
   ////////////////////
   // HBI Connection //
   ////////////////////
-  axi_a48_d512_i6_u0_req_t  wide_xbar_quadrant_s1_out_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_xbar_quadrant_s1_out_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_xbar_quadrant_s1_out_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_xbar_quadrant_s1_out_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_xbar_quadrant_s1_out_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -331,11 +331,11 @@ module occamy_quadrant_s1
       .AxiSlvPortIdWidth(8),
       .AxiSlvPortMaxUniqIds(4),
       .AxiMaxTxnsPerId(4),
-      .AxiMstPortIdWidth(3),
+      .AxiMstPortIdWidth(4),
       .slv_req_t(axi_a48_d512_i8_u0_req_t),
       .slv_resp_t(axi_a48_d512_i8_u0_resp_t),
-      .mst_req_t(axi_a48_d512_i3_u0_req_t),
-      .mst_resp_t(axi_a48_d512_i3_u0_resp_t)
+      .mst_req_t(axi_a48_d512_i4_u0_req_t),
+      .mst_resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_cluster_in_iwc (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -415,12 +415,12 @@ module occamy_quadrant_s1
   axi_a48_d512_i2_u0_resp_t wide_in_iwc_0_rsp;
 
   axi_id_remap #(
-      .AxiSlvPortIdWidth(6),
+      .AxiSlvPortIdWidth(7),
       .AxiSlvPortMaxUniqIds(4),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(2),
-      .slv_req_t(axi_a48_d512_i6_u0_req_t),
-      .slv_resp_t(axi_a48_d512_i6_u0_resp_t),
+      .slv_req_t(axi_a48_d512_i7_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i7_u0_resp_t),
       .mst_req_t(axi_a48_d512_i2_u0_req_t),
       .mst_resp_t(axi_a48_d512_i2_u0_resp_t)
   ) i_wide_in_iwc_0 (
@@ -451,18 +451,18 @@ module occamy_quadrant_s1
       .mst_req_o(wide_in_iwc_0_cut_req),
       .mst_resp_i(wide_in_iwc_0_cut_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_0_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_0_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_0_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_0_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_0_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -563,12 +563,12 @@ module occamy_quadrant_s1
   axi_a48_d512_i2_u0_resp_t wide_in_iwc_1_rsp;
 
   axi_id_remap #(
-      .AxiSlvPortIdWidth(6),
+      .AxiSlvPortIdWidth(7),
       .AxiSlvPortMaxUniqIds(4),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(2),
-      .slv_req_t(axi_a48_d512_i6_u0_req_t),
-      .slv_resp_t(axi_a48_d512_i6_u0_resp_t),
+      .slv_req_t(axi_a48_d512_i7_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i7_u0_resp_t),
       .mst_req_t(axi_a48_d512_i2_u0_req_t),
       .mst_resp_t(axi_a48_d512_i2_u0_resp_t)
   ) i_wide_in_iwc_1 (
@@ -599,18 +599,18 @@ module occamy_quadrant_s1
       .mst_req_o(wide_in_iwc_1_cut_req),
       .mst_resp_i(wide_in_iwc_1_cut_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_1_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_1_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_1_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_1_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_1_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -711,12 +711,12 @@ module occamy_quadrant_s1
   axi_a48_d512_i2_u0_resp_t wide_in_iwc_2_rsp;
 
   axi_id_remap #(
-      .AxiSlvPortIdWidth(6),
+      .AxiSlvPortIdWidth(7),
       .AxiSlvPortMaxUniqIds(4),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(2),
-      .slv_req_t(axi_a48_d512_i6_u0_req_t),
-      .slv_resp_t(axi_a48_d512_i6_u0_resp_t),
+      .slv_req_t(axi_a48_d512_i7_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i7_u0_resp_t),
       .mst_req_t(axi_a48_d512_i2_u0_req_t),
       .mst_resp_t(axi_a48_d512_i2_u0_resp_t)
   ) i_wide_in_iwc_2 (
@@ -747,18 +747,18 @@ module occamy_quadrant_s1
       .mst_req_o(wide_in_iwc_2_cut_req),
       .mst_resp_i(wide_in_iwc_2_cut_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_2_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_2_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_2_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_2_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_2_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -859,12 +859,12 @@ module occamy_quadrant_s1
   axi_a48_d512_i2_u0_resp_t wide_in_iwc_3_rsp;
 
   axi_id_remap #(
-      .AxiSlvPortIdWidth(6),
+      .AxiSlvPortIdWidth(7),
       .AxiSlvPortMaxUniqIds(4),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(2),
-      .slv_req_t(axi_a48_d512_i6_u0_req_t),
-      .slv_resp_t(axi_a48_d512_i6_u0_resp_t),
+      .slv_req_t(axi_a48_d512_i7_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i7_u0_resp_t),
       .mst_req_t(axi_a48_d512_i2_u0_req_t),
       .mst_resp_t(axi_a48_d512_i2_u0_resp_t)
   ) i_wide_in_iwc_3 (
@@ -895,18 +895,18 @@ module occamy_quadrant_s1
       .mst_req_o(wide_in_iwc_3_cut_req),
       .mst_resp_i(wide_in_iwc_3_cut_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_3_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_3_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_3_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_3_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_3_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -102,36 +102,36 @@ module occamy_top
     /// HBI Ports
     input  axi_a48_d512_i3_u0_req_t  hbi_0_req_i,
     output axi_a48_d512_i3_u0_resp_t hbi_0_rsp_o,
-    output axi_a48_d512_i6_u0_req_t  hbi_0_req_o,
-    input  axi_a48_d512_i6_u0_resp_t hbi_0_rsp_i,
+    output axi_a48_d512_i7_u0_req_t  hbi_0_req_o,
+    input  axi_a48_d512_i7_u0_resp_t hbi_0_rsp_i,
     input  axi_a48_d512_i3_u0_req_t  hbi_1_req_i,
     output axi_a48_d512_i3_u0_resp_t hbi_1_rsp_o,
-    output axi_a48_d512_i6_u0_req_t  hbi_1_req_o,
-    input  axi_a48_d512_i6_u0_resp_t hbi_1_rsp_i,
+    output axi_a48_d512_i7_u0_req_t  hbi_1_req_o,
+    input  axi_a48_d512_i7_u0_resp_t hbi_1_rsp_i,
     input  axi_a48_d512_i3_u0_req_t  hbi_2_req_i,
     output axi_a48_d512_i3_u0_resp_t hbi_2_rsp_o,
-    output axi_a48_d512_i6_u0_req_t  hbi_2_req_o,
-    input  axi_a48_d512_i6_u0_resp_t hbi_2_rsp_i,
+    output axi_a48_d512_i7_u0_req_t  hbi_2_req_o,
+    input  axi_a48_d512_i7_u0_resp_t hbi_2_rsp_i,
     input  axi_a48_d512_i3_u0_req_t  hbi_3_req_i,
     output axi_a48_d512_i3_u0_resp_t hbi_3_rsp_o,
-    output axi_a48_d512_i6_u0_req_t  hbi_3_req_o,
-    input  axi_a48_d512_i6_u0_resp_t hbi_3_rsp_i,
+    output axi_a48_d512_i7_u0_req_t  hbi_3_req_o,
+    input  axi_a48_d512_i7_u0_resp_t hbi_3_rsp_i,
     input  axi_a48_d512_i3_u0_req_t  hbi_4_req_i,
     output axi_a48_d512_i3_u0_resp_t hbi_4_rsp_o,
-    output axi_a48_d512_i6_u0_req_t  hbi_4_req_o,
-    input  axi_a48_d512_i6_u0_resp_t hbi_4_rsp_i,
+    output axi_a48_d512_i7_u0_req_t  hbi_4_req_o,
+    input  axi_a48_d512_i7_u0_resp_t hbi_4_rsp_i,
     input  axi_a48_d512_i3_u0_req_t  hbi_5_req_i,
     output axi_a48_d512_i3_u0_resp_t hbi_5_rsp_o,
-    output axi_a48_d512_i6_u0_req_t  hbi_5_req_o,
-    input  axi_a48_d512_i6_u0_resp_t hbi_5_rsp_i,
+    output axi_a48_d512_i7_u0_req_t  hbi_5_req_o,
+    input  axi_a48_d512_i7_u0_resp_t hbi_5_rsp_i,
     input  axi_a48_d512_i3_u0_req_t  hbi_6_req_i,
     output axi_a48_d512_i3_u0_resp_t hbi_6_rsp_o,
-    output axi_a48_d512_i6_u0_req_t  hbi_6_req_o,
-    input  axi_a48_d512_i6_u0_resp_t hbi_6_rsp_i,
+    output axi_a48_d512_i7_u0_req_t  hbi_6_req_o,
+    input  axi_a48_d512_i7_u0_resp_t hbi_6_rsp_i,
     input  axi_a48_d512_i3_u0_req_t  hbi_7_req_i,
     output axi_a48_d512_i3_u0_resp_t hbi_7_rsp_o,
-    output axi_a48_d512_i6_u0_req_t  hbi_7_req_o,
-    input  axi_a48_d512_i6_u0_resp_t hbi_7_rsp_i,
+    output axi_a48_d512_i7_u0_req_t  hbi_7_req_o,
+    input  axi_a48_d512_i7_u0_resp_t hbi_7_rsp_i,
 
     /// PCIe Ports
     output axi_a48_d512_i8_u0_req_t  pcie_axi_req_o,
@@ -625,21 +625,21 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_S1_QUADRANT_0]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_S1_QUADRANT_0])
   );
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_0_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_0_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_0_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_0_rsp;
 
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_0_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_0_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_0_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_0_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_hbi_out_cut_0_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -760,21 +760,21 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_S1_QUADRANT_1]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_S1_QUADRANT_1])
   );
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_1_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_1_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_1_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_1_rsp;
 
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_1_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_1_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_1_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_1_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_hbi_out_cut_1_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -895,21 +895,21 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_S1_QUADRANT_2]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_S1_QUADRANT_2])
   );
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_2_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_2_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_2_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_2_rsp;
 
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_2_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_2_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_2_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_2_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_hbi_out_cut_2_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1030,21 +1030,21 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_S1_QUADRANT_3]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_S1_QUADRANT_3])
   );
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_3_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_3_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_3_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_3_rsp;
 
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_3_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_3_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_3_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_3_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_hbi_out_cut_3_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1165,21 +1165,21 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_S1_QUADRANT_4]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_S1_QUADRANT_4])
   );
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_4_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_4_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_4_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_4_rsp;
 
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_4_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_4_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_4_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_4_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_hbi_out_cut_4_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1300,21 +1300,21 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_S1_QUADRANT_5]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_S1_QUADRANT_5])
   );
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_5_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_5_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_5_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_5_rsp;
 
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_5_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_5_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_5_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_5_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_hbi_out_cut_5_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1435,21 +1435,21 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_S1_QUADRANT_6]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_S1_QUADRANT_6])
   );
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_6_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_6_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_6_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_6_rsp;
 
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_6_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_6_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_6_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_6_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_hbi_out_cut_6_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1570,21 +1570,21 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_S1_QUADRANT_7]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_S1_QUADRANT_7])
   );
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_7_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_7_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_7_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_7_rsp;
 
-  axi_a48_d512_i6_u0_req_t  wide_hbi_out_cut_7_cut_req;
-  axi_a48_d512_i6_u0_resp_t wide_hbi_out_cut_7_cut_rsp;
+  axi_a48_d512_i7_u0_req_t  wide_hbi_out_cut_7_cut_req;
+  axi_a48_d512_i7_u0_resp_t wide_hbi_out_cut_7_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i6_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i6_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i6_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i6_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i6_u0_r_chan_t),
-      .req_t(axi_a48_d512_i6_u0_req_t),
-      .resp_t(axi_a48_d512_i6_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i7_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i7_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i7_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i7_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i7_u0_r_chan_t),
+      .req_t(axi_a48_d512_i7_u0_req_t),
+      .resp_t(axi_a48_d512_i7_u0_resp_t)
   ) i_wide_hbi_out_cut_7_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),

--- a/util/occamygen.py
+++ b/util/occamygen.py
@@ -321,7 +321,7 @@ def main():
     wide_xbar_quadrant_s1 = solder.AxiXbar(
         48,
         512,
-        3,  # TODO: Source from JSON description
+        4,  # TODO: Source from JSON description
         name="wide_xbar_quadrant_s1",
         clk="clk_i",
         rst="rst_ni",


### PR DESCRIPTION
Now that we have the wide DMA port it (can) make sense to actually
perform icache refills from that port, this potentially cuts down the
re-fill latency a couple of cycles.

More importantly, in case there is a read-only cache on the wide
network, it makes use of the same.

(Based on #191)