### PR TITLE
banshee: Set mcause on interrupt even if mstatus.mie is 0

### DIFF
--- a/sw/snRuntime/tests/interrupt.c
+++ b/sw/snRuntime/tests/interrupt.c
@@ -33,6 +33,7 @@ int main() {
         snrt_interrupt_global_enable();
         asm volatile("wfi");
         snrt_interrupt_global_disable();
+        write_csr(mcause, 0);
     }
 
     snrt_cluster_hw_barrier();


### PR DESCRIPTION
An interrupt without global interrupt enable would not set the `mcause` CSR correctly. This fixes it and changes the interrupt test to sensitize this bug