### PR TITLE
banshee: Fix `fcvt` + add `fmv` for half-floats

### DIFF
--- a/sw/banshee/flexfloat/src/lib.rs
+++ b/sw/banshee/flexfloat/src/lib.rs
@@ -325,7 +325,7 @@ pub unsafe fn ff_instruction_cvt_to_s(
     op: FfOpCvt,
     fpmode_src: bool,
     _fpmode_dst: bool,
-) -> f32 {
+) -> i32 {
     let env_fp8_src: flexfloat_desc_t = if fpmode_src { env_fp8alt } else { env_fp8 };
     let env_fp16_src: flexfloat_desc_t = if fpmode_src { env_fp16alt } else { env_fp16 };
 
@@ -351,8 +351,8 @@ pub unsafe fn ff_instruction_cvt_to_s(
         _ => (),
     };
 
-    let rd = ff_get_float(ff_res);
-    rd as f32
+    let rd = flexfloat_get_bits(ff_res);
+    rd as i32
 }
 
 /// conversions to fp64

--- a/sw/banshee/flexfloat/src/lib.rs
+++ b/sw/banshee/flexfloat/src/lib.rs
@@ -325,7 +325,7 @@ pub unsafe fn ff_instruction_cvt_to_s(
     op: FfOpCvt,
     fpmode_src: bool,
     _fpmode_dst: bool,
-) -> u32 {
+) -> f32 {
     let env_fp8_src: flexfloat_desc_t = if fpmode_src { env_fp8alt } else { env_fp8 };
     let env_fp16_src: flexfloat_desc_t = if fpmode_src { env_fp16alt } else { env_fp16 };
 
@@ -351,8 +351,8 @@ pub unsafe fn ff_instruction_cvt_to_s(
         _ => (),
     };
 
-    let rd = flexfloat_get_bits(ff_res);
-    rd as u32
+    let rd = ff_get_float(ff_res);
+    rd as f32
 }
 
 /// conversions to fp64

--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -1060,7 +1060,7 @@ impl<'a, 'b> Cpu<'a, 'b> {
         op: flexfloat::FfOpCvt,
         fpmode_src: bool,
         fpmode_dst: bool,
-    ) -> u32 {
+    ) -> f32 {
         flexfloat::ff_instruction_cvt_to_s(rs1, op, fpmode_src, fpmode_dst)
     }
 

--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -1060,7 +1060,7 @@ impl<'a, 'b> Cpu<'a, 'b> {
         op: flexfloat::FfOpCvt,
         fpmode_src: bool,
         fpmode_dst: bool,
-    ) -> f32 {
+    ) -> i32 {
         flexfloat::ff_instruction_cvt_to_s(rs1, op, fpmode_src, fpmode_dst)
     }
 

--- a/sw/banshee/src/runtime/jit.ll
+++ b/sw/banshee/src/runtime/jit.ll
@@ -45,7 +45,7 @@ declare i8 @banshee_fcvtb(i64 %rs1, i8 %op)
 declare i8 @banshee_fcvtab(i64 %rs1, i8 %op)
 
 declare i64 @banshee_fp64_op_cvt_to_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)
-declare i32 @banshee_fp32_op_cvt_to_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)
+declare float @banshee_fp32_op_cvt_to_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)
 declare i16 @banshee_fp16_op(i16 %rs1, i16 %rs2, i16 %rs3, i8 %op, i1 %fpmode_dst)
 declare i32 @banshee_fp16_op_cvt_from_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)
 declare i16 @banshee_fp16_op_cvt_to_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)

--- a/sw/banshee/src/runtime/jit.ll
+++ b/sw/banshee/src/runtime/jit.ll
@@ -45,7 +45,7 @@ declare i8 @banshee_fcvtb(i64 %rs1, i8 %op)
 declare i8 @banshee_fcvtab(i64 %rs1, i8 %op)
 
 declare i64 @banshee_fp64_op_cvt_to_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)
-declare float @banshee_fp32_op_cvt_to_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)
+declare i32 @banshee_fp32_op_cvt_to_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)
 declare i16 @banshee_fp16_op(i16 %rs1, i16 %rs2, i16 %rs3, i8 %op, i1 %fpmode_dst)
 declare i32 @banshee_fp16_op_cvt_from_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)
 declare i16 @banshee_fp16_op_cvt_to_f(i64 %rs1, i8 %op, i1 %fpmode_src, i1 %fpmode_dst)

--- a/sw/banshee/src/tran.rs
+++ b/sw/banshee/src/tran.rs
@@ -3303,18 +3303,6 @@ impl<'a> InstructionTranslator<'a> {
                 );
                 self.write_freg(data.rd, value);
             }
-            riscv::OpcodeRdRs1::FcvtHD => {
-                let (fpmode_src, fpmode_dst) = self.read_fpmode();
-                let rs1 = self.read_freg(data.rs1);
-                let rs1 = LLVMBuildZExt(self.builder, rs1, LLVMInt64Type(), NONAME);
-                let value = self.emit_fp16_op_cvt_to_f(
-                    rs1,
-                    flexfloat::FfOpCvt::Fcvt16f2f,
-                    fpmode_src,
-                    fpmode_dst,
-                );
-                self.write_freg_f16(data.rd, value);
-            }
             riscv::OpcodeRdRs1::VfsumS => {
                 let (a1, a0) = self.read_freg_vf64s(data.rs1);
                 let c0 = self.read_freg_f32(data.rd);

--- a/sw/banshee/src/tran.rs
+++ b/sw/banshee/src/tran.rs
@@ -7251,7 +7251,6 @@ impl<'a> InstructionTranslator<'a> {
 
     /// Emit the code to write a f8 value to a float register.
     unsafe fn write_freg_f8(&self, rd: u32, data: LLVMValueRef) {
-
         // Nan-box value
         let nan_box = LLVMConstInt(LLVMInt64Type(), (-1i64 - 0xff) as u64, 0);
         let value = LLVMBuildZExt(self.builder, data, LLVMInt64Type(), NONAME);


### PR DESCRIPTION
* Fixes `fcvt.s.h` instruction in banshee which was broken due to a `float` and `i32` mismatch.
* Adds `fmv.x.h` and `fmv.h.x` instructions