### PR TITLE
RTL sim: fix return value overwrite with 0

### DIFF
--- a/hw/ip/test/src/tb_bin.cc
+++ b/hw/ip/test/src/tb_bin.cc
@@ -2,9 +2,22 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
+#include <printf.h>
+
 #include "sim.hh"
 
 int main(int argc, char **argv, char **env) {
+    // Write binary path to logs/binary for the `make annotate` target
+    FILE *fd;
+    fd = fopen("logs/.rtlbinary", "w");
+    if (fd != NULL && argc >= 2) {
+        fprintf(fd, "%s\n", argv[1]);
+        fclose(fd);
+    } else {
+        fprintf(stderr,
+                "Warning: Failed to write binary name to logs/.rtlbinary\n");
+    }
+
     auto sim = std::make_unique<sim::Sim>(argc, argv);
     return sim->run();
 }

--- a/hw/system/.gitignore
+++ b/hw/system/.gitignore
@@ -14,3 +14,4 @@ ucli.key
 vc_hdrs.h
 build/
 AN.DB/
+.rtlbinary

--- a/hw/system/snitch_cluster/README.md
+++ b/hw/system/snitch_cluster/README.md
@@ -37,6 +37,10 @@ target.
 
     make traces
 
+A source-code annotated trace can be generated using the `annotate` target
+
+    make annotate
+
 ## Software
 
 The runtime and additional software libraries for the cluster configuration can be compiled as follows:

--- a/sw/snRuntime/CMakeLists.txt
+++ b/sw/snRuntime/CMakeLists.txt
@@ -150,7 +150,6 @@ add_snitch_test_args(printf_fmtint printf_fmtint-cluster --no-opt-llvm --base-ha
 add_snitch_test_args(printf_fmtint printf_fmtint-system --no-opt-llvm --base-hartid=3 --num-cores=8 --num-clusters=4)
 
 add_snitch_test_executable(team_global tests/team_global.c)
-add_snitch_test_rtl(team_global)
 add_snitch_test_args(team_global team_global --base-hartid=3 --num-cores=4 --num-clusters=2)
 
 # Tests exclusive to LLVM

--- a/sw/snRuntime/src/start.S
+++ b/sw/snRuntime/src/start.S
@@ -181,6 +181,7 @@ snrt.crt0.pre_barrier:
     # Execute the main function.
 snrt.crt0.main:
     call      main  # main(int core_id, int core_num, void *spm_start, void *spm_end)
+    mv        s0, a0 # store return value in s0
     # lw        s0, tcdm_end_address_reg  # add return value to special slot
     # addi      s0, s0, -8
     # amoadd.w  zero, a0, (s0)
@@ -191,6 +192,7 @@ snrt.crt0.post_barrier:
 
     # Write execution result to EOC register.
 snrt.crt0.end:
+    mv        a0, s0 # recover return value of main function in s0
     call      _snrt_exit
 1:
     wfi

--- a/util/trace/annotate.py
+++ b/util/trace/annotate.py
@@ -59,6 +59,11 @@ parser.add_argument(
     type=int,
     default=-1,
     help='Last line to parse')
+parser.add_argument(
+    '-q',
+    '--quiet',
+    action='store_true',
+    help='Quiet output')
 
 args = parser.parse_args()
 
@@ -66,15 +71,18 @@ elf = args.elf
 trace = args.trace
 output = args.output
 addr2line = args.addr2line
+quiet = args.quiet
 
-print('elf:', elf, file=sys.stderr)
-print('trace:', trace, file=sys.stderr)
-print('output:', output, file=sys.stderr)
-print('addr2line:', addr2line, file=sys.stderr)
+if not quiet:
+    print('elf:', elf, file=sys.stderr)
+    print('trace:', trace, file=sys.stderr)
+    print('output:', output, file=sys.stderr)
+    print('addr2line:', addr2line, file=sys.stderr)
 
 of = open(output, 'w')
 
-print(f' annotating: {output}    ', end='')
+if not quiet:
+    print(f' annotating: {output}    ', end='')
 
 # buffer source files
 src_files = {}
@@ -138,10 +146,12 @@ with open(trace, 'r') as f:
         last = annot
 
         # very simple progress
-        prog = int(100.0 / tot_lines * lino)
-        if prog > last_prog:
-            last_prog = prog
-            sys.stdout.write(f'\b\b\b\b{prog:3d}%')
-            sys.stdout.flush()
-print(' done')
-print(adr2line.cache_info())
+        if not quiet:
+            prog = int(100.0 / tot_lines * lino)
+            if prog > last_prog:
+                last_prog = prog
+                sys.stdout.write(f'\b\b\b\b{prog:3d}%')
+                sys.stdout.flush()
+if not quiet:
+    print(' done')
+    print(adr2line.cache_info())


### PR DESCRIPTION
The return value stored in `a0` in RTL sims was overwritten in `_snrt_cluster_barrier`.

This PR further smuggles in the `make annotate` target in cluster sims. It generates source-code annotated traces from RTL simulation using the `annotate.py` script.