### PR TITLE
doc: Gen doxygen from runtime and include in mkdocs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
     - master
+    - doc/doxygen
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -15,5 +16,24 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.x
+    - uses: mattnotmitt/doxygen-action@v1
+      with:
+        working-directory: sw/
+    - name: Generate Runtime Documentation
+      run: |
+        mkdir doxybook2; cd doxybook2
+        wget https://github.com/matusnovak/doxybook2/releases/download/v1.4.0/doxybook2-linux-amd64-v1.4.0.zip
+        unzip doxybook2-linux-amd64-v1.4.0.zip; cd ../
+        chmod +x doxybook2/bin/doxybook2
+        mkdir docs/runtime
+        ./doxybook2/bin/doxybook2 --input sw/doxygen/xml --output docs/runtime --config docs/doxybook2.json
+        rm -rf doxybook2
     - run: pip install -r docs/requirements.txt
-    - run: mkdocs gh-deploy --force
+    - run: mkdocs build
+    # - run: mkdocs gh-deploy --force
+    - uses: actions/upload-artifact@v2
+      with:
+        name: mkdocs
+        path: |
+          site/
+          docs/runtime

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
     - master
-    - doc/doxygen
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,11 +28,4 @@ jobs:
         ./doxybook2/bin/doxybook2 --input sw/doxygen/xml --output docs/runtime --config docs/doxybook2.json
         rm -rf doxybook2
     - run: pip install -r docs/requirements.txt
-    - run: mkdocs build
-    # - run: mkdocs gh-deploy --force
-    - uses: actions/upload-artifact@v2
-      with:
-        name: mkdocs
-        path: |
-          site/
-          docs/runtime
+    - run: mkdocs gh-deploy --force

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+runtime

--- a/docs/doxybook2.json
+++ b/docs/doxybook2.json
@@ -1,0 +1,13 @@
+{
+  "baseUrl": "/runtime/",
+  "indexInFolders": true,
+  "linkSuffix": "/",
+  "indexClassesName": "index",
+  "indexFilesName": "index",
+  "indexGroupsName": "index",
+  "indexNamespacesName": "index",
+  "indexRelatedPagesName": "index",
+  "indexExamplesName": "index",
+  "mainPageInRoot": true,
+  "mainPageName": "index"
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,4 +40,11 @@ nav:
   - Snitch Cluster: rm/snitch_cluster/index.md
   - Reqrsp Interface: rm/reqrsp_interface/index.md
   - Custom Instructions: rm/custom_instructions.md
+- Snitch Runtime:
+  - Pages: runtime/Pages/index.md
+  - Files: runtime/Files/index.md
+  - Classes: runtime/Classes/index.md
+  - Examples: runtime/Examples/index.md
+  - Modules: runtime/Modules/index.md
+  - Namespaces: runtime/Namespaces/index.md
   # - Solder: rm/solder.md

--- a/sw/.gitignore
+++ b/sw/.gitignore
@@ -1,0 +1,1 @@
+doxygen

--- a/sw/Doxyfile
+++ b/sw/Doxyfile
@@ -1,0 +1,31 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+DOXYFILE_ENCODING = UTF-8
+PROJECT_NAME = "Snitch Runtime"
+OUTPUT_DIRECTORY = doxygen
+GENERATE_LATEX = NO
+
+# Necessary for doxybook2
+GENERATE_XML = YES
+XML_OUTPUT = xml
+
+# Source
+INPUT = benchmark snBLAS snRuntime
+RECURSIVE = YES
+FILE_PATTERNS = *.h *.hpp *.md
+EXAMPLE_PATH = examples snRuntime/test
+EXAMPLE_PATTERNS = *.c
+
+# Html related stuff, optional
+SHOW_NAMESPACES = YES
+EXTRACT_ALL = YES
+GENERATE_HTML = YES
+
+# This is here just so we don't have to mess
+# with dot executable on continous integration.
+CALL_GRAPH = NO
+HAVE_DOT = NO
+
+IMAGE_PATH = images


### PR DESCRIPTION
Generate doxygen documentation in XML format, convert XML to Markdown using [doxybook2](https://github.com/matusnovak/doxybook2) and include in the published mkdocs documentation on gh-pages.

[This run](https://github.com/pulp-platform/snitch/actions/runs/1277244190) was triggered on a debug-commit and once merged, it *should* work on the regular doc-CI ;)

![image](https://user-images.githubusercontent.com/3391933/134864590-9e6c4b9a-c0ba-4574-90f2-1d33d02bcd39.png)
