### PR TITLE
solder: Make full use of target ID space in IWC

### DIFF
--- a/hw/system/occamy/src/occamy_quadrant_s1.sv
+++ b/hw/system/occamy/src/occamy_quadrant_s1.sv
@@ -171,7 +171,7 @@ module occamy_quadrant_s1
 
   axi_id_remap #(
       .AxiSlvPortIdWidth(8),
-      .AxiSlvPortMaxUniqIds(4),
+      .AxiSlvPortMaxUniqIds(16),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(4),
       .slv_req_t(axi_a48_d64_i8_u0_req_t),
@@ -198,7 +198,7 @@ module occamy_quadrant_s1
 
   axi_id_remap #(
       .AxiSlvPortIdWidth(7),
-      .AxiSlvPortMaxUniqIds(4),
+      .AxiSlvPortMaxUniqIds(16),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(4),
       .slv_req_t(axi_a48_d64_i7_u0_req_t),
@@ -253,7 +253,7 @@ module occamy_quadrant_s1
 
   axi_id_remap #(
       .AxiSlvPortIdWidth(7),
-      .AxiSlvPortMaxUniqIds(4),
+      .AxiSlvPortMaxUniqIds(8),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(3),
       .slv_req_t(axi_a48_d512_i7_u0_req_t),
@@ -357,7 +357,7 @@ module occamy_quadrant_s1
 
   axi_id_remap #(
       .AxiSlvPortIdWidth(8),
-      .AxiSlvPortMaxUniqIds(4),
+      .AxiSlvPortMaxUniqIds(16),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(4),
       .slv_req_t(axi_a48_d512_i8_u0_req_t),

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -374,7 +374,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
   axi_id_remap #(
       .AxiSlvPortIdWidth(8),
-      .AxiSlvPortMaxUniqIds(4),
+      .AxiSlvPortMaxUniqIds(8),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(3),
       .slv_req_t(axi_a48_d64_i8_u0_req_t),
@@ -530,7 +530,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
   axi_id_remap #(
       .AxiSlvPortIdWidth(8),
-      .AxiSlvPortMaxUniqIds(4),
+      .AxiSlvPortMaxUniqIds(16),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(4),
       .slv_req_t(axi_a48_d512_i8_u0_req_t),

--- a/util/solder/solder.axi_change_iw.sv.tpl
+++ b/util/solder/solder.axi_change_iw.sv.tpl
@@ -1,6 +1,6 @@
   axi_id_remap #(
     .AxiSlvPortIdWidth ( ${axi_in.iw} ),
-    .AxiSlvPortMaxUniqIds ( 4 ),
+    .AxiSlvPortMaxUniqIds ( ${2**axi_out.iw} ),
     .AxiMaxTxnsPerId ( 4 ),
     .AxiMstPortIdWidth ( ${axi_out.iw} ),
     .slv_req_t ( ${axi_in.req_type()} ),


### PR DESCRIPTION
Use all IDs in the remapped space instead of a static 4. I'm not sure what the impact on HW complexity is, so please chip in!