### PR TITLE
occamy_pkg: Derive number of clusters from cfg

### DIFF
--- a/hw/system/occamy/src/occamy_pkg.sv.tpl
+++ b/hw/system/occamy/src/occamy_pkg.sv.tpl
@@ -19,7 +19,7 @@ package occamy_pkg;
   localparam int unsigned AddrWidth = occamy_cluster_pkg::AddrWidth;
   localparam int unsigned UserWidth = occamy_cluster_pkg::UserWidth;
 
-  localparam int unsigned NrClustersS1Quadrant = 4;
+  localparam int unsigned NrClustersS1Quadrant = ${nr_s1_clusters};
   localparam int unsigned NrCoresCluster = occamy_cluster_pkg::NrCores;
   localparam int unsigned NrCoresS1Quadrant = NrClustersS1Quadrant * NrCoresCluster;
 


### PR DESCRIPTION
Derive the number of clusters from `occamy_cfg.hjson`. This fixes port
mismatches for numbers of clusters different from the default value
(`4`)