### PR TITLE
soc-regs: Stagger ro-cache reset regions to avoid illegal address rules

### DIFF
--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson
@@ -210,9 +210,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_0_QUADRANT_0",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 0
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -232,9 +233,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_0_QUADRANT_0",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -254,9 +256,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_1_QUADRANT_0",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -276,9 +279,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_1_QUADRANT_0",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 2
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -298,9 +302,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_0_QUADRANT_1",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 0
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -320,9 +325,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_0_QUADRANT_1",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -342,9 +348,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_1_QUADRANT_1",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -364,9 +371,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_1_QUADRANT_1",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 2
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -386,9 +394,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_0_QUADRANT_2",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 0
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -408,9 +417,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_0_QUADRANT_2",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -430,9 +440,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_1_QUADRANT_2",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -452,9 +463,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_1_QUADRANT_2",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 2
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -474,9 +486,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_0_QUADRANT_3",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 0
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -496,9 +509,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_0_QUADRANT_3",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -518,9 +532,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_1_QUADRANT_3",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -540,9 +555,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_1_QUADRANT_3",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 2
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -562,9 +578,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_0_QUADRANT_4",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 0
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -584,9 +601,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_0_QUADRANT_4",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -606,9 +624,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_1_QUADRANT_4",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -628,9 +647,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_1_QUADRANT_4",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 2
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -650,9 +670,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_0_QUADRANT_5",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 0
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -672,9 +693,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_0_QUADRANT_5",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -694,9 +716,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_1_QUADRANT_5",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -716,9 +739,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_1_QUADRANT_5",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 2
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -738,9 +762,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_0_QUADRANT_6",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 0
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -760,9 +785,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_0_QUADRANT_6",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -782,9 +808,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_1_QUADRANT_6",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -804,9 +831,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_1_QUADRANT_6",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 2
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -826,9 +854,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_0_QUADRANT_7",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 0
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -848,9 +877,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_0_QUADRANT_7",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -870,9 +900,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_1_QUADRANT_7",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 1
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -892,9 +923,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_1_QUADRANT_7",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: 2
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson.tpl
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson.tpl
@@ -212,9 +212,10 @@
       ]
     },
     { name: "RO_START_ADDR_HIGH_${j}_QUADRANT_${i}",
-      desc: "Read-only cache start address low",
+      desc: "Read-only cache start address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: ${j}
       fields: [
         { bits: "${soc_wide_xbar.aw-33}:0"
         name: "ADDR_HIGH"
@@ -234,9 +235,10 @@
       ]
     },
     { name: "RO_END_ADDR_HIGH_${j}_QUADRANT_${i}",
-      desc: "Read-only cache end address low",
+      desc: "Read-only cache end address high",
       swaccess: "rw",
       hwaccess: "hro",
+      resval: ${j + 1}
       fields: [
         { bits: "${soc_wide_xbar.aw-33}:0"
         name: "ADDR_HIGH"

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_top.sv
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_top.sv
@@ -4291,7 +4291,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_end_addr_high_0_quadrant_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4345,7 +4345,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_start_addr_high_1_quadrant_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4399,7 +4399,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h2)
   ) u_ro_end_addr_high_1_quadrant_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4507,7 +4507,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_end_addr_high_0_quadrant_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4561,7 +4561,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_start_addr_high_1_quadrant_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4615,7 +4615,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h2)
   ) u_ro_end_addr_high_1_quadrant_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4723,7 +4723,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_end_addr_high_0_quadrant_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4777,7 +4777,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_start_addr_high_1_quadrant_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4831,7 +4831,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h2)
   ) u_ro_end_addr_high_1_quadrant_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4939,7 +4939,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_end_addr_high_0_quadrant_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -4993,7 +4993,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_start_addr_high_1_quadrant_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5047,7 +5047,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h2)
   ) u_ro_end_addr_high_1_quadrant_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5155,7 +5155,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_end_addr_high_0_quadrant_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5209,7 +5209,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_start_addr_high_1_quadrant_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5263,7 +5263,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h2)
   ) u_ro_end_addr_high_1_quadrant_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5371,7 +5371,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_end_addr_high_0_quadrant_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5425,7 +5425,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_start_addr_high_1_quadrant_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5479,7 +5479,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h2)
   ) u_ro_end_addr_high_1_quadrant_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5587,7 +5587,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_end_addr_high_0_quadrant_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5641,7 +5641,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_start_addr_high_1_quadrant_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5695,7 +5695,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h2)
   ) u_ro_end_addr_high_1_quadrant_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5803,7 +5803,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_end_addr_high_0_quadrant_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5857,7 +5857,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h1)
   ) u_ro_start_addr_high_1_quadrant_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -5911,7 +5911,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (16),
     .SWACCESS("RW"),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h2)
   ) u_ro_end_addr_high_1_quadrant_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),


### PR DESCRIPTION
Currently, the default read-only cache address regions cause a fatal assertion failure on simulation. This assertion is unfortunately worded, but valid, as the address decoder used is not designed for address ranges of size 0 or smaller and spews further assertion failures if the former is circumvented.

This MR sets sensible default values for the SoC registers setting the address rules: each rule is set to a 32-bit block continuously addressed from 0 on reset. this should not be an issue, as the cache is bypassed by default.

This could be improved upon with configurable default address ranges, but this might be overkill and needs further configuration validation.