### PR TITLE
occamy: Update CVA6 memories to write-back migration

### DIFF
--- a/hw/system/occamy/src/memories.json
+++ b/hw/system/occamy/src/memories.json
@@ -17,6 +17,20 @@
         "byte_width": 8,
         "density_optimized": false,
         "description": [
+            "cva6 data cache valid and dirty"
+        ],
+        "latency": 1,
+        "ports": 1,
+        "speed_optimized": true,
+        "width": 64,
+        "words": 256
+    },
+    {
+        "byte_enable": true,
+        "byte_width": 8,
+        "density_optimized": false,
+        "description": [
+            "cva6 data cache array",
             "cva6 instruction cache array"
         ],
         "latency": 1,
@@ -44,19 +58,6 @@
         "density_optimized": true,
         "description": [
             "ro cache data"
-        ],
-        "latency": 1,
-        "ports": 1,
-        "speed_optimized": true,
-        "width": 512,
-        "words": 256
-    },
-    {
-        "byte_enable": true,
-        "byte_width": 8,
-        "density_optimized": false,
-        "description": [
-            "cva6 data cache array"
         ],
         "latency": 1,
         "ports": 1,

--- a/util/clustergen/occamy.py
+++ b/util/clustergen/occamy.py
@@ -49,7 +49,7 @@ class Occamy(Generator):
 
         # CVA6
         self.cluster.add_mem(256,
-                             512,
+                             128,
                              desc="cva6 data cache array",
                              byte_enable=True,
                              speed_optimized=True,
@@ -69,6 +69,12 @@ class Occamy(Generator):
         self.cluster.add_mem(256,
                              45,
                              desc="cva6 instruction cache tag",
+                             byte_enable=True,
+                             speed_optimized=True,
+                             density_optimized=False)
+        self.cluster.add_mem(256,
+                             64,
+                             desc="cva6 data cache valid and dirty",
                              byte_enable=True,
                              speed_optimized=True,
                              density_optimized=False)


### PR DESCRIPTION
The CVA6 memories declared in `occamygen.py` still reflected the write-through data cache configuration; now, they declare the correct write-back memories.