### PR TITLE
Fix CSR wfi

### DIFF
--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -722,14 +722,14 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
         opb_select = None;
         rd_select = RdBypass;
         rd_bypass = csr_rvalue;
-        csr_en = 1'b1;
+        csr_en = valid_instr;
       end
       CSRRWI: begin
         opa_select = CSRImmmediate;
         opb_select = None;
         rd_select = RdBypass;
         rd_bypass = csr_rvalue;
-        csr_en = 1'b1;
+        csr_en = valid_instr;
       end
       CSRRS: begin  // Atomic Read and Set Bits in CSR
           alu_op = LOr;
@@ -737,7 +737,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
           opb_select = CSR;
           rd_select = RdBypass;
           rd_bypass = csr_rvalue;
-          csr_en = 1'b1;
+          csr_en = valid_instr;
       end
       CSRRSI: begin
         // offload CSR enable to FP SS
@@ -747,7 +747,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
           opb_select = CSR;
           rd_select = RdBypass;
           rd_bypass = csr_rvalue;
-          csr_en = 1'b1;
+          csr_en = valid_instr;
         end else begin
           write_rd = 1'b0;
           acc_qvalid_o = valid_instr;
@@ -759,7 +759,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
         opb_select = CSR;
         rd_select = RdBypass;
         rd_bypass = csr_rvalue;
-        csr_en = 1'b1;
+        csr_en = valid_instr;
       end
       CSRRCI: begin
         if (inst_data_i[31:20] != CSR_SSR) begin
@@ -768,7 +768,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
           opb_select = CSR;
           rd_select = RdBypass;
           rd_bypass = csr_rvalue;
-          csr_en = 1'b1;
+          csr_en = valid_instr;
         end else begin
           write_rd = 1'b0;
           acc_qvalid_o = valid_instr;

--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -2057,7 +2057,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
     end
     // Right now we skip this due to simplicity.
-    if (csr_en) begin
+    if (csr_en && !wfi_q) begin
       // Check privilege level.
       if ((priv_lvl_q & inst_data_i[29:28]) == inst_data_i[29:28]) begin
         unique case (inst_data_i[31:20])

--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -2057,7 +2057,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       end
     end
     // Right now we skip this due to simplicity.
-    if (csr_en && !wfi_q) begin
+    if (csr_en) begin
       // Check privilege level.
       if ((priv_lvl_q & inst_data_i[29:28]) == inst_data_i[29:28]) begin
         unique case (inst_data_i[31:20])

--- a/hw/ip/snitch/src/snitch_pkg.sv
+++ b/hw/ip/snitch/src/snitch_pkg.sv
@@ -177,6 +177,7 @@ package snitch_pkg;
   typedef struct packed {
     longint source;
     longint stall;
+    longint exception;
     longint rs1;
     longint rs2;
     longint rd;
@@ -209,6 +210,7 @@ package snitch_pkg;
     string extras_str = "{";
     extras_str = $sformatf("%s'%s': 0x%0x, ", extras_str, "source", snitch_trace.source);
     extras_str = $sformatf("%s'%s': 0x%0x, ", extras_str, "stall", snitch_trace.stall);
+    extras_str = $sformatf("%s'%s': 0x%0x, ", extras_str, "exception", snitch_trace.exception);
     extras_str = $sformatf("%s'%s': 0x%0x, ", extras_str, "rs1", snitch_trace.rs1);
     extras_str = $sformatf("%s'%s': 0x%0x, ", extras_str, "rs2", snitch_trace.rs2);
     extras_str = $sformatf("%s'%s': 0x%0x, ", extras_str, "rd", snitch_trace.rd);

--- a/hw/ip/snitch_cluster/src/snitch_cc.sv
+++ b/hw/ip/snitch_cluster/src/snitch_cc.sv
@@ -772,6 +772,7 @@ module snitch_cc #(
           // State
           source:       snitch_pkg::SrcSnitch,
           stall:        i_snitch.stall,
+          exception:    i_snitch.exception,
           // Decoding
           rs1:          i_snitch.rs1,
           rs2:          i_snitch.rs2,

--- a/util/gen_trace.py
+++ b/util/gen_trace.py
@@ -478,6 +478,9 @@ def annotate_snitch(extras: dict,
     if annot_fseq_offl and extras['fpu_offload']:
         target_name = 'FSEQ' if extras['is_seq_insn'] else 'FPSS'
         ret.append('{} <~~ 0x{:08x}'.format(target_name, pc))
+    # If exception, annotate
+    if not (extras['stall']) and extras['exception']:
+        ret.append('exception')
     # Regular linear datapath operation
     if not (extras['stall'] or extras['fpu_offload']):
         # Operand registers


### PR DESCRIPTION
This specific sequence of instructions

```assembly
1: csrrsi	a0, mstatus, 8 # enable interrupts
2: wfi
3: csrrci	a0, mstatus, 8 # disable interrupts
```

Causes the core to sleep after `2` but immediately afterwards clears the interrupt enable from instruction `3`. Not sure if this is the right fix but it works for this problem

Before
![irq-broken](https://user-images.githubusercontent.com/3391933/128690824-8eb229cf-7866-45e0-bb57-8e8f6477def1.png)

After
![irq-fixed](https://user-images.githubusercontent.com/3391933/128690834-f9f45442-cdef-42fd-988d-c74e07cc7253.png)
