### PR TITLE
occamy_xilinx: Fix port assignment

### DIFF
--- a/hw/system/occamy/src/occamy_xilinx.sv
+++ b/hw/system/occamy/src/occamy_xilinx.sv
@@ -622,10 +622,10 @@ module occamy_xilinx
       .hbi_cfg_rsp_i('0),
       .apb_hbi_ctl_req_o(),
       .apb_hbi_ctl_rsp_i('0),
-      .hbm_phy_cfg_req_o('0),
-      .hbm_phy_cfg_rsp_i(),
-      .hbm_seq_req_o('0),
-      .hbm_seq_rsp_i(),
+      .hbm_phy_cfg_req_o(),
+      .hbm_phy_cfg_rsp_i('0),
+      .hbm_seq_req_o(),
+      .hbm_seq_rsp_i('0),
       .*
   );
 

--- a/hw/system/occamy/src/occamy_xilinx.sv.tpl
+++ b/hw/system/occamy/src/occamy_xilinx.sv.tpl
@@ -144,10 +144,10 @@ import occamy_pkg::*;
     .hbi_cfg_rsp_i ('0),
     .apb_hbi_ctl_req_o (),
     .apb_hbi_ctl_rsp_i ('0),
-    .hbm_phy_cfg_req_o ('0),
-    .hbm_phy_cfg_rsp_i (),
-    .hbm_seq_req_o ('0),
-    .hbm_seq_rsp_i (),
+    .hbm_phy_cfg_req_o (),
+    .hbm_phy_cfg_rsp_i ('0),
+    .hbm_seq_req_o (),
+    .hbm_seq_rsp_i ('0),
     .*
   );
 


### PR DESCRIPTION
Fix a small typo in the port assignment of `i_occamy`.