### PR TITLE
occamy: Move SPM from narrow to wide crossbar

### DIFF
--- a/hw/system/occamy/src/occamy_pkg.sv
+++ b/hw/system/occamy/src/occamy_pkg.sv
@@ -226,6 +226,7 @@ package occamy_pkg;
     SOC_WIDE_XBAR_OUT_HBM_7,
     SOC_WIDE_XBAR_OUT_SOC_NARROW,
     SOC_WIDE_XBAR_OUT_PCIE,
+    SOC_WIDE_XBAR_OUT_SPM,
     SOC_WIDE_XBAR_NUM_OUTPUTS
   } soc_wide_xbar_outputs_e;
 
@@ -298,7 +299,6 @@ package occamy_pkg;
     SOC_NARROW_XBAR_OUT_S1_QUADRANT_6,
     SOC_NARROW_XBAR_OUT_S1_QUADRANT_7,
     SOC_NARROW_XBAR_OUT_PERIPH,
-    SOC_NARROW_XBAR_OUT_SPM,
     SOC_NARROW_XBAR_OUT_SOC_WIDE,
     SOC_NARROW_XBAR_OUT_REGBUS_PERIPH,
     SOC_NARROW_XBAR_NUM_OUTPUTS
@@ -316,7 +316,7 @@ package occamy_pkg;
   AxiIdUsedSlvPorts:  4,
   AxiAddrWidth:       48,
   AxiDataWidth:       64,
-  NoAddrRules:        13
+  NoAddrRules:        12
 };
 
   // AXI bus with 48 bit address, 64 bit data, 4 bit IDs, and 0 bit user data.
@@ -478,8 +478,8 @@ package occamy_pkg;
   `AXI_TYPEDEF_ALL(axi_a48_d64_i3_u0, logic [47:0], logic [2:0], logic [63:0], logic [7:0],
                    logic [0:0])
 
-  // AXI bus with 48 bit address, 64 bit data, 1 bit IDs, and 0 bit user data.
-  `AXI_TYPEDEF_ALL(axi_a48_d64_i1_u0, logic [47:0], logic [0:0], logic [63:0], logic [7:0],
+  // AXI bus with 48 bit address, 512 bit data, 1 bit IDs, and 0 bit user data.
+  `AXI_TYPEDEF_ALL(axi_a48_d512_i1_u0, logic [47:0], logic [0:0], logic [511:0], logic [63:0],
                    logic [0:0])
 
   // AXI bus with 48 bit address, 32 bit data, 8 bit IDs, and 0 bit user data.

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -149,8 +149,8 @@ module occamy_top
 
 
   typedef logic [16:0] mem_addr_t;
-  typedef logic [63:0] mem_data_t;
-  typedef logic [7:0] mem_strb_t;
+  typedef logic [511:0] mem_data_t;
+  typedef logic [63:0] mem_strb_t;
 
   logic spm_req, spm_gnt, spm_we, spm_rvalid;
   logic [1:0] spm_rerror;
@@ -277,12 +277,12 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
   soc_wide_xbar_in_req_t   [17:0] soc_wide_xbar_in_req;
   soc_wide_xbar_in_resp_t  [17:0] soc_wide_xbar_in_rsp;
-  soc_wide_xbar_out_req_t  [17:0] soc_wide_xbar_out_req;
-  soc_wide_xbar_out_resp_t [17:0] soc_wide_xbar_out_rsp;
+  soc_wide_xbar_out_req_t  [18:0] soc_wide_xbar_out_req;
+  soc_wide_xbar_out_resp_t [18:0] soc_wide_xbar_out_rsp;
 
   axi_xbar #(
       .Cfg(SocWideXbarCfg),
-      .Connectivity  ( 324'b011111111111111111101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111101111111111111111110111111111111111111011111111111111111101111111111111111110111111111111111111011111111111111111101111111111111111110 ),
+      .Connectivity  ( 342'b101111111111111111111011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111011111111111111111110111111111111111111101111111111111111111011111111111111111110111111111111111111101111111111111111111011111111111111111110 ),
       .AtopSupport(0),
       .slv_aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
       .mst_aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
@@ -312,13 +312,12 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   );
 
   /// Address map of the `soc_narrow_xbar` crossbar.
-  xbar_rule_48_t [12:0] SocNarrowXbarAddrmap;
+  xbar_rule_48_t [11:0] SocNarrowXbarAddrmap;
   assign SocNarrowXbarAddrmap = '{
   '{ idx: 8, start_addr: 48'h00000000, end_addr: 48'h00001000 },
-  '{ idx: 9, start_addr: 48'h70000000, end_addr: 48'h70020000 },
-  '{ idx: 10, start_addr: 48'h20000000, end_addr: 48'h70000000 },
-  '{ idx: 10, start_addr: 48'h80000000, end_addr: 48'h1200000000 },
-  '{ idx: 11, start_addr: 48'h01000000, end_addr: 48'h10000000 },
+  '{ idx: 9, start_addr: 48'h20000000, end_addr: 48'h70000000 },
+  '{ idx: 9, start_addr: 48'h80000000, end_addr: 48'h1200000000 },
+  '{ idx: 10, start_addr: 48'h01000000, end_addr: 48'h10000000 },
   '{ idx: 0, start_addr: s1_quadrant_base_addr[0], end_addr: s1_quadrant_base_addr[0] + S1QuadrantAddressSpace },
   '{ idx: 1, start_addr: s1_quadrant_base_addr[1], end_addr: s1_quadrant_base_addr[1] + S1QuadrantAddressSpace },
   '{ idx: 2, start_addr: s1_quadrant_base_addr[2], end_addr: s1_quadrant_base_addr[2] + S1QuadrantAddressSpace },
@@ -331,12 +330,12 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
   soc_narrow_xbar_in_req_t   [ 9:0] soc_narrow_xbar_in_req;
   soc_narrow_xbar_in_resp_t  [ 9:0] soc_narrow_xbar_in_rsp;
-  soc_narrow_xbar_out_req_t  [11:0] soc_narrow_xbar_out_req;
-  soc_narrow_xbar_out_resp_t [11:0] soc_narrow_xbar_out_rsp;
+  soc_narrow_xbar_out_req_t  [10:0] soc_narrow_xbar_out_req;
+  soc_narrow_xbar_out_resp_t [10:0] soc_narrow_xbar_out_rsp;
 
   axi_xbar #(
       .Cfg(SocNarrowXbarCfg),
-      .Connectivity  ( 120'b101111111111111111111111111101111111111110111111111111011111111111101111111111110111111111111011111111111101111111111110 ),
+      .Connectivity  ( 110'b10111111111111111111111110111111111110111111111110111111111110111111111110111111111110111111111110111111111110 ),
       .AtopSupport(1),
       .slv_aw_chan_t(axi_a48_d64_i4_u0_aw_chan_t),
       .mst_aw_chan_t(axi_a48_d64_i8_u0_aw_chan_t),
@@ -1680,31 +1679,31 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   //////////
   // SPM //
   //////////
-  axi_a48_d64_i8_u0_req_t  spm_cdc_req;
-  axi_a48_d64_i8_u0_resp_t spm_cdc_rsp;
+  axi_a48_d512_i8_u0_req_t  spm_cdc_req;
+  axi_a48_d512_i8_u0_resp_t spm_cdc_rsp;
 
   axi_cdc #(
-      .aw_chan_t (axi_a48_d64_i8_u0_aw_chan_t),
-      .w_chan_t  (axi_a48_d64_i8_u0_w_chan_t),
-      .b_chan_t  (axi_a48_d64_i8_u0_b_chan_t),
-      .ar_chan_t (axi_a48_d64_i8_u0_ar_chan_t),
-      .r_chan_t  (axi_a48_d64_i8_u0_r_chan_t),
-      .axi_req_t (axi_a48_d64_i8_u0_req_t),
-      .axi_resp_t(axi_a48_d64_i8_u0_resp_t),
+      .aw_chan_t (axi_a48_d512_i8_u0_aw_chan_t),
+      .w_chan_t  (axi_a48_d512_i8_u0_w_chan_t),
+      .b_chan_t  (axi_a48_d512_i8_u0_b_chan_t),
+      .ar_chan_t (axi_a48_d512_i8_u0_ar_chan_t),
+      .r_chan_t  (axi_a48_d512_i8_u0_r_chan_t),
+      .axi_req_t (axi_a48_d512_i8_u0_req_t),
+      .axi_resp_t(axi_a48_d512_i8_u0_resp_t),
       .LogDepth  (2)
   ) i_spm_cdc (
       .src_clk_i (clk_i),
       .src_rst_ni(rst_ni),
-      .src_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM]),
-      .src_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM]),
+      .src_req_i (soc_wide_xbar_out_req[SOC_WIDE_XBAR_OUT_SPM]),
+      .src_resp_o(soc_wide_xbar_out_rsp[SOC_WIDE_XBAR_OUT_SPM]),
       .dst_clk_i (clk_periph_i),
       .dst_rst_ni(rst_periph_ni),
       .dst_req_o (spm_cdc_req),
       .dst_resp_i(spm_cdc_rsp)
   );
 
-  axi_a48_d64_i1_u0_req_t  spm_serialize_req;
-  axi_a48_d64_i1_u0_resp_t spm_serialize_rsp;
+  axi_a48_d512_i1_u0_req_t  spm_serialize_req;
+  axi_a48_d512_i1_u0_resp_t spm_serialize_rsp;
 
   axi_id_serialize #(
       .AtopSupport(1),
@@ -1714,12 +1713,12 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .AxiMstPortMaxUniqIds(2),
       .AxiMstPortMaxTxnsPerId(2),
       .AxiAddrWidth(48),
-      .AxiDataWidth(64),
+      .AxiDataWidth(512),
       .AxiUserWidth(1),
-      .slv_req_t(axi_a48_d64_i8_u0_req_t),
-      .slv_resp_t(axi_a48_d64_i8_u0_resp_t),
-      .mst_req_t(axi_a48_d64_i1_u0_req_t),
-      .mst_resp_t(axi_a48_d64_i1_u0_resp_t)
+      .slv_req_t(axi_a48_d512_i8_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i8_u0_resp_t),
+      .mst_req_t(axi_a48_d512_i1_u0_req_t),
+      .mst_resp_t(axi_a48_d512_i1_u0_resp_t)
   ) i_spm_serialize (
       .clk_i(clk_periph_i),
       .rst_ni(rst_periph_ni),
@@ -1728,12 +1727,12 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(spm_serialize_req),
       .mst_resp_i(spm_serialize_rsp)
   );
-  axi_a48_d64_i1_u0_req_t  spm_amo_adapter_req;
-  axi_a48_d64_i1_u0_resp_t spm_amo_adapter_rsp;
+  axi_a48_d512_i1_u0_req_t  spm_amo_adapter_req;
+  axi_a48_d512_i1_u0_resp_t spm_amo_adapter_rsp;
 
   axi_riscv_atomics #(
       .AXI_ADDR_WIDTH(48),
-      .AXI_DATA_WIDTH(64),
+      .AXI_DATA_WIDTH(512),
       .AXI_ID_WIDTH(1),
       .AXI_USER_WIDTH(1),
       .AXI_MAX_WRITE_TXNS(16),
@@ -1834,18 +1833,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_b_valid_i(spm_amo_adapter_rsp.b_valid)
   );
 
-  axi_a48_d64_i1_u0_req_t  spm_amo_adapter_cut_req;
-  axi_a48_d64_i1_u0_resp_t spm_amo_adapter_cut_rsp;
+  axi_a48_d512_i1_u0_req_t  spm_amo_adapter_cut_req;
+  axi_a48_d512_i1_u0_resp_t spm_amo_adapter_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d64_i1_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d64_i1_u0_w_chan_t),
-      .b_chan_t(axi_a48_d64_i1_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d64_i1_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d64_i1_u0_r_chan_t),
-      .req_t(axi_a48_d64_i1_u0_req_t),
-      .resp_t(axi_a48_d64_i1_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i1_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i1_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i1_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i1_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i1_u0_r_chan_t),
+      .req_t(axi_a48_d512_i1_u0_req_t),
+      .resp_t(axi_a48_d512_i1_u0_resp_t)
   ) i_spm_amo_adapter_cut (
       .clk_i(clk_periph_i),
       .rst_ni(rst_periph_ni),
@@ -1857,10 +1856,10 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   axi_to_mem #(
-      .axi_req_t(axi_a48_d64_i1_u0_req_t),
-      .axi_resp_t(axi_a48_d64_i1_u0_resp_t),
+      .axi_req_t(axi_a48_d512_i1_u0_req_t),
+      .axi_resp_t(axi_a48_d512_i1_u0_resp_t),
       .AddrWidth(17),
-      .DataWidth(64),
+      .DataWidth(512),
       .IdWidth(1),
       .NumBanks(1),
       .BufDepth(1)
@@ -1882,8 +1881,8 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   );
 
   spm_1p_adv #(
-      .NumWords(16384),
-      .DataWidth(64),
+      .NumWords(2048),
+      .DataWidth(512),
       .ByteWidth(8),
       .EnableInputPipeline(1'b1),
       .EnableOutputPipeline(1'b1)
@@ -1893,7 +1892,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .valid_i(spm_req),
       .ready_o(spm_gnt),
       .we_i(spm_we),
-      .addr_i(spm_addr[16:3]),
+      .addr_i(spm_addr[16:6]),
       .wdata_i(spm_wdata),
       .be_i(spm_strb),
       .rdata_o(spm_rdata),

--- a/hw/system/occamy/src/occamy_top.sv.tpl
+++ b/hw/system/occamy/src/occamy_top.sv.tpl
@@ -108,11 +108,11 @@ module occamy_top
   occamy_soc_reg_pkg::occamy_soc_hw2reg_t soc_ctrl_in;
   assign soc_ctrl_in.boot_mode.d = boot_mode_i;
 
-  <% spm_words = cfg["spm"]["length"]//(soc_narrow_xbar.out_spm.dw//8) %>
+  <% spm_words = cfg["spm"]["length"]//(soc_wide_xbar.out_spm.dw//8) %>
 
-  typedef logic [${util.clog2(spm_words) + util.clog2(soc_narrow_xbar.out_spm.dw//8)-1}:0] mem_addr_t;
-  typedef logic [${soc_narrow_xbar.out_spm.dw-1}:0] mem_data_t;
-  typedef logic [${soc_narrow_xbar.out_spm.dw//8-1}:0] mem_strb_t;
+  typedef logic [${util.clog2(spm_words) + util.clog2(soc_wide_xbar.out_spm.dw//8)-1}:0] mem_addr_t;
+  typedef logic [${soc_wide_xbar.out_spm.dw-1}:0] mem_data_t;
+  typedef logic [${soc_wide_xbar.out_spm.dw//8-1}:0] mem_strb_t;
 
   logic spm_req, spm_gnt, spm_we, spm_rvalid;
   logic [1:0] spm_rerror;
@@ -232,7 +232,7 @@ module occamy_top
   //////////
   // SPM //
   //////////
-  <% narrow_spm_cdc = soc_narrow_xbar.out_spm \
+  <% wide_spm_cdc = soc_wide_xbar.out_spm \
                       .cdc(context, "clk_periph_i", "rst_periph_ni", "spm_cdc") \
                       .serialize(context, "spm_serialize", iw=1) \
                       .atomic_adapter(context, 16, "spm_amo_adapter") \
@@ -240,19 +240,19 @@ module occamy_top
   %>
 
   axi_to_mem #(
-    .axi_req_t (${narrow_spm_cdc.req_type()}),
-    .axi_resp_t (${narrow_spm_cdc.rsp_type()}),
-    .AddrWidth (${util.clog2(spm_words) + util.clog2(narrow_spm_cdc.dw//8)}),
-    .DataWidth (${narrow_spm_cdc.dw}),
-    .IdWidth (${narrow_spm_cdc.iw}),
+    .axi_req_t (${wide_spm_cdc.req_type()}),
+    .axi_resp_t (${wide_spm_cdc.rsp_type()}),
+    .AddrWidth (${util.clog2(spm_words) + util.clog2(wide_spm_cdc.dw//8)}),
+    .DataWidth (${wide_spm_cdc.dw}),
+    .IdWidth (${wide_spm_cdc.iw}),
     .NumBanks (1),
     .BufDepth (1)
   ) i_axi_to_mem (
-    .clk_i (${narrow_spm_cdc.clk}),
-    .rst_ni (${narrow_spm_cdc.rst}),
+    .clk_i (${wide_spm_cdc.clk}),
+    .rst_ni (${wide_spm_cdc.rst}),
     .busy_o (),
-    .axi_req_i (${narrow_spm_cdc.req_name()}),
-    .axi_resp_o (${narrow_spm_cdc.rsp_name()}),
+    .axi_req_i (${wide_spm_cdc.req_name()}),
+    .axi_resp_o (${wide_spm_cdc.rsp_name()}),
     .mem_req_o (spm_req),
     .mem_gnt_i (spm_gnt),
     .mem_addr_o (spm_addr),
@@ -266,17 +266,17 @@ module occamy_top
 
   spm_1p_adv #(
     .NumWords (${spm_words}),
-    .DataWidth (${narrow_spm_cdc.dw}),
+    .DataWidth (${wide_spm_cdc.dw}),
     .ByteWidth (8),
     .EnableInputPipeline (1'b1),
     .EnableOutputPipeline (1'b1)
   ) i_spm_cut (
-    .clk_i (${narrow_spm_cdc.clk}),
-    .rst_ni (${narrow_spm_cdc.rst}),
+    .clk_i (${wide_spm_cdc.clk}),
+    .rst_ni (${wide_spm_cdc.rst}),
     .valid_i (spm_req),
     .ready_o (spm_gnt),
     .we_i (spm_we),
-    .addr_i (spm_addr[${util.clog2(spm_words) + util.clog2(narrow_spm_cdc.dw//8)-1}:${util.clog2(narrow_spm_cdc.dw//8)}]),
+    .addr_i (spm_addr[${util.clog2(spm_words) + util.clog2(wide_spm_cdc.dw//8)-1}:${util.clog2(wide_spm_cdc.dw//8)}]),
     .wdata_i (spm_wdata),
     .be_i (spm_strb),
     .rdata_o (spm_rdata),

--- a/util/occamygen.py
+++ b/util/occamygen.py
@@ -302,6 +302,8 @@ def main():
     soc_wide_xbar.add_input("pcie")
     soc_wide_xbar.add_output_entry("pcie", am_pcie)
 
+    soc_wide_xbar.add_output_entry("spm", am_spm)
+
     ###################
     # SoC Narrow Xbar #
     ###################
@@ -325,7 +327,6 @@ def main():
     dts.add_cpu("eth,ariane")
 
     soc_narrow_xbar.add_output_entry("periph", am_soc_axi_lite_periph_xbar)
-    soc_narrow_xbar.add_output_entry("spm", am_spm)
     soc_narrow_xbar.add_output_entry("soc_wide", am_soc_wide_xbar)
     soc_narrow_xbar.add_output_entry("regbus_periph",
                                      am_soc_regbus_periph_xbar)


### PR DESCRIPTION
This moves the main scratchpad memory (SPM) in Occamy from the narrow 64-bit crossbar to the wide 512-bit crossbar in an effort to improve its usefulness in high-bandwidth applications / when used with the Snitch clusters.

TODO list:
* [x] Modified system can be simulated without issues
* [ ] CVA6 can access and fetch from SPM
* [ ] SPM works in FPGA emulation with Linux boot