### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 # Run functional regression checks
 name: ci
-on: [push]
+on: [push, pull_request]
 
 jobs:
   ###########


### PR DESCRIPTION
I propose that we run the CI on pull requests so that PRs from external repositories also run the CI (e.g. #174 )