### PR TITLE
sw: Disable printf in interrupt test

### DIFF
--- a/sw/snRuntime/tests/interrupt.c
+++ b/sw/snRuntime/tests/interrupt.c
@@ -8,8 +8,8 @@
 
 int reboot = 0;
 
-#define tprintf(f_, ...) printf((f_), __VA_ARGS__)
-// #define tprintf(f_, ...) while (0
+// #define tprintf(f_, ...) printf((f_), __VA_ARGS__)
+#define tprintf(f_, ...) while (0)
 
 volatile static int32_t INTERRUPT_FLAG;
 


### PR DESCRIPTION
Disable `printf` in the interrupt test to speed-up the CI