### PR TITLE
ci: Fix editorconfig-checker version

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -4,7 +4,7 @@
 
 bin2coe
 dataclasses
-editorconfig-checker
+editorconfig-checker==2.3.51
 flake8
 gitpython
 hjson


### PR DESCRIPTION
In `2.3.52` the binray name changed to `ec`. This fixes the version used to mitigate further CI lint problems