### PR TITLE
occamy: Isolate all S1 quadrants by default

### DIFF
--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson
@@ -122,7 +122,8 @@
         cname: "isolate"
         fields: [
           { bits: "3:0"
-            resval: "1"
+            // Isolate all channels by default
+            resval: "15"
             name: "ISOLATE"
             desc: '''
                   Isolate S1 Quadrant. Four bits corresponding to:
@@ -149,7 +150,8 @@
         cname: "isolated"
         fields: [
           { bits: "3:0"
-            resval: "1"
+            // Should correspond to ISOLATE reset value
+            resval: "15"
             name: "ISOLATED"
             desc: '''
                   Isolate satus of S1 Quadrant. Four bits corresponding to:

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson.tpl
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson.tpl
@@ -122,7 +122,8 @@
         cname: "isolate"
         fields: [
           { bits: "3:0"
-            resval: "1"
+            // Isolate all channels by default
+            resval: "15"
             name: "ISOLATE"
             desc: '''
                   Isolate S1 Quadrant. Four bits corresponding to:
@@ -149,7 +150,8 @@
         cname: "isolated"
         fields: [
           { bits: "3:0"
-            resval: "1"
+            // Should correspond to ISOLATE reset value
+            resval: "15"
             name: "ISOLATED"
             desc: '''
                   Isolate satus of S1 Quadrant. Four bits corresponding to:

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_pkg.sv
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_pkg.sv
@@ -549,15 +549,15 @@ package occamy_soc_reg_pkg;
   parameter logic [0:0] OCCAMY_SOC_INTR_TEST_ECC_UNCORRECTABLE_RESVAL = 1'h 0;
   parameter logic [0:0] OCCAMY_SOC_INTR_TEST_ECC_CORRECTABLE_RESVAL = 1'h 0;
   parameter logic [1:0] OCCAMY_SOC_BOOT_MODE_RESVAL = 2'h 0;
-  parameter logic [31:0] OCCAMY_SOC_ISOLATED_RESVAL = 32'h 11111111;
-  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_0_RESVAL = 4'h 1;
-  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_1_RESVAL = 4'h 1;
-  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_2_RESVAL = 4'h 1;
-  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_3_RESVAL = 4'h 1;
-  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_4_RESVAL = 4'h 1;
-  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_5_RESVAL = 4'h 1;
-  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_6_RESVAL = 4'h 1;
-  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_7_RESVAL = 4'h 1;
+  parameter logic [31:0] OCCAMY_SOC_ISOLATED_RESVAL = 32'h ffffffff;
+  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_0_RESVAL = 4'h f;
+  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_1_RESVAL = 4'h f;
+  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_2_RESVAL = 4'h f;
+  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_3_RESVAL = 4'h f;
+  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_4_RESVAL = 4'h f;
+  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_5_RESVAL = 4'h f;
+  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_6_RESVAL = 4'h f;
+  parameter logic [3:0] OCCAMY_SOC_ISOLATED_ISOLATED_7_RESVAL = 4'h f;
 
   // Register index
   typedef enum int {

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_top.sv
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_top.sv
@@ -3453,7 +3453,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'hf)
   ) u_isolate_isolate_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -3479,7 +3479,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'hf)
   ) u_isolate_isolate_1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -3505,7 +3505,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'hf)
   ) u_isolate_isolate_2 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -3531,7 +3531,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'hf)
   ) u_isolate_isolate_3 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -3557,7 +3557,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'hf)
   ) u_isolate_isolate_4 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -3583,7 +3583,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'hf)
   ) u_isolate_isolate_5 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -3609,7 +3609,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'hf)
   ) u_isolate_isolate_6 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -3635,7 +3635,7 @@ module occamy_soc_reg_top #(
   prim_subreg #(
     .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (4'h1)
+    .RESVAL  (4'hf)
   ) u_isolate_isolate_7 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),


### PR DESCRIPTION
This ensures that all S1 quadrants have all of their master and slave ports isolated on reset by changing the respective SoC registers' reset values.