### PR TITLE
docker: Change LLVM toolchain URL

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -96,13 +96,13 @@ RUN wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-${RISCV
 ENV PATH "/tools/riscv/bin:${PATH}"
 
 # Get the precompiled LLVM toolchain
-RUN latest_tag=`curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/pulp-platform/snitch-llvm/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'` && \
+RUN latest_tag=`curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/pulp-platform/llvm-project/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'` && \
     echo "SNITCH_LLVM_VERSION=${SNITCH_LLVM_VERSION} LLVM_TAR=${LLVM_TAR} latest_tag=${latest_tag}" && \
     test "${SNITCH_LLVM_VERSION}" = "latest" && SNITCH_LLVM_VERSION=${latest_tag} || : ; \
     LLVM_TAR=riscv32-snitch-llvm-ubuntu1804-snitch-$(echo $SNITCH_LLVM_VERSION | cut -d '-' -f3-).tar.gz && \
     mkdir -p riscv-llvm && \
     echo "SNITCH_LLVM_VERSION=${SNITCH_LLVM_VERSION} LLVM_TAR=${LLVM_TAR} latest_tag=${latest_tag}" && \
-    wget -qO- https://github.com/pulp-platform/snitch-llvm/releases/download/${SNITCH_LLVM_VERSION}/${LLVM_TAR} | \
+    wget -qO- https://github.com/pulp-platform/llvm-project/releases/download/${SNITCH_LLVM_VERSION}/${LLVM_TAR} | \
     tar xvz --strip-components=1 -C riscv-llvm
 ENV PATH "/tools/riscv-llvm/bin:${PATH}"
 


### PR DESCRIPTION
The `snitch-llvm` repository moved to `llvm-project` which causes the container build to fail