### PR TITLE
Increase Banshee timeout to 360s

### DIFF
--- a/sw/cmake/SnitchUtilities.cmake
+++ b/sw/cmake/SnitchUtilities.cmake
@@ -4,7 +4,7 @@
 
 # Locate the banshee simulator for test execution.
 set(SNITCH_BANSHEE "banshee" CACHE PATH "Path to the banshee simulator for testing")
-set(BANSHEE_TIMEOUT "180" CACHE STRING "Timeout when running tests on banshee")
+set(BANSHEE_TIMEOUT "360" CACHE STRING "Timeout when running tests on banshee")
 set(RUN_BANSHEE_ARGS "--num-cores=8" CACHE PATH "Arguments passed to the banshee sim for the run-banshee target")
 set(SNITCH_RUNTIME "snRuntime-banshee" CACHE STRING "Target name of the snRuntime flavor to link against")
 set(SNITCH_SIMULATOR "" CACHE PATH "Command to run a binary in an RTL simulation")
@@ -68,7 +68,7 @@ endmacro()
 macro(add_snitch_raw_test_args test_name target_name)
     if (SNITCH_RUNTIME STREQUAL "snRuntime-banshee" AND BUILD_TESTS)
         add_test(NAME ${SNITCH_TEST_PREFIX}${test_name} COMMAND ${SNITCH_BANSHEE} $<TARGET_FILE:${target_name}> ${ARGN})
-        set_tests_properties(${SNITCH_TEST_PREFIX}${test_name} PROPERTIES TIMEOUT ${BANSHEE_TIMEOUT}) 
+        set_tests_properties(${SNITCH_TEST_PREFIX}${test_name} PROPERTIES TIMEOUT ${BANSHEE_TIMEOUT})
     endif()
 endmacro()
 
@@ -81,7 +81,7 @@ endmacro()
 macro(add_snitch_raw_test_rtl test_name target_name)
     if (NOT SNITCH_RUNTIME STREQUAL "snRuntime-banshee" AND BUILD_TESTS)
         add_test(NAME ${SNITCH_TEST_PREFIX}rtl-${test_name} COMMAND ${SNITCH_SIMULATOR} $<TARGET_FILE:${target_name}>)
-        set_tests_properties(${SNITCH_TEST_PREFIX}rtl-${test_name} PROPERTIES TIMEOUT ${SIMULATOR_TIMEOUT}) 
+        set_tests_properties(${SNITCH_TEST_PREFIX}rtl-${test_name} PROPERTIES TIMEOUT ${SIMULATOR_TIMEOUT})
     endif()
 endmacro()
 


### PR DESCRIPTION
I think the 180s are a bit too optimistic for one of the tests. Let's double it, still better than 5h :-)