### PR TITLE
ro-cache: Fix Bender manifest dependencies

### DIFF
--- a/hw/ip/snitch_read_only_cache/Bender.yml
+++ b/hw/ip/snitch_read_only_cache/Bender.yml
@@ -9,8 +9,9 @@ package:
   - Samuel Riedel <sriedel@iis.ee.ethz.ch>
 
 dependencies:
-  axi: {path: ../../vendor/pulp_axi}
-  tech_cells_generic: {path: ../../vendor/pulp_tech_cells_generic}
+  axi: {path: ../../vendor/pulp_platform_axi}
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
+  tech_cells_generic: {path: ../../vendor/pulp_platform_tech_cells_generic}
   snitch_icache: {path: ../snitch_icache}
 
 sources:


### PR DESCRIPTION
The read-only cache's Bender manifest contains wrong paths and is missing a dependency on `common_cells`. This currently causes no issues, but we could eventually trip over this as we did with `reqrsp_interface`.