### PR TITLE
occamy: Provide wide to narrow connection

### DIFF
--- a/hw/system/occamy/src/occamy_pkg.sv
+++ b/hw/system/occamy/src/occamy_pkg.sv
@@ -221,6 +221,7 @@ package occamy_pkg;
     SOC_WIDE_XBAR_OUT_HBM_5,
     SOC_WIDE_XBAR_OUT_HBM_6,
     SOC_WIDE_XBAR_OUT_HBM_7,
+    SOC_WIDE_XBAR_OUT_SOC_NARROW,
     SOC_WIDE_XBAR_OUT_PCIE,
     SOC_WIDE_XBAR_NUM_OUTPUTS
   } soc_wide_xbar_outputs_e;
@@ -237,7 +238,7 @@ package occamy_pkg;
   AxiIdUsedSlvPorts:  3,
   AxiAddrWidth:       48,
   AxiDataWidth:       512,
-  NoAddrRules:        19
+  NoAddrRules:        21
 };
 
   // AXI bus with 48 bit address, 512 bit data, 3 bit IDs, and 0 bit user data.
@@ -279,6 +280,7 @@ package occamy_pkg;
     SOC_NARROW_XBAR_IN_S1_QUADRANT_6,
     SOC_NARROW_XBAR_IN_S1_QUADRANT_7,
     SOC_NARROW_XBAR_IN_CVA6,
+    SOC_NARROW_XBAR_IN_SOC_WIDE,
     SOC_NARROW_XBAR_NUM_INPUTS
   } soc_narrow_xbar_inputs_e;
 
@@ -467,6 +469,10 @@ package occamy_pkg;
 
   // AXI bus with 48 bit address, 64 bit data, 3 bit IDs, and 0 bit user data.
   `AXI_TYPEDEF_ALL(axi_a48_d64_i3_u0, logic [47:0], logic [2:0], logic [63:0], logic [7:0],
+                   logic [0:0])
+
+  // AXI bus with 48 bit address, 512 bit data, 4 bit IDs, and 0 bit user data.
+  `AXI_TYPEDEF_ALL(axi_a48_d512_i4_u0, logic [47:0], logic [3:0], logic [511:0], logic [63:0],
                    logic [0:0])
 
   // AXI bus with 48 bit address, 64 bit data, 1 bit IDs, and 0 bit user data.

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -249,7 +249,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   );
 
   /// Address map of the `soc_wide_xbar` crossbar.
-  xbar_rule_48_t [18:0] SocWideXbarAddrmap;
+  xbar_rule_48_t [20:0] SocWideXbarAddrmap;
   assign SocWideXbarAddrmap = '{
   '{ idx: 8, start_addr: 48'h80000000, end_addr: 48'hc0000000 },
   '{ idx: 8, start_addr: 48'h1000000000, end_addr: 48'h1040000000 },
@@ -261,7 +261,9 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   '{ idx: 13, start_addr: 48'h1140000000, end_addr: 48'h1180000000 },
   '{ idx: 14, start_addr: 48'h1180000000, end_addr: 48'h11c0000000 },
   '{ idx: 15, start_addr: 48'h11c0000000, end_addr: 48'h1200000000 },
-  '{ idx: 16, start_addr: 48'h20000000, end_addr: 48'h70000000 },
+  '{ idx: 16, start_addr: 48'h00000000, end_addr: 48'h10000000 },
+  '{ idx: 16, start_addr: 48'h70000000, end_addr: 48'h70020000 },
+  '{ idx: 17, start_addr: 48'h20000000, end_addr: 48'h70000000 },
   '{ idx: 0, start_addr: s1_quadrant_base_addr[0], end_addr: s1_quadrant_base_addr[0] + S1QuadrantAddressSpace },
   '{ idx: 1, start_addr: s1_quadrant_base_addr[1], end_addr: s1_quadrant_base_addr[1] + S1QuadrantAddressSpace },
   '{ idx: 2, start_addr: s1_quadrant_base_addr[2], end_addr: s1_quadrant_base_addr[2] + S1QuadrantAddressSpace },
@@ -274,12 +276,12 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
   soc_wide_xbar_in_req_t   [17:0] soc_wide_xbar_in_req;
   soc_wide_xbar_in_resp_t  [17:0] soc_wide_xbar_in_rsp;
-  soc_wide_xbar_out_req_t  [16:0] soc_wide_xbar_out_req;
-  soc_wide_xbar_out_resp_t [16:0] soc_wide_xbar_out_rsp;
+  soc_wide_xbar_out_req_t  [17:0] soc_wide_xbar_out_req;
+  soc_wide_xbar_out_resp_t [17:0] soc_wide_xbar_out_rsp;
 
   axi_xbar #(
       .Cfg(SocWideXbarCfg),
-      .Connectivity  ( 306'b011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110111111111111111110111111111111111110111111111111111110111111111111111110111111111111111110111111111111111110111111111111111110 ),
+      .Connectivity  ( 324'b011111111111111111101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111101111111111111111110111111111111111111011111111111111111101111111111111111110111111111111111111011111111111111111101111111111111111110 ),
       .AtopSupport(0),
       .slv_aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
       .mst_aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
@@ -326,14 +328,14 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   '{ idx: 7, start_addr: s1_quadrant_base_addr[7], end_addr: s1_quadrant_base_addr[7] + S1QuadrantAddressSpace }
 };
 
-  soc_narrow_xbar_in_req_t   [ 8:0] soc_narrow_xbar_in_req;
-  soc_narrow_xbar_in_resp_t  [ 8:0] soc_narrow_xbar_in_rsp;
+  soc_narrow_xbar_in_req_t   [ 9:0] soc_narrow_xbar_in_req;
+  soc_narrow_xbar_in_resp_t  [ 9:0] soc_narrow_xbar_in_rsp;
   soc_narrow_xbar_out_req_t  [11:0] soc_narrow_xbar_out_req;
   soc_narrow_xbar_out_resp_t [11:0] soc_narrow_xbar_out_rsp;
 
   axi_xbar #(
       .Cfg(SocNarrowXbarCfg),
-      .Connectivity  ( 108'b111111111111111101111111111110111111111111011111111111101111111111110111111111111011111111111101111111111110 ),
+      .Connectivity  ( 120'b101111111111111111111111111101111111111110111111111111011111111111101111111111110111111111111011111111111101111111111110 ),
       .AtopSupport(1),
       .slv_aw_chan_t(axi_a48_d64_i4_u0_aw_chan_t),
       .mst_aw_chan_t(axi_a48_d64_i8_u0_aw_chan_t),
@@ -515,6 +517,56 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .slv_resp_o(soc_narrow_wide_amo_adapter_rsp),
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_SOC_NARROW]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_SOC_NARROW])
+  );
+
+
+
+  /////////////////////////////
+  // Wide to Narrow Crossbar //
+  /////////////////////////////
+  axi_a48_d512_i4_u0_req_t  soc_wide_narrow_iwc_req;
+  axi_a48_d512_i4_u0_resp_t soc_wide_narrow_iwc_rsp;
+
+  axi_id_remap #(
+      .AxiSlvPortIdWidth(8),
+      .AxiSlvPortMaxUniqIds(4),
+      .AxiMaxTxnsPerId(4),
+      .AxiMstPortIdWidth(4),
+      .slv_req_t(axi_a48_d512_i8_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i8_u0_resp_t),
+      .mst_req_t(axi_a48_d512_i4_u0_req_t),
+      .mst_resp_t(axi_a48_d512_i4_u0_resp_t)
+  ) i_soc_wide_narrow_iwc (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(soc_wide_xbar_out_req[SOC_WIDE_XBAR_OUT_SOC_NARROW]),
+      .slv_resp_o(soc_wide_xbar_out_rsp[SOC_WIDE_XBAR_OUT_SOC_NARROW]),
+      .mst_req_o(soc_wide_narrow_iwc_req),
+      .mst_resp_i(soc_wide_narrow_iwc_rsp)
+  );
+  axi_dw_converter #(
+      .AxiSlvPortDataWidth(512),
+      .AxiMstPortDataWidth(64),
+      .AxiAddrWidth(48),
+      .AxiIdWidth(4),
+      .aw_chan_t(axi_a48_d64_i4_u0_aw_chan_t),
+      .mst_w_chan_t(axi_a48_d64_i4_u0_w_chan_t),
+      .slv_w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d64_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d64_i4_u0_ar_chan_t),
+      .mst_r_chan_t(axi_a48_d64_i4_u0_r_chan_t),
+      .slv_r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .axi_mst_req_t(axi_a48_d64_i4_u0_req_t),
+      .axi_mst_resp_t(axi_a48_d64_i4_u0_resp_t),
+      .axi_slv_req_t(axi_a48_d512_i4_u0_req_t),
+      .axi_slv_resp_t(axi_a48_d512_i4_u0_resp_t)
+  ) i_soc_wide_narrow_dw (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(soc_wide_narrow_iwc_req),
+      .slv_resp_o(soc_wide_narrow_iwc_rsp),
+      .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_SOC_WIDE]),
+      .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_SOC_WIDE])
   );
 
 

--- a/hw/system/occamy/src/occamy_top.sv.tpl
+++ b/hw/system/occamy/src/occamy_top.sv.tpl
@@ -142,9 +142,18 @@ module occamy_top
   // Narrow to Wide Crossbar //
   /////////////////////////////
   <% soc_narrow_xbar.out_soc_wide \
-        .change_iw(context, 3, "soc_narrow_wide_iwc") \
+        .change_iw(context, soc_wide_xbar.in_soc_narrow.iw, "soc_narrow_wide_iwc") \
         .atomic_adapter(context, 16, "soc_narrow_wide_amo_adapter") \
-        .change_dw(context, 512, "soc_narrow_wide_dw", to=soc_wide_xbar.in_soc_narrow)
+        .change_dw(context, soc_wide_xbar.in_soc_narrow.dw, "soc_narrow_wide_dw", to=soc_wide_xbar.in_soc_narrow)
+  %>
+
+  /////////////////////////////
+  // Wide to Narrow Crossbar //
+  /////////////////////////////
+  <%
+    soc_wide_xbar.out_soc_narrow \
+      .change_iw(context, soc_narrow_xbar.in_soc_wide.iw, "soc_wide_narrow_iwc") \
+      .change_dw(context, soc_narrow_xbar.in_soc_wide.dw, "soc_wide_narrow_dw", to=soc_narrow_xbar.in_soc_wide)
   %>
 
   //////////

--- a/util/occamygen.py
+++ b/util/occamygen.py
@@ -106,7 +106,10 @@ def main():
     nr_s1_quadrants = occamy.cfg["nr_s1_quadrant"]
     nr_s1_clusters = occamy.cfg["s1_quadrant"]["nr_clusters"]
     # Iterate over Hives to get the number of cores.
-    nr_cluster_cores = len([core for hive in occamy.cfg["cluster"]["hives"] for core in hive["cores"]])
+    nr_cluster_cores = len([
+        core for hive in occamy.cfg["cluster"]["hives"]
+        for core in hive["cores"]
+    ])
 
     if not args.outdir.is_dir():
         exit("Out directory is not a valid path.")
@@ -189,7 +192,8 @@ def main():
     am_pcie = am.new_leaf("pcie", 0x28000000, 0x20000000,
                           0x48000000).attach_to(am_soc_wide_xbar)
 
-    am_spm = am.new_leaf("spm", occamy.cfg["spm"]["length"], occamy.cfg["spm"]["address"])
+    am_spm = am.new_leaf("spm", occamy.cfg["spm"]["length"],
+                         occamy.cfg["spm"]["address"])
 
     # HBM
     am_hbm = list()
@@ -293,7 +297,6 @@ def main():
     # TODO(zarubaf): PCIe should probably go into the small crossbar.
     soc_wide_xbar.add_input("pcie")
     soc_wide_xbar.add_output_entry("pcie", am_pcie)
-
 
     ###################
     # SoC Narrow Xbar #

--- a/util/occamygen.py
+++ b/util/occamygen.py
@@ -212,6 +212,8 @@ def main():
     am_soc_narrow_xbar.attach(am_soc_wide_xbar)
     am_soc_narrow_xbar.attach(am_spm)
 
+    am_soc_wide_xbar.attach(am_soc_narrow_xbar)
+
     # HBI
     am_hbi = am.new_leaf("hbi", 0x10000000000,
                          0x10000000000).attach_to(am_wide_xbar_quadrant_s1)
@@ -286,10 +288,12 @@ def main():
         soc_wide_xbar.add_input("hbi_{}".format(i))
 
     soc_wide_xbar.add_input("soc_narrow")
+    soc_wide_xbar.add_output_entry("soc_narrow", am_soc_narrow_xbar)
 
     # TODO(zarubaf): PCIe should probably go into the small crossbar.
     soc_wide_xbar.add_input("pcie")
     soc_wide_xbar.add_output_entry("pcie", am_pcie)
+
 
     ###################
     # SoC Narrow Xbar #
@@ -310,6 +314,7 @@ def main():
         soc_narrow_xbar.add_input("s1_quadrant_{}".format(i))
 
     soc_narrow_xbar.add_input("cva6")
+    soc_narrow_xbar.add_input("soc_wide")
     dts.add_cpu("eth,ariane")
 
     soc_narrow_xbar.add_output_entry("periph", am_soc_axi_lite_periph_xbar)


### PR DESCRIPTION
As discussed in #192 the missing wide to narrow connection makes it impossible for the Snitch clusters to fetch from the bootrom. This PR fixes that issue and should probably go before #192.