### PR TITLE
occamy: Fix const cache mismatches

### DIFF
--- a/hw/system/occamy/src/occamy_pkg.sv
+++ b/hw/system/occamy/src/occamy_pkg.sv
@@ -241,40 +241,40 @@ package occamy_pkg;
   MaxMstTrans:        4,
   FallThrough:        0,
   LatencyMode:        axi_pkg::CUT_ALL_PORTS,
-  AxiIdWidthSlvPorts: 3,
-  AxiIdUsedSlvPorts:  3,
+  AxiIdWidthSlvPorts: 4,
+  AxiIdUsedSlvPorts:  4,
   AxiAddrWidth:       48,
   AxiDataWidth:       512,
   NoAddrRules:        21
 };
 
-  // AXI bus with 48 bit address, 512 bit data, 3 bit IDs, and 0 bit user data.
-  `AXI_TYPEDEF_ALL(axi_a48_d512_i3_u0, logic [47:0], logic [2:0], logic [511:0], logic [63:0],
+  // AXI bus with 48 bit address, 512 bit data, 4 bit IDs, and 0 bit user data.
+  `AXI_TYPEDEF_ALL(axi_a48_d512_i4_u0, logic [47:0], logic [3:0], logic [511:0], logic [63:0],
                    logic [0:0])
 
-  // AXI bus with 48 bit address, 512 bit data, 8 bit IDs, and 0 bit user data.
-  `AXI_TYPEDEF_ALL(axi_a48_d512_i8_u0, logic [47:0], logic [7:0], logic [511:0], logic [63:0],
+  // AXI bus with 48 bit address, 512 bit data, 9 bit IDs, and 0 bit user data.
+  `AXI_TYPEDEF_ALL(axi_a48_d512_i9_u0, logic [47:0], logic [8:0], logic [511:0], logic [63:0],
                    logic [0:0])
 
-  typedef axi_a48_d512_i3_u0_req_t soc_wide_xbar_in_req_t;
-  typedef axi_a48_d512_i8_u0_req_t soc_wide_xbar_out_req_t;
-  typedef axi_a48_d512_i3_u0_resp_t soc_wide_xbar_in_resp_t;
-  typedef axi_a48_d512_i8_u0_resp_t soc_wide_xbar_out_resp_t;
-  typedef axi_a48_d512_i3_u0_aw_chan_t soc_wide_xbar_in_aw_chan_t;
-  typedef axi_a48_d512_i8_u0_aw_chan_t soc_wide_xbar_out_aw_chan_t;
-  typedef axi_a48_d512_i3_u0_w_chan_t soc_wide_xbar_in_w_chan_t;
-  typedef axi_a48_d512_i8_u0_w_chan_t soc_wide_xbar_out_w_chan_t;
-  typedef axi_a48_d512_i3_u0_b_chan_t soc_wide_xbar_in_b_chan_t;
-  typedef axi_a48_d512_i8_u0_b_chan_t soc_wide_xbar_out_b_chan_t;
-  typedef axi_a48_d512_i3_u0_ar_chan_t soc_wide_xbar_in_ar_chan_t;
-  typedef axi_a48_d512_i8_u0_ar_chan_t soc_wide_xbar_out_ar_chan_t;
-  typedef axi_a48_d512_i3_u0_r_chan_t soc_wide_xbar_in_r_chan_t;
-  typedef axi_a48_d512_i8_u0_r_chan_t soc_wide_xbar_out_r_chan_t;
+  typedef axi_a48_d512_i4_u0_req_t soc_wide_xbar_in_req_t;
+  typedef axi_a48_d512_i9_u0_req_t soc_wide_xbar_out_req_t;
+  typedef axi_a48_d512_i4_u0_resp_t soc_wide_xbar_in_resp_t;
+  typedef axi_a48_d512_i9_u0_resp_t soc_wide_xbar_out_resp_t;
+  typedef axi_a48_d512_i4_u0_aw_chan_t soc_wide_xbar_in_aw_chan_t;
+  typedef axi_a48_d512_i9_u0_aw_chan_t soc_wide_xbar_out_aw_chan_t;
+  typedef axi_a48_d512_i4_u0_w_chan_t soc_wide_xbar_in_w_chan_t;
+  typedef axi_a48_d512_i9_u0_w_chan_t soc_wide_xbar_out_w_chan_t;
+  typedef axi_a48_d512_i4_u0_b_chan_t soc_wide_xbar_in_b_chan_t;
+  typedef axi_a48_d512_i9_u0_b_chan_t soc_wide_xbar_out_b_chan_t;
+  typedef axi_a48_d512_i4_u0_ar_chan_t soc_wide_xbar_in_ar_chan_t;
+  typedef axi_a48_d512_i9_u0_ar_chan_t soc_wide_xbar_out_ar_chan_t;
+  typedef axi_a48_d512_i4_u0_r_chan_t soc_wide_xbar_in_r_chan_t;
+  typedef axi_a48_d512_i9_u0_r_chan_t soc_wide_xbar_out_r_chan_t;
 
   // verilog_lint: waive parameter-name-style
-  localparam int SOC_WIDE_XBAR_IW_IN = 3;
+  localparam int SOC_WIDE_XBAR_IW_IN = 4;
   // verilog_lint: waive parameter-name-style
-  localparam int SOC_WIDE_XBAR_IW_OUT = 8;
+  localparam int SOC_WIDE_XBAR_IW_OUT = 9;
 
   /// Inputs of the `soc_narrow_xbar` crossbar.
   typedef enum int {
@@ -387,10 +387,6 @@ package occamy_pkg;
   NoAddrRules:        5
 };
 
-  // AXI bus with 48 bit address, 512 bit data, 4 bit IDs, and 0 bit user data.
-  `AXI_TYPEDEF_ALL(axi_a48_d512_i4_u0, logic [47:0], logic [3:0], logic [511:0], logic [63:0],
-                   logic [0:0])
-
   // AXI bus with 48 bit address, 512 bit data, 7 bit IDs, and 0 bit user data.
   `AXI_TYPEDEF_ALL(axi_a48_d512_i7_u0, logic [47:0], logic [6:0], logic [511:0], logic [63:0],
                    logic [0:0])
@@ -478,10 +474,6 @@ package occamy_pkg;
   `APB_TYPEDEF_REQ_T(apb_a48_d32_req_t, logic [47:0], logic [31:0], logic [3:0])
   `APB_TYPEDEF_RESP_T(apb_a48_d32_rsp_t, logic [31:0])
 
-  // AXI bus with 48 bit address, 64 bit data, 3 bit IDs, and 0 bit user data.
-  `AXI_TYPEDEF_ALL(axi_a48_d64_i3_u0, logic [47:0], logic [2:0], logic [63:0], logic [7:0],
-                   logic [0:0])
-
   // AXI bus with 48 bit address, 64 bit data, 1 bit IDs, and 0 bit user data.
   `AXI_TYPEDEF_ALL(axi_a48_d64_i1_u0, logic [47:0], logic [0:0], logic [63:0], logic [7:0],
                    logic [0:0])
@@ -495,6 +487,10 @@ package occamy_pkg;
 
   // Register bus with 48 bit address and 64 bit data.
   `REG_BUS_TYPEDEF_ALL(reg_a48_d64, logic [47:0], logic [63:0], logic [7:0])
+
+  // AXI bus with 48 bit address, 512 bit data, 3 bit IDs, and 0 bit user data.
+  `AXI_TYPEDEF_ALL(axi_a48_d512_i3_u0, logic [47:0], logic [2:0], logic [511:0], logic [63:0],
+                   logic [0:0])
 
   // AXI bus with 48 bit address, 64 bit data, 2 bit IDs, and 0 bit user data.
   `AXI_TYPEDEF_ALL(axi_a48_d64_i2_u0, logic [47:0], logic [1:0], logic [63:0], logic [7:0],

--- a/hw/system/occamy/src/occamy_quadrant_s1.sv
+++ b/hw/system/occamy/src/occamy_quadrant_s1.sv
@@ -35,10 +35,10 @@ module occamy_quadrant_s1
     input  axi_a48_d64_i4_u0_resp_t                                quadrant_narrow_out_rsp_i,
     input  axi_a48_d64_i8_u0_req_t                                 quadrant_narrow_in_req_i,
     output axi_a48_d64_i8_u0_resp_t                                quadrant_narrow_in_rsp_o,
-    output axi_a48_d512_i3_u0_req_t                                quadrant_wide_out_req_o,
-    input  axi_a48_d512_i3_u0_resp_t                               quadrant_wide_out_rsp_i,
-    input  axi_a48_d512_i8_u0_req_t                                quadrant_wide_in_req_i,
-    output axi_a48_d512_i8_u0_resp_t                               quadrant_wide_in_rsp_o
+    output axi_a48_d512_i4_u0_req_t                                quadrant_wide_out_req_o,
+    input  axi_a48_d512_i4_u0_resp_t                               quadrant_wide_out_rsp_i,
+    input  axi_a48_d512_i9_u0_req_t                                quadrant_wide_in_req_i,
+    output axi_a48_d512_i9_u0_resp_t                               quadrant_wide_in_rsp_o
 );
 
   // Calculate cluster base address based on `tile id`.
@@ -361,22 +361,22 @@ module occamy_quadrant_s1
   ////////////////////////////
   // Wide In + IW Converter //
   ////////////////////////////
-  axi_a48_d512_i8_u0_req_t  wide_cluster_in_iwc_req;
-  axi_a48_d512_i8_u0_resp_t wide_cluster_in_iwc_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_cluster_in_iwc_req;
+  axi_a48_d512_i9_u0_resp_t wide_cluster_in_iwc_rsp;
 
-  axi_a48_d512_i8_u0_req_t  wide_cluster_in_isolate_req;
-  axi_a48_d512_i8_u0_resp_t wide_cluster_in_isolate_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_cluster_in_isolate_req;
+  axi_a48_d512_i9_u0_resp_t wide_cluster_in_isolate_rsp;
 
   axi_isolate #(
       .NumPending(16),
       .TerminateTransaction(1),
       .AtopSupport(0),
-      .AxiIdWidth(8),
+      .AxiIdWidth(9),
       .AxiAddrWidth(48),
       .AxiDataWidth(512),
       .AxiUserWidth(1),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_cluster_in_isolate (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -389,12 +389,12 @@ module occamy_quadrant_s1
   );
 
   axi_id_remap #(
-      .AxiSlvPortIdWidth(8),
+      .AxiSlvPortIdWidth(9),
       .AxiSlvPortMaxUniqIds(16),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(4),
-      .slv_req_t(axi_a48_d512_i8_u0_req_t),
-      .slv_resp_t(axi_a48_d512_i8_u0_resp_t),
+      .slv_req_t(axi_a48_d512_i9_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i9_u0_resp_t),
       .mst_req_t(axi_a48_d512_i4_u0_req_t),
       .mst_resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_cluster_in_iwc (

--- a/hw/system/occamy/src/occamy_quadrant_s1.sv.tpl
+++ b/hw/system/occamy/src/occamy_quadrant_s1.sv.tpl
@@ -99,6 +99,8 @@ module occamy_quadrant_s1
 
     wide_cluster_out_cut = wide_cluster_out_ro_cache \
       .isolate(context, "isolate_i[3]", "wide_cluster_out_isolate", isolated="isolated_o[3]", atop_support=False)
+
+    assert soc_wide_xbar.in_s1_quadrant_0.iw == wide_cluster_out_cut.iw, "S1 Quadrant and Cluster Out IW mismatches."
   %>
 
   assign quadrant_wide_out_req_o = ${wide_cluster_out_cut.req_name()};

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -87,63 +87,63 @@ module occamy_top
     input logic [11:0] ext_irq_i,
 
     /// HBM2e Ports
-    output axi_a48_d512_i8_u0_req_t  hbm_0_req_o,
-    input  axi_a48_d512_i8_u0_resp_t hbm_0_rsp_i,
-    output axi_a48_d512_i8_u0_req_t  hbm_1_req_o,
-    input  axi_a48_d512_i8_u0_resp_t hbm_1_rsp_i,
-    output axi_a48_d512_i8_u0_req_t  hbm_2_req_o,
-    input  axi_a48_d512_i8_u0_resp_t hbm_2_rsp_i,
-    output axi_a48_d512_i8_u0_req_t  hbm_3_req_o,
-    input  axi_a48_d512_i8_u0_resp_t hbm_3_rsp_i,
-    output axi_a48_d512_i8_u0_req_t  hbm_4_req_o,
-    input  axi_a48_d512_i8_u0_resp_t hbm_4_rsp_i,
-    output axi_a48_d512_i8_u0_req_t  hbm_5_req_o,
-    input  axi_a48_d512_i8_u0_resp_t hbm_5_rsp_i,
-    output axi_a48_d512_i8_u0_req_t  hbm_6_req_o,
-    input  axi_a48_d512_i8_u0_resp_t hbm_6_rsp_i,
-    output axi_a48_d512_i8_u0_req_t  hbm_7_req_o,
-    input  axi_a48_d512_i8_u0_resp_t hbm_7_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  hbm_0_req_o,
+    input  axi_a48_d512_i9_u0_resp_t hbm_0_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  hbm_1_req_o,
+    input  axi_a48_d512_i9_u0_resp_t hbm_1_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  hbm_2_req_o,
+    input  axi_a48_d512_i9_u0_resp_t hbm_2_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  hbm_3_req_o,
+    input  axi_a48_d512_i9_u0_resp_t hbm_3_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  hbm_4_req_o,
+    input  axi_a48_d512_i9_u0_resp_t hbm_4_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  hbm_5_req_o,
+    input  axi_a48_d512_i9_u0_resp_t hbm_5_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  hbm_6_req_o,
+    input  axi_a48_d512_i9_u0_resp_t hbm_6_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  hbm_7_req_o,
+    input  axi_a48_d512_i9_u0_resp_t hbm_7_rsp_i,
 
     /// HBI Ports
-    input  axi_a48_d512_i3_u0_req_t  hbi_0_req_i,
-    output axi_a48_d512_i3_u0_resp_t hbi_0_rsp_o,
+    input  axi_a48_d512_i4_u0_req_t  hbi_0_req_i,
+    output axi_a48_d512_i4_u0_resp_t hbi_0_rsp_o,
     output axi_a48_d512_i7_u0_req_t  hbi_0_req_o,
     input  axi_a48_d512_i7_u0_resp_t hbi_0_rsp_i,
-    input  axi_a48_d512_i3_u0_req_t  hbi_1_req_i,
-    output axi_a48_d512_i3_u0_resp_t hbi_1_rsp_o,
+    input  axi_a48_d512_i4_u0_req_t  hbi_1_req_i,
+    output axi_a48_d512_i4_u0_resp_t hbi_1_rsp_o,
     output axi_a48_d512_i7_u0_req_t  hbi_1_req_o,
     input  axi_a48_d512_i7_u0_resp_t hbi_1_rsp_i,
-    input  axi_a48_d512_i3_u0_req_t  hbi_2_req_i,
-    output axi_a48_d512_i3_u0_resp_t hbi_2_rsp_o,
+    input  axi_a48_d512_i4_u0_req_t  hbi_2_req_i,
+    output axi_a48_d512_i4_u0_resp_t hbi_2_rsp_o,
     output axi_a48_d512_i7_u0_req_t  hbi_2_req_o,
     input  axi_a48_d512_i7_u0_resp_t hbi_2_rsp_i,
-    input  axi_a48_d512_i3_u0_req_t  hbi_3_req_i,
-    output axi_a48_d512_i3_u0_resp_t hbi_3_rsp_o,
+    input  axi_a48_d512_i4_u0_req_t  hbi_3_req_i,
+    output axi_a48_d512_i4_u0_resp_t hbi_3_rsp_o,
     output axi_a48_d512_i7_u0_req_t  hbi_3_req_o,
     input  axi_a48_d512_i7_u0_resp_t hbi_3_rsp_i,
-    input  axi_a48_d512_i3_u0_req_t  hbi_4_req_i,
-    output axi_a48_d512_i3_u0_resp_t hbi_4_rsp_o,
+    input  axi_a48_d512_i4_u0_req_t  hbi_4_req_i,
+    output axi_a48_d512_i4_u0_resp_t hbi_4_rsp_o,
     output axi_a48_d512_i7_u0_req_t  hbi_4_req_o,
     input  axi_a48_d512_i7_u0_resp_t hbi_4_rsp_i,
-    input  axi_a48_d512_i3_u0_req_t  hbi_5_req_i,
-    output axi_a48_d512_i3_u0_resp_t hbi_5_rsp_o,
+    input  axi_a48_d512_i4_u0_req_t  hbi_5_req_i,
+    output axi_a48_d512_i4_u0_resp_t hbi_5_rsp_o,
     output axi_a48_d512_i7_u0_req_t  hbi_5_req_o,
     input  axi_a48_d512_i7_u0_resp_t hbi_5_rsp_i,
-    input  axi_a48_d512_i3_u0_req_t  hbi_6_req_i,
-    output axi_a48_d512_i3_u0_resp_t hbi_6_rsp_o,
+    input  axi_a48_d512_i4_u0_req_t  hbi_6_req_i,
+    output axi_a48_d512_i4_u0_resp_t hbi_6_rsp_o,
     output axi_a48_d512_i7_u0_req_t  hbi_6_req_o,
     input  axi_a48_d512_i7_u0_resp_t hbi_6_rsp_i,
-    input  axi_a48_d512_i3_u0_req_t  hbi_7_req_i,
-    output axi_a48_d512_i3_u0_resp_t hbi_7_rsp_o,
+    input  axi_a48_d512_i4_u0_req_t  hbi_7_req_i,
+    output axi_a48_d512_i4_u0_resp_t hbi_7_rsp_o,
     output axi_a48_d512_i7_u0_req_t  hbi_7_req_o,
     input  axi_a48_d512_i7_u0_resp_t hbi_7_rsp_i,
 
     /// PCIe Ports
-    output axi_a48_d512_i8_u0_req_t  pcie_axi_req_o,
-    input  axi_a48_d512_i8_u0_resp_t pcie_axi_rsp_i,
+    output axi_a48_d512_i9_u0_req_t  pcie_axi_req_o,
+    input  axi_a48_d512_i9_u0_resp_t pcie_axi_rsp_i,
 
-    input  axi_a48_d512_i3_u0_req_t  pcie_axi_req_i,
-    output axi_a48_d512_i3_u0_resp_t pcie_axi_rsp_o
+    input  axi_a48_d512_i4_u0_req_t  pcie_axi_req_i,
+    output axi_a48_d512_i4_u0_resp_t pcie_axi_rsp_o
 );
 
   occamy_soc_reg_pkg::occamy_soc_reg2hw_t soc_ctrl_out;
@@ -288,19 +288,19 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .Cfg(SocWideXbarCfg),
       .Connectivity  ( 324'b011111111111111111101111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111101111111111111111110111111111111111111011111111111111111101111111111111111110111111111111111111011111111111111111101111111111111111110 ),
       .AtopSupport(0),
-      .slv_aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .mst_aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .slv_b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .mst_b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .slv_ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .mst_ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .slv_r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .mst_r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .slv_req_t(axi_a48_d512_i3_u0_req_t),
-      .slv_resp_t(axi_a48_d512_i3_u0_resp_t),
-      .mst_req_t(axi_a48_d512_i8_u0_req_t),
-      .mst_resp_t(axi_a48_d512_i8_u0_resp_t),
+      .slv_aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .mst_aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .slv_b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .mst_b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .slv_ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .mst_ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .slv_r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .mst_r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .slv_req_t(axi_a48_d512_i4_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i4_u0_resp_t),
+      .mst_req_t(axi_a48_d512_i9_u0_req_t),
+      .mst_resp_t(axi_a48_d512_i9_u0_resp_t),
       .rule_t(xbar_rule_48_t)
   ) i_soc_wide_xbar (
       .clk_i                (clk_i),
@@ -373,18 +373,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   /////////////////////////////
   // Narrow to Wide Crossbar //
   /////////////////////////////
-  axi_a48_d64_i3_u0_req_t  soc_narrow_wide_iwc_req;
-  axi_a48_d64_i3_u0_resp_t soc_narrow_wide_iwc_rsp;
+  axi_a48_d64_i4_u0_req_t  soc_narrow_wide_iwc_req;
+  axi_a48_d64_i4_u0_resp_t soc_narrow_wide_iwc_rsp;
 
   axi_id_remap #(
       .AxiSlvPortIdWidth(8),
-      .AxiSlvPortMaxUniqIds(8),
+      .AxiSlvPortMaxUniqIds(16),
       .AxiMaxTxnsPerId(4),
-      .AxiMstPortIdWidth(3),
+      .AxiMstPortIdWidth(4),
       .slv_req_t(axi_a48_d64_i8_u0_req_t),
       .slv_resp_t(axi_a48_d64_i8_u0_resp_t),
-      .mst_req_t(axi_a48_d64_i3_u0_req_t),
-      .mst_resp_t(axi_a48_d64_i3_u0_resp_t)
+      .mst_req_t(axi_a48_d64_i4_u0_req_t),
+      .mst_resp_t(axi_a48_d64_i4_u0_resp_t)
   ) i_soc_narrow_wide_iwc (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -393,13 +393,13 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_wide_iwc_req),
       .mst_resp_i(soc_narrow_wide_iwc_rsp)
   );
-  axi_a48_d64_i3_u0_req_t  soc_narrow_wide_amo_adapter_req;
-  axi_a48_d64_i3_u0_resp_t soc_narrow_wide_amo_adapter_rsp;
+  axi_a48_d64_i4_u0_req_t  soc_narrow_wide_amo_adapter_req;
+  axi_a48_d64_i4_u0_resp_t soc_narrow_wide_amo_adapter_rsp;
 
   axi_riscv_atomics #(
       .AXI_ADDR_WIDTH(48),
       .AXI_DATA_WIDTH(64),
-      .AXI_ID_WIDTH(3),
+      .AXI_ID_WIDTH(4),
       .AXI_USER_WIDTH(1),
       .AXI_MAX_WRITE_TXNS(16),
       .RISCV_WORD_WIDTH(64)
@@ -503,18 +503,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .AxiSlvPortDataWidth(64),
       .AxiMstPortDataWidth(512),
       .AxiAddrWidth(48),
-      .AxiIdWidth(3),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .mst_w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .slv_w_chan_t(axi_a48_d64_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .mst_r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .slv_r_chan_t(axi_a48_d64_i3_u0_r_chan_t),
-      .axi_mst_req_t(axi_a48_d512_i3_u0_req_t),
-      .axi_mst_resp_t(axi_a48_d512_i3_u0_resp_t),
-      .axi_slv_req_t(axi_a48_d64_i3_u0_req_t),
-      .axi_slv_resp_t(axi_a48_d64_i3_u0_resp_t)
+      .AxiIdWidth(4),
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .mst_w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .slv_w_chan_t(axi_a48_d64_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .mst_r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .slv_r_chan_t(axi_a48_d64_i4_u0_r_chan_t),
+      .axi_mst_req_t(axi_a48_d512_i4_u0_req_t),
+      .axi_mst_resp_t(axi_a48_d512_i4_u0_resp_t),
+      .axi_slv_req_t(axi_a48_d64_i4_u0_req_t),
+      .axi_slv_resp_t(axi_a48_d64_i4_u0_resp_t)
   ) i_soc_narrow_wide_dw (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -533,12 +533,12 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   axi_a48_d512_i4_u0_resp_t soc_wide_narrow_iwc_rsp;
 
   axi_id_remap #(
-      .AxiSlvPortIdWidth(8),
+      .AxiSlvPortIdWidth(9),
       .AxiSlvPortMaxUniqIds(16),
       .AxiMaxTxnsPerId(4),
       .AxiMstPortIdWidth(4),
-      .slv_req_t(axi_a48_d512_i8_u0_req_t),
-      .slv_resp_t(axi_a48_d512_i8_u0_resp_t),
+      .slv_req_t(axi_a48_d512_i9_u0_req_t),
+      .slv_resp_t(axi_a48_d512_i9_u0_resp_t),
       .mst_req_t(axi_a48_d512_i4_u0_req_t),
       .mst_resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_soc_wide_narrow_iwc (
@@ -642,18 +642,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_S1_QUADRANT_0]),
       .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_S1_QUADRANT_0])
   );
-  axi_a48_d512_i8_u0_req_t  wide_in_cut_0_req;
-  axi_a48_d512_i8_u0_resp_t wide_in_cut_0_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_in_cut_0_req;
+  axi_a48_d512_i9_u0_resp_t wide_in_cut_0_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i8_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_in_cut_0 (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -662,18 +662,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(wide_in_cut_0_req),
       .mst_resp_i(wide_in_cut_0_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_cut_0_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_cut_0_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_cut_0_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_cut_0_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_cut_0_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -798,18 +798,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_S1_QUADRANT_1]),
       .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_S1_QUADRANT_1])
   );
-  axi_a48_d512_i8_u0_req_t  wide_in_cut_1_req;
-  axi_a48_d512_i8_u0_resp_t wide_in_cut_1_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_in_cut_1_req;
+  axi_a48_d512_i9_u0_resp_t wide_in_cut_1_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i8_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_in_cut_1 (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -818,18 +818,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(wide_in_cut_1_req),
       .mst_resp_i(wide_in_cut_1_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_cut_1_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_cut_1_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_cut_1_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_cut_1_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_cut_1_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -954,18 +954,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_S1_QUADRANT_2]),
       .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_S1_QUADRANT_2])
   );
-  axi_a48_d512_i8_u0_req_t  wide_in_cut_2_req;
-  axi_a48_d512_i8_u0_resp_t wide_in_cut_2_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_in_cut_2_req;
+  axi_a48_d512_i9_u0_resp_t wide_in_cut_2_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i8_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_in_cut_2 (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -974,18 +974,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(wide_in_cut_2_req),
       .mst_resp_i(wide_in_cut_2_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_cut_2_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_cut_2_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_cut_2_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_cut_2_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_cut_2_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1110,18 +1110,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_S1_QUADRANT_3]),
       .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_S1_QUADRANT_3])
   );
-  axi_a48_d512_i8_u0_req_t  wide_in_cut_3_req;
-  axi_a48_d512_i8_u0_resp_t wide_in_cut_3_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_in_cut_3_req;
+  axi_a48_d512_i9_u0_resp_t wide_in_cut_3_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i8_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_in_cut_3 (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1130,18 +1130,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(wide_in_cut_3_req),
       .mst_resp_i(wide_in_cut_3_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_cut_3_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_cut_3_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_cut_3_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_cut_3_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_cut_3_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1266,18 +1266,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_S1_QUADRANT_4]),
       .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_S1_QUADRANT_4])
   );
-  axi_a48_d512_i8_u0_req_t  wide_in_cut_4_req;
-  axi_a48_d512_i8_u0_resp_t wide_in_cut_4_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_in_cut_4_req;
+  axi_a48_d512_i9_u0_resp_t wide_in_cut_4_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i8_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_in_cut_4 (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1286,18 +1286,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(wide_in_cut_4_req),
       .mst_resp_i(wide_in_cut_4_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_cut_4_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_cut_4_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_cut_4_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_cut_4_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_cut_4_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1422,18 +1422,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_S1_QUADRANT_5]),
       .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_S1_QUADRANT_5])
   );
-  axi_a48_d512_i8_u0_req_t  wide_in_cut_5_req;
-  axi_a48_d512_i8_u0_resp_t wide_in_cut_5_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_in_cut_5_req;
+  axi_a48_d512_i9_u0_resp_t wide_in_cut_5_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i8_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_in_cut_5 (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1442,18 +1442,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(wide_in_cut_5_req),
       .mst_resp_i(wide_in_cut_5_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_cut_5_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_cut_5_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_cut_5_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_cut_5_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_cut_5_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1578,18 +1578,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_S1_QUADRANT_6]),
       .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_S1_QUADRANT_6])
   );
-  axi_a48_d512_i8_u0_req_t  wide_in_cut_6_req;
-  axi_a48_d512_i8_u0_resp_t wide_in_cut_6_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_in_cut_6_req;
+  axi_a48_d512_i9_u0_resp_t wide_in_cut_6_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i8_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_in_cut_6 (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1598,18 +1598,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(wide_in_cut_6_req),
       .mst_resp_i(wide_in_cut_6_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_cut_6_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_cut_6_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_cut_6_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_cut_6_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_cut_6_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1734,18 +1734,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(soc_narrow_xbar_in_req[SOC_NARROW_XBAR_IN_S1_QUADRANT_7]),
       .mst_resp_i(soc_narrow_xbar_in_rsp[SOC_NARROW_XBAR_IN_S1_QUADRANT_7])
   );
-  axi_a48_d512_i8_u0_req_t  wide_in_cut_7_req;
-  axi_a48_d512_i8_u0_resp_t wide_in_cut_7_rsp;
+  axi_a48_d512_i9_u0_req_t  wide_in_cut_7_req;
+  axi_a48_d512_i9_u0_resp_t wide_in_cut_7_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i8_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i8_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i8_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i8_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i8_u0_r_chan_t),
-      .req_t(axi_a48_d512_i8_u0_req_t),
-      .resp_t(axi_a48_d512_i8_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
   ) i_wide_in_cut_7 (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -1754,18 +1754,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
       .mst_req_o(wide_in_cut_7_req),
       .mst_resp_i(wide_in_cut_7_rsp)
   );
-  axi_a48_d512_i3_u0_req_t  wide_out_cut_7_req;
-  axi_a48_d512_i3_u0_resp_t wide_out_cut_7_rsp;
+  axi_a48_d512_i4_u0_req_t  wide_out_cut_7_req;
+  axi_a48_d512_i4_u0_resp_t wide_out_cut_7_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d512_i3_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d512_i3_u0_w_chan_t),
-      .b_chan_t(axi_a48_d512_i3_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d512_i3_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d512_i3_u0_r_chan_t),
-      .req_t(axi_a48_d512_i3_u0_req_t),
-      .resp_t(axi_a48_d512_i3_u0_resp_t)
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
   ) i_wide_out_cut_7_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),

--- a/hw/system/occamy/src/occamy_xilinx.sv
+++ b/hw/system/occamy/src/occamy_xilinx.sv
@@ -68,7 +68,7 @@ module occamy_xilinx
     /// HBM2e Ports
     input  logic                     m_axi_hbm_0_awready,
     output logic                     m_axi_hbm_0_awvalid,
-    output logic             [  7:0] m_axi_hbm_0_awid,
+    output logic             [  8:0] m_axi_hbm_0_awid,
     output logic             [ 47:0] m_axi_hbm_0_awaddr,
     output axi_pkg::len_t            m_axi_hbm_0_awlen,
     output axi_pkg::size_t           m_axi_hbm_0_awsize,
@@ -88,7 +88,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_0_wuser,
     input  logic                     m_axi_hbm_0_arready,
     output logic                     m_axi_hbm_0_arvalid,
-    output logic             [  7:0] m_axi_hbm_0_arid,
+    output logic             [  8:0] m_axi_hbm_0_arid,
     output logic             [ 47:0] m_axi_hbm_0_araddr,
     output axi_pkg::len_t            m_axi_hbm_0_arlen,
     output axi_pkg::size_t           m_axi_hbm_0_arsize,
@@ -101,19 +101,19 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_0_aruser,
     output logic                     m_axi_hbm_0_rready,
     input  logic                     m_axi_hbm_0_rvalid,
-    input  logic             [  7:0] m_axi_hbm_0_rid,
+    input  logic             [  8:0] m_axi_hbm_0_rid,
     input  logic             [511:0] m_axi_hbm_0_rdata,
     input  axi_pkg::resp_t           m_axi_hbm_0_rresp,
     input  logic                     m_axi_hbm_0_rlast,
     input  logic             [  0:0] m_axi_hbm_0_ruser,
     output logic                     m_axi_hbm_0_bready,
     input  logic                     m_axi_hbm_0_bvalid,
-    input  logic             [  7:0] m_axi_hbm_0_bid,
+    input  logic             [  8:0] m_axi_hbm_0_bid,
     input  axi_pkg::resp_t           m_axi_hbm_0_bresp,
     input  logic             [  0:0] m_axi_hbm_0_buser,
     input  logic                     m_axi_hbm_1_awready,
     output logic                     m_axi_hbm_1_awvalid,
-    output logic             [  7:0] m_axi_hbm_1_awid,
+    output logic             [  8:0] m_axi_hbm_1_awid,
     output logic             [ 47:0] m_axi_hbm_1_awaddr,
     output axi_pkg::len_t            m_axi_hbm_1_awlen,
     output axi_pkg::size_t           m_axi_hbm_1_awsize,
@@ -133,7 +133,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_1_wuser,
     input  logic                     m_axi_hbm_1_arready,
     output logic                     m_axi_hbm_1_arvalid,
-    output logic             [  7:0] m_axi_hbm_1_arid,
+    output logic             [  8:0] m_axi_hbm_1_arid,
     output logic             [ 47:0] m_axi_hbm_1_araddr,
     output axi_pkg::len_t            m_axi_hbm_1_arlen,
     output axi_pkg::size_t           m_axi_hbm_1_arsize,
@@ -146,19 +146,19 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_1_aruser,
     output logic                     m_axi_hbm_1_rready,
     input  logic                     m_axi_hbm_1_rvalid,
-    input  logic             [  7:0] m_axi_hbm_1_rid,
+    input  logic             [  8:0] m_axi_hbm_1_rid,
     input  logic             [511:0] m_axi_hbm_1_rdata,
     input  axi_pkg::resp_t           m_axi_hbm_1_rresp,
     input  logic                     m_axi_hbm_1_rlast,
     input  logic             [  0:0] m_axi_hbm_1_ruser,
     output logic                     m_axi_hbm_1_bready,
     input  logic                     m_axi_hbm_1_bvalid,
-    input  logic             [  7:0] m_axi_hbm_1_bid,
+    input  logic             [  8:0] m_axi_hbm_1_bid,
     input  axi_pkg::resp_t           m_axi_hbm_1_bresp,
     input  logic             [  0:0] m_axi_hbm_1_buser,
     input  logic                     m_axi_hbm_2_awready,
     output logic                     m_axi_hbm_2_awvalid,
-    output logic             [  7:0] m_axi_hbm_2_awid,
+    output logic             [  8:0] m_axi_hbm_2_awid,
     output logic             [ 47:0] m_axi_hbm_2_awaddr,
     output axi_pkg::len_t            m_axi_hbm_2_awlen,
     output axi_pkg::size_t           m_axi_hbm_2_awsize,
@@ -178,7 +178,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_2_wuser,
     input  logic                     m_axi_hbm_2_arready,
     output logic                     m_axi_hbm_2_arvalid,
-    output logic             [  7:0] m_axi_hbm_2_arid,
+    output logic             [  8:0] m_axi_hbm_2_arid,
     output logic             [ 47:0] m_axi_hbm_2_araddr,
     output axi_pkg::len_t            m_axi_hbm_2_arlen,
     output axi_pkg::size_t           m_axi_hbm_2_arsize,
@@ -191,19 +191,19 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_2_aruser,
     output logic                     m_axi_hbm_2_rready,
     input  logic                     m_axi_hbm_2_rvalid,
-    input  logic             [  7:0] m_axi_hbm_2_rid,
+    input  logic             [  8:0] m_axi_hbm_2_rid,
     input  logic             [511:0] m_axi_hbm_2_rdata,
     input  axi_pkg::resp_t           m_axi_hbm_2_rresp,
     input  logic                     m_axi_hbm_2_rlast,
     input  logic             [  0:0] m_axi_hbm_2_ruser,
     output logic                     m_axi_hbm_2_bready,
     input  logic                     m_axi_hbm_2_bvalid,
-    input  logic             [  7:0] m_axi_hbm_2_bid,
+    input  logic             [  8:0] m_axi_hbm_2_bid,
     input  axi_pkg::resp_t           m_axi_hbm_2_bresp,
     input  logic             [  0:0] m_axi_hbm_2_buser,
     input  logic                     m_axi_hbm_3_awready,
     output logic                     m_axi_hbm_3_awvalid,
-    output logic             [  7:0] m_axi_hbm_3_awid,
+    output logic             [  8:0] m_axi_hbm_3_awid,
     output logic             [ 47:0] m_axi_hbm_3_awaddr,
     output axi_pkg::len_t            m_axi_hbm_3_awlen,
     output axi_pkg::size_t           m_axi_hbm_3_awsize,
@@ -223,7 +223,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_3_wuser,
     input  logic                     m_axi_hbm_3_arready,
     output logic                     m_axi_hbm_3_arvalid,
-    output logic             [  7:0] m_axi_hbm_3_arid,
+    output logic             [  8:0] m_axi_hbm_3_arid,
     output logic             [ 47:0] m_axi_hbm_3_araddr,
     output axi_pkg::len_t            m_axi_hbm_3_arlen,
     output axi_pkg::size_t           m_axi_hbm_3_arsize,
@@ -236,19 +236,19 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_3_aruser,
     output logic                     m_axi_hbm_3_rready,
     input  logic                     m_axi_hbm_3_rvalid,
-    input  logic             [  7:0] m_axi_hbm_3_rid,
+    input  logic             [  8:0] m_axi_hbm_3_rid,
     input  logic             [511:0] m_axi_hbm_3_rdata,
     input  axi_pkg::resp_t           m_axi_hbm_3_rresp,
     input  logic                     m_axi_hbm_3_rlast,
     input  logic             [  0:0] m_axi_hbm_3_ruser,
     output logic                     m_axi_hbm_3_bready,
     input  logic                     m_axi_hbm_3_bvalid,
-    input  logic             [  7:0] m_axi_hbm_3_bid,
+    input  logic             [  8:0] m_axi_hbm_3_bid,
     input  axi_pkg::resp_t           m_axi_hbm_3_bresp,
     input  logic             [  0:0] m_axi_hbm_3_buser,
     input  logic                     m_axi_hbm_4_awready,
     output logic                     m_axi_hbm_4_awvalid,
-    output logic             [  7:0] m_axi_hbm_4_awid,
+    output logic             [  8:0] m_axi_hbm_4_awid,
     output logic             [ 47:0] m_axi_hbm_4_awaddr,
     output axi_pkg::len_t            m_axi_hbm_4_awlen,
     output axi_pkg::size_t           m_axi_hbm_4_awsize,
@@ -268,7 +268,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_4_wuser,
     input  logic                     m_axi_hbm_4_arready,
     output logic                     m_axi_hbm_4_arvalid,
-    output logic             [  7:0] m_axi_hbm_4_arid,
+    output logic             [  8:0] m_axi_hbm_4_arid,
     output logic             [ 47:0] m_axi_hbm_4_araddr,
     output axi_pkg::len_t            m_axi_hbm_4_arlen,
     output axi_pkg::size_t           m_axi_hbm_4_arsize,
@@ -281,19 +281,19 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_4_aruser,
     output logic                     m_axi_hbm_4_rready,
     input  logic                     m_axi_hbm_4_rvalid,
-    input  logic             [  7:0] m_axi_hbm_4_rid,
+    input  logic             [  8:0] m_axi_hbm_4_rid,
     input  logic             [511:0] m_axi_hbm_4_rdata,
     input  axi_pkg::resp_t           m_axi_hbm_4_rresp,
     input  logic                     m_axi_hbm_4_rlast,
     input  logic             [  0:0] m_axi_hbm_4_ruser,
     output logic                     m_axi_hbm_4_bready,
     input  logic                     m_axi_hbm_4_bvalid,
-    input  logic             [  7:0] m_axi_hbm_4_bid,
+    input  logic             [  8:0] m_axi_hbm_4_bid,
     input  axi_pkg::resp_t           m_axi_hbm_4_bresp,
     input  logic             [  0:0] m_axi_hbm_4_buser,
     input  logic                     m_axi_hbm_5_awready,
     output logic                     m_axi_hbm_5_awvalid,
-    output logic             [  7:0] m_axi_hbm_5_awid,
+    output logic             [  8:0] m_axi_hbm_5_awid,
     output logic             [ 47:0] m_axi_hbm_5_awaddr,
     output axi_pkg::len_t            m_axi_hbm_5_awlen,
     output axi_pkg::size_t           m_axi_hbm_5_awsize,
@@ -313,7 +313,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_5_wuser,
     input  logic                     m_axi_hbm_5_arready,
     output logic                     m_axi_hbm_5_arvalid,
-    output logic             [  7:0] m_axi_hbm_5_arid,
+    output logic             [  8:0] m_axi_hbm_5_arid,
     output logic             [ 47:0] m_axi_hbm_5_araddr,
     output axi_pkg::len_t            m_axi_hbm_5_arlen,
     output axi_pkg::size_t           m_axi_hbm_5_arsize,
@@ -326,19 +326,19 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_5_aruser,
     output logic                     m_axi_hbm_5_rready,
     input  logic                     m_axi_hbm_5_rvalid,
-    input  logic             [  7:0] m_axi_hbm_5_rid,
+    input  logic             [  8:0] m_axi_hbm_5_rid,
     input  logic             [511:0] m_axi_hbm_5_rdata,
     input  axi_pkg::resp_t           m_axi_hbm_5_rresp,
     input  logic                     m_axi_hbm_5_rlast,
     input  logic             [  0:0] m_axi_hbm_5_ruser,
     output logic                     m_axi_hbm_5_bready,
     input  logic                     m_axi_hbm_5_bvalid,
-    input  logic             [  7:0] m_axi_hbm_5_bid,
+    input  logic             [  8:0] m_axi_hbm_5_bid,
     input  axi_pkg::resp_t           m_axi_hbm_5_bresp,
     input  logic             [  0:0] m_axi_hbm_5_buser,
     input  logic                     m_axi_hbm_6_awready,
     output logic                     m_axi_hbm_6_awvalid,
-    output logic             [  7:0] m_axi_hbm_6_awid,
+    output logic             [  8:0] m_axi_hbm_6_awid,
     output logic             [ 47:0] m_axi_hbm_6_awaddr,
     output axi_pkg::len_t            m_axi_hbm_6_awlen,
     output axi_pkg::size_t           m_axi_hbm_6_awsize,
@@ -358,7 +358,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_6_wuser,
     input  logic                     m_axi_hbm_6_arready,
     output logic                     m_axi_hbm_6_arvalid,
-    output logic             [  7:0] m_axi_hbm_6_arid,
+    output logic             [  8:0] m_axi_hbm_6_arid,
     output logic             [ 47:0] m_axi_hbm_6_araddr,
     output axi_pkg::len_t            m_axi_hbm_6_arlen,
     output axi_pkg::size_t           m_axi_hbm_6_arsize,
@@ -371,19 +371,19 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_6_aruser,
     output logic                     m_axi_hbm_6_rready,
     input  logic                     m_axi_hbm_6_rvalid,
-    input  logic             [  7:0] m_axi_hbm_6_rid,
+    input  logic             [  8:0] m_axi_hbm_6_rid,
     input  logic             [511:0] m_axi_hbm_6_rdata,
     input  axi_pkg::resp_t           m_axi_hbm_6_rresp,
     input  logic                     m_axi_hbm_6_rlast,
     input  logic             [  0:0] m_axi_hbm_6_ruser,
     output logic                     m_axi_hbm_6_bready,
     input  logic                     m_axi_hbm_6_bvalid,
-    input  logic             [  7:0] m_axi_hbm_6_bid,
+    input  logic             [  8:0] m_axi_hbm_6_bid,
     input  axi_pkg::resp_t           m_axi_hbm_6_bresp,
     input  logic             [  0:0] m_axi_hbm_6_buser,
     input  logic                     m_axi_hbm_7_awready,
     output logic                     m_axi_hbm_7_awvalid,
-    output logic             [  7:0] m_axi_hbm_7_awid,
+    output logic             [  8:0] m_axi_hbm_7_awid,
     output logic             [ 47:0] m_axi_hbm_7_awaddr,
     output axi_pkg::len_t            m_axi_hbm_7_awlen,
     output axi_pkg::size_t           m_axi_hbm_7_awsize,
@@ -403,7 +403,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_7_wuser,
     input  logic                     m_axi_hbm_7_arready,
     output logic                     m_axi_hbm_7_arvalid,
-    output logic             [  7:0] m_axi_hbm_7_arid,
+    output logic             [  8:0] m_axi_hbm_7_arid,
     output logic             [ 47:0] m_axi_hbm_7_araddr,
     output axi_pkg::len_t            m_axi_hbm_7_arlen,
     output axi_pkg::size_t           m_axi_hbm_7_arsize,
@@ -416,21 +416,21 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_hbm_7_aruser,
     output logic                     m_axi_hbm_7_rready,
     input  logic                     m_axi_hbm_7_rvalid,
-    input  logic             [  7:0] m_axi_hbm_7_rid,
+    input  logic             [  8:0] m_axi_hbm_7_rid,
     input  logic             [511:0] m_axi_hbm_7_rdata,
     input  axi_pkg::resp_t           m_axi_hbm_7_rresp,
     input  logic                     m_axi_hbm_7_rlast,
     input  logic             [  0:0] m_axi_hbm_7_ruser,
     output logic                     m_axi_hbm_7_bready,
     input  logic                     m_axi_hbm_7_bvalid,
-    input  logic             [  7:0] m_axi_hbm_7_bid,
+    input  logic             [  8:0] m_axi_hbm_7_bid,
     input  axi_pkg::resp_t           m_axi_hbm_7_bresp,
     input  logic             [  0:0] m_axi_hbm_7_buser,
 
     /// PCIe Ports
     input  logic                     m_axi_pcie_awready,
     output logic                     m_axi_pcie_awvalid,
-    output logic             [  7:0] m_axi_pcie_awid,
+    output logic             [  8:0] m_axi_pcie_awid,
     output logic             [ 47:0] m_axi_pcie_awaddr,
     output axi_pkg::len_t            m_axi_pcie_awlen,
     output axi_pkg::size_t           m_axi_pcie_awsize,
@@ -450,7 +450,7 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_pcie_wuser,
     input  logic                     m_axi_pcie_arready,
     output logic                     m_axi_pcie_arvalid,
-    output logic             [  7:0] m_axi_pcie_arid,
+    output logic             [  8:0] m_axi_pcie_arid,
     output logic             [ 47:0] m_axi_pcie_araddr,
     output axi_pkg::len_t            m_axi_pcie_arlen,
     output axi_pkg::size_t           m_axi_pcie_arsize,
@@ -463,19 +463,19 @@ module occamy_xilinx
     output logic             [  0:0] m_axi_pcie_aruser,
     output logic                     m_axi_pcie_rready,
     input  logic                     m_axi_pcie_rvalid,
-    input  logic             [  7:0] m_axi_pcie_rid,
+    input  logic             [  8:0] m_axi_pcie_rid,
     input  logic             [511:0] m_axi_pcie_rdata,
     input  axi_pkg::resp_t           m_axi_pcie_rresp,
     input  logic                     m_axi_pcie_rlast,
     input  logic             [  0:0] m_axi_pcie_ruser,
     output logic                     m_axi_pcie_bready,
     input  logic                     m_axi_pcie_bvalid,
-    input  logic             [  7:0] m_axi_pcie_bid,
+    input  logic             [  8:0] m_axi_pcie_bid,
     input  axi_pkg::resp_t           m_axi_pcie_bresp,
     input  logic             [  0:0] m_axi_pcie_buser,
     output logic                     s_axi_pcie_awready,
     input  logic                     s_axi_pcie_awvalid,
-    input  logic             [  2:0] s_axi_pcie_awid,
+    input  logic             [  3:0] s_axi_pcie_awid,
     input  logic             [ 47:0] s_axi_pcie_awaddr,
     input  axi_pkg::len_t            s_axi_pcie_awlen,
     input  axi_pkg::size_t           s_axi_pcie_awsize,
@@ -495,7 +495,7 @@ module occamy_xilinx
     input  logic             [  0:0] s_axi_pcie_wuser,
     output logic                     s_axi_pcie_arready,
     input  logic                     s_axi_pcie_arvalid,
-    input  logic             [  2:0] s_axi_pcie_arid,
+    input  logic             [  3:0] s_axi_pcie_arid,
     input  logic             [ 47:0] s_axi_pcie_araddr,
     input  axi_pkg::len_t            s_axi_pcie_arlen,
     input  axi_pkg::size_t           s_axi_pcie_arsize,
@@ -508,14 +508,14 @@ module occamy_xilinx
     input  logic             [  0:0] s_axi_pcie_aruser,
     input  logic                     s_axi_pcie_rready,
     output logic                     s_axi_pcie_rvalid,
-    output logic             [  2:0] s_axi_pcie_rid,
+    output logic             [  3:0] s_axi_pcie_rid,
     output logic             [511:0] s_axi_pcie_rdata,
     output axi_pkg::resp_t           s_axi_pcie_rresp,
     output logic                     s_axi_pcie_rlast,
     output logic             [  0:0] s_axi_pcie_ruser,
     input  logic                     s_axi_pcie_bready,
     output logic                     s_axi_pcie_bvalid,
-    output logic             [  2:0] s_axi_pcie_bid,
+    output logic             [  3:0] s_axi_pcie_bid,
     output axi_pkg::resp_t           s_axi_pcie_bresp,
     output logic             [  0:0] s_axi_pcie_buser
     /// HBI Ports
@@ -525,11 +525,11 @@ module occamy_xilinx
   //////////
   // PCIe //
   //////////
-  axi_a48_d512_i8_u0_req_t  pcie_axi_req_o;
-  axi_a48_d512_i8_u0_resp_t pcie_axi_rsp_i;
+  axi_a48_d512_i9_u0_req_t  pcie_axi_req_o;
+  axi_a48_d512_i9_u0_resp_t pcie_axi_rsp_i;
 
-  axi_a48_d512_i3_u0_req_t  pcie_axi_req_i;
-  axi_a48_d512_i3_u0_resp_t pcie_axi_rsp_o;
+  axi_a48_d512_i4_u0_req_t  pcie_axi_req_i;
+  axi_a48_d512_i4_u0_resp_t pcie_axi_rsp_o;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(pcie, pcie_axi_req_o, pcie_axi_rsp_i)
@@ -538,43 +538,43 @@ module occamy_xilinx
   /////////
   // HBM //
   /////////
-  axi_a48_d512_i8_u0_req_t  hbm_0_req_o;
-  axi_a48_d512_i8_u0_resp_t hbm_0_rsp_i;
+  axi_a48_d512_i9_u0_req_t  hbm_0_req_o;
+  axi_a48_d512_i9_u0_resp_t hbm_0_rsp_i;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(hbm_0, hbm_0_req_o, hbm_0_rsp_i)
-  axi_a48_d512_i8_u0_req_t  hbm_1_req_o;
-  axi_a48_d512_i8_u0_resp_t hbm_1_rsp_i;
+  axi_a48_d512_i9_u0_req_t  hbm_1_req_o;
+  axi_a48_d512_i9_u0_resp_t hbm_1_rsp_i;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(hbm_1, hbm_1_req_o, hbm_1_rsp_i)
-  axi_a48_d512_i8_u0_req_t  hbm_2_req_o;
-  axi_a48_d512_i8_u0_resp_t hbm_2_rsp_i;
+  axi_a48_d512_i9_u0_req_t  hbm_2_req_o;
+  axi_a48_d512_i9_u0_resp_t hbm_2_rsp_i;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(hbm_2, hbm_2_req_o, hbm_2_rsp_i)
-  axi_a48_d512_i8_u0_req_t  hbm_3_req_o;
-  axi_a48_d512_i8_u0_resp_t hbm_3_rsp_i;
+  axi_a48_d512_i9_u0_req_t  hbm_3_req_o;
+  axi_a48_d512_i9_u0_resp_t hbm_3_rsp_i;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(hbm_3, hbm_3_req_o, hbm_3_rsp_i)
-  axi_a48_d512_i8_u0_req_t  hbm_4_req_o;
-  axi_a48_d512_i8_u0_resp_t hbm_4_rsp_i;
+  axi_a48_d512_i9_u0_req_t  hbm_4_req_o;
+  axi_a48_d512_i9_u0_resp_t hbm_4_rsp_i;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(hbm_4, hbm_4_req_o, hbm_4_rsp_i)
-  axi_a48_d512_i8_u0_req_t  hbm_5_req_o;
-  axi_a48_d512_i8_u0_resp_t hbm_5_rsp_i;
+  axi_a48_d512_i9_u0_req_t  hbm_5_req_o;
+  axi_a48_d512_i9_u0_resp_t hbm_5_rsp_i;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(hbm_5, hbm_5_req_o, hbm_5_rsp_i)
-  axi_a48_d512_i8_u0_req_t  hbm_6_req_o;
-  axi_a48_d512_i8_u0_resp_t hbm_6_rsp_i;
+  axi_a48_d512_i9_u0_req_t  hbm_6_req_o;
+  axi_a48_d512_i9_u0_resp_t hbm_6_rsp_i;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(hbm_6, hbm_6_req_o, hbm_6_rsp_i)
-  axi_a48_d512_i8_u0_req_t  hbm_7_req_o;
-  axi_a48_d512_i8_u0_resp_t hbm_7_rsp_i;
+  axi_a48_d512_i9_u0_req_t  hbm_7_req_o;
+  axi_a48_d512_i9_u0_resp_t hbm_7_rsp_i;
 
   // Assign structs to flattened ports
   `AXI_FLATTEN_MASTER(hbm_7, hbm_7_req_o, hbm_7_rsp_i)

--- a/hw/system/occamy/test/testharness.sv
+++ b/hw/system/occamy/test/testharness.sv
@@ -27,17 +27,17 @@ module testharness import occamy_pkg::*; (
 
 
 
-  axi_a48_d512_i8_u0_req_t hbm_channel_0_req;
-  axi_a48_d512_i8_u0_resp_t hbm_channel_0_rsp;
+  axi_a48_d512_i9_u0_req_t hbm_channel_0_req;
+  axi_a48_d512_i9_u0_resp_t hbm_channel_0_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_hbm_channel_0_channel (
     .clk_i,
     .rst_ni,
@@ -46,17 +46,17 @@ module testharness import occamy_pkg::*; (
   );
 
 
-  axi_a48_d512_i8_u0_req_t hbm_channel_1_req;
-  axi_a48_d512_i8_u0_resp_t hbm_channel_1_rsp;
+  axi_a48_d512_i9_u0_req_t hbm_channel_1_req;
+  axi_a48_d512_i9_u0_resp_t hbm_channel_1_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_hbm_channel_1_channel (
     .clk_i,
     .rst_ni,
@@ -65,17 +65,17 @@ module testharness import occamy_pkg::*; (
   );
 
 
-  axi_a48_d512_i8_u0_req_t hbm_channel_2_req;
-  axi_a48_d512_i8_u0_resp_t hbm_channel_2_rsp;
+  axi_a48_d512_i9_u0_req_t hbm_channel_2_req;
+  axi_a48_d512_i9_u0_resp_t hbm_channel_2_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_hbm_channel_2_channel (
     .clk_i,
     .rst_ni,
@@ -84,17 +84,17 @@ module testharness import occamy_pkg::*; (
   );
 
 
-  axi_a48_d512_i8_u0_req_t hbm_channel_3_req;
-  axi_a48_d512_i8_u0_resp_t hbm_channel_3_rsp;
+  axi_a48_d512_i9_u0_req_t hbm_channel_3_req;
+  axi_a48_d512_i9_u0_resp_t hbm_channel_3_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_hbm_channel_3_channel (
     .clk_i,
     .rst_ni,
@@ -103,17 +103,17 @@ module testharness import occamy_pkg::*; (
   );
 
 
-  axi_a48_d512_i8_u0_req_t hbm_channel_4_req;
-  axi_a48_d512_i8_u0_resp_t hbm_channel_4_rsp;
+  axi_a48_d512_i9_u0_req_t hbm_channel_4_req;
+  axi_a48_d512_i9_u0_resp_t hbm_channel_4_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_hbm_channel_4_channel (
     .clk_i,
     .rst_ni,
@@ -122,17 +122,17 @@ module testharness import occamy_pkg::*; (
   );
 
 
-  axi_a48_d512_i8_u0_req_t hbm_channel_5_req;
-  axi_a48_d512_i8_u0_resp_t hbm_channel_5_rsp;
+  axi_a48_d512_i9_u0_req_t hbm_channel_5_req;
+  axi_a48_d512_i9_u0_resp_t hbm_channel_5_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_hbm_channel_5_channel (
     .clk_i,
     .rst_ni,
@@ -141,17 +141,17 @@ module testharness import occamy_pkg::*; (
   );
 
 
-  axi_a48_d512_i8_u0_req_t hbm_channel_6_req;
-  axi_a48_d512_i8_u0_resp_t hbm_channel_6_rsp;
+  axi_a48_d512_i9_u0_req_t hbm_channel_6_req;
+  axi_a48_d512_i9_u0_resp_t hbm_channel_6_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_hbm_channel_6_channel (
     .clk_i,
     .rst_ni,
@@ -160,17 +160,17 @@ module testharness import occamy_pkg::*; (
   );
 
 
-  axi_a48_d512_i8_u0_req_t hbm_channel_7_req;
-  axi_a48_d512_i8_u0_resp_t hbm_channel_7_rsp;
+  axi_a48_d512_i9_u0_req_t hbm_channel_7_req;
+  axi_a48_d512_i9_u0_resp_t hbm_channel_7_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_hbm_channel_7_channel (
     .clk_i,
     .rst_ni,
@@ -181,17 +181,17 @@ module testharness import occamy_pkg::*; (
 
   logic tx, rx;
 
-  axi_a48_d512_i8_u0_req_t pcie_axi_req;
-  axi_a48_d512_i8_u0_resp_t pcie_axi_rsp;
+  axi_a48_d512_i9_u0_req_t pcie_axi_req;
+  axi_a48_d512_i9_u0_resp_t pcie_axi_rsp;
 
   tb_memory_axi #(
     .AxiAddrWidth (48),
     .AxiDataWidth (512),
-    .AxiIdWidth (8),
+    .AxiIdWidth (9),
     .AxiUserWidth (1),
     .ATOPSupport (0),
-    .req_t (axi_a48_d512_i8_u0_req_t),
-    .rsp_t (axi_a48_d512_i8_u0_resp_t)
+    .req_t (axi_a48_d512_i9_u0_req_t),
+    .rsp_t (axi_a48_d512_i9_u0_resp_t)
   ) i_pcie_axi_channel (
     .clk_i,
     .rst_ni,

--- a/util/occamygen.py
+++ b/util/occamygen.py
@@ -286,7 +286,7 @@ def main():
     soc_wide_xbar = solder.AxiXbar(
         48,
         512,
-        3,
+        4 if occamy.cfg["s1_quadrant"].get("ro_cache_cfg") else 3,
         name="soc_wide_xbar",
         clk="clk_i",
         rst="rst_ni",


### PR DESCRIPTION
Okay, here is my untested try to fix the mismatches. I've also added an assertion so that this doesn't happen again. Probably also wise to add the check to the other cluster ports.