### PR TITLE
banshee: Build banshee in container if changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,19 @@ jobs:
         - -DOMPSTATIC_NUMTHREADS=8
     name: SW on Banshee (Container)
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 0
+    - name: Get Banshee changed
+      id: banshee-changes
+      run: echo "::set-output name=banshee_changed::$(! git diff --name-only --diff-filter=ACMRT
+        ${{ github.event.pull_request.base.sha }} | grep -q ^sw/banshee; echo $?)"
+    - name: Build banshee
+      if: ${{ steps.banshee-changes.outputs.banshee_changed == 1 }}
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        export PATH=$HOME/.cargo/bin:${PATH}
+        cargo install --path sw/banshee
     - name: Build runtime
       working-directory: sw/snRuntime
       run: mkdir build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=toolchain-${{ matrix.toolchain

--- a/sw/banshee/README.md
+++ b/sw/banshee/README.md
@@ -129,7 +129,7 @@ As a hacky workaround, try changing the `llvm-sys = "120"` line to whatever majo
 
 - [x] Add instruction tracing
 - [x] Add SSR support
-- [ ] Add DMA support
+- [x] Add DMA support
 - [x] Add FREP support
 - [x] Add fast local memory / memory hierarchy
 - [x] Add multi-core execution


### PR DESCRIPTION
Addressing #262

The `Get Banshee changed` job sets `banshee_changed` to `1` if there are any changes in `sw/banshee`. This re-builds banshee on pull requests that make changes to banshee. 

For workflows triggered on push, `github.event.pull_request.base.sha` is empty and banshee is not re-built