### PR TITLE
occamy: Chip simulation fixes

### DIFF
--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -1989,6 +1989,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
                    | (dtlb_page_fault & dtlb_trans_valid)
                    | (itlb_page_fault & itlb_trans_valid);
 
+  `ifndef VCS
   // pragma translate_off
   always_ff @(posedge clk_i) begin
     if (!rst_i && illegal_inst && valid_instr) begin
@@ -1997,6 +1998,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
     end
   end
   // pragma translate_on
+  `endif
 
   assign meip = irq_i.meip & eie_q[M];
   assign mtip = irq_i.mtip & tie_q[M];

--- a/hw/system/occamy/src/memories.json
+++ b/hw/system/occamy/src/memories.json
@@ -17,6 +17,19 @@
         "byte_width": 8,
         "density_optimized": false,
         "description": [
+            "cva6 instruction cache array"
+        ],
+        "latency": 1,
+        "ports": 1,
+        "speed_optimized": true,
+        "width": 128,
+        "words": 256
+    },
+    {
+        "byte_enable": true,
+        "byte_width": 8,
+        "density_optimized": false,
+        "description": [
             "cva6 instruction cache tag"
         ],
         "latency": 1,
@@ -30,7 +43,7 @@
         "byte_width": 8,
         "density_optimized": false,
         "description": [
-            "cva6 instruction/data cache array"
+            "cva6 data cache array"
         ],
         "latency": 1,
         "ports": 1,

--- a/hw/vendor/openhwgroup_cva6/src/util/instr_tracer.sv
+++ b/hw/vendor/openhwgroup_cva6/src/util/instr_tracer.sv
@@ -140,10 +140,12 @@ module instr_tracer (
       // --------------
       // Exceptions
       // --------------
+      `ifndef VCS
       if (tracer_if.pck.exception.valid && !(tracer_if.pck.debug_mode && tracer_if.pck.exception.cause == riscv::BREAKPOINT)) begin
         // print exception
         printException(tracer_if.pck.commit_instr[0].pc, tracer_if.pck.exception.cause, tracer_if.pck.exception.tval);
       end
+      `endif
       // ----------------------
       // Commit Registers
       // ----------------------

--- a/hw/vendor/patches/openhwgroup_cva6/0007-occamy-Chip-simulation-fixes.patch
+++ b/hw/vendor/patches/openhwgroup_cva6/0007-occamy-Chip-simulation-fixes.patch
@@ -1,0 +1,29 @@
+From 31d9656fc1594bc87a7285e9e30f1e9556d038aa Mon Sep 17 00:00:00 2001
+From: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+Date: Mon, 23 Aug 2021 16:19:27 +0200
+Subject: [PATCH] occamy: Chip simulation fixes
+
+---
+ src/util/instr_tracer.sv | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/util/instr_tracer.sv b/src/util/instr_tracer.sv
+index 2fbe781..6d9c860 100644
+--- a/src/util/instr_tracer.sv
++++ b/src/util/instr_tracer.sv
+@@ -140,10 +140,12 @@ module instr_tracer (
+       // --------------
+       // Exceptions
+       // --------------
++      `ifndef VCS
+       if (tracer_if.pck.exception.valid && !(tracer_if.pck.debug_mode && tracer_if.pck.exception.cause == riscv::BREAKPOINT)) begin
+         // print exception
+         printException(tracer_if.pck.commit_instr[0].pc, tracer_if.pck.exception.cause, tracer_if.pck.exception.tval);
+       end
++      `endif
+       // ----------------------
+       // Commit Registers
+       // ----------------------
+-- 
+2.25.1.377.g2d2118b814
+

--- a/util/clustergen/occamy.py
+++ b/util/clustergen/occamy.py
@@ -48,7 +48,13 @@ class Occamy(Generator):
         # CVA6
         self.cluster.add_mem(256,
                              512,
-                             desc="cva6 instruction/data cache array",
+                             desc="cva6 data cache array",
+                             byte_enable=True,
+                             speed_optimized=True,
+                             density_optimized=False)
+        self.cluster.add_mem(256,
+                             128,
+                             desc="cva6 instruction cache array",
                              byte_enable=True,
                              speed_optimized=True,
                              density_optimized=False)


### PR DESCRIPTION
Apparently, there is some kind of race condition in the `display` in VCS. I didn't yet have the time to properly debug this and suggest disabling this (since it is only a problem with the async triggered exceptions).