### PR TITLE
occamy: Update generator to include read-only cache memories

### DIFF
--- a/hw/system/occamy/src/memories.json
+++ b/hw/system/occamy/src/memories.json
@@ -39,6 +39,19 @@
         "words": 256
     },
     {
+        "byte_enable": false,
+        "byte_width": 8,
+        "density_optimized": true,
+        "description": [
+            "ro cache data"
+        ],
+        "latency": 1,
+        "ports": 1,
+        "speed_optimized": true,
+        "width": 512,
+        "words": 256
+    },
+    {
         "byte_enable": true,
         "byte_width": 8,
         "density_optimized": false,
@@ -102,5 +115,18 @@
         "speed_optimized": true,
         "width": 256,
         "words": 128
+    },
+    {
+        "byte_enable": false,
+        "byte_width": 8,
+        "density_optimized": true,
+        "description": [
+            "ro cache tag"
+        ],
+        "latency": 1,
+        "ports": 1,
+        "speed_optimized": true,
+        "width": 37,
+        "words": 256
     }
 ]

--- a/util/clustergen/occamy.py
+++ b/util/clustergen/occamy.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from .cluster import Generator, PMA, PMACfg, SnitchCluster
+from .cluster import Generator, PMA, PMACfg, SnitchCluster, clog2
 
 
 class Occamy(Generator):
@@ -28,17 +28,19 @@ class Occamy(Generator):
 
         self.cluster.cfg['tie_ports'] = False
 
-        if "const_cache" in self.cfg["s1_quadrant"]:
-            const_cache = self.cfg["s1_quadrant"]["const_cache"]
-            self.cluster.add_mem(const_cache["count"],
-                                 const_cache["width"],
-                                 desc="const cache data",
+        if "ro_cache_cfg" in self.cfg["s1_quadrant"]:
+            ro_cache = self.cfg["s1_quadrant"]["ro_cache_cfg"]
+            ro_tag_width = self.cluster.cfg['addr_width'] - clog2(
+                ro_cache['width'] // 8) - clog2(ro_cache['count']) + 3
+            self.cluster.add_mem(ro_cache["count"],
+                                 ro_cache["width"],
+                                 desc="ro cache data",
                                  byte_enable=False,
                                  speed_optimized=True,
                                  density_optimized=True)
-            self.cluster.add_mem(const_cache["count"],
-                                 self.cluster.tag_width,
-                                 desc="const_cache tag",
+            self.cluster.add_mem(ro_cache["count"],
+                                 ro_tag_width,
+                                 desc="ro cache tag",
                                  byte_enable=False,
                                  speed_optimized=True,
                                  density_optimized=True)


### PR DESCRIPTION
`occamygen` was outdated, resulting in read-only cache SRAMs not being included in the generated `memories.json`. This PR fixes this.