### PR TITLE
cluster: Verilator testbench with LLVM12

### DIFF
--- a/docs/ug/snitch_cluster.md
+++ b/docs/ug/snitch_cluster.md
@@ -82,3 +82,20 @@ make bin/snitch_cluster.vlt CFG=cfg/single-core.hjson
 The default config is in `cfg/cluster.default.hjson`. Alternatively, you can also
 set your `CFG` environment variable, the Makefile will pick it up and override
 the standard config.
+
+
+## Using Verilator with LLVM
+
+LLVM+clang can be used to build the Verilator model. Optionally specify a path
+to the LLVM toolchain in `CLANG_PATH` and set `VLT_USE_LLVM=ON`.
+For the verilated model itself to be complied with LLVM, verilator must be built
+with LLVM (`CC=clang CXX=clang++ ./configure`). The `VLT` environment variable
+can then be used to point to the verilator binary.
+
+```bash
+# Optional: Specify which llvm to use
+export CLANG_PATH=/path/to/llvm-12.0.1
+# Optional: Point to a verilator binary compiled with LLVM
+export VLT=/path/to/verilator-llvm/bin/verilator
+make VLT_USE_LLVM=ON bin/snitch_cluster.vlt
+```

--- a/hw/ip/test/src/sim.hh
+++ b/hw/ip/test/src/sim.hh
@@ -42,6 +42,7 @@ struct Sim : htif_t {
    private:
     context_t *host;
     context_t target;
+    bool vlt_vcd = false;
 };
 
 void sim_thread_main(void *arg);

--- a/hw/ip/test/src/verilator_lib.cc
+++ b/hw/ip/test/src/verilator_lib.cc
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: SHL-0.51
 
 #include "Vtestharness.h"
+#include "Vtestharness__Dpi.h"
 #include "sim.hh"
 #include "tb_lib.hh"
 #include "verilated.h"

--- a/hw/system/snitch_cluster/Makefile
+++ b/hw/system/snitch_cluster/Makefile
@@ -80,7 +80,7 @@ $(VLT_BUILDDIR)/generated/%.o: generated/%.cc ${VLT_BUILDDIR}/lib/libfesvr.a
 # Link verilated archive wich $(VLT_COBJ)
 bin/snitch_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
 	mkdir -p $(dir $@)
-	$(CXX) $(LDFLAGS) -std=c++14 -lpthread -L ${VLT_BUILDDIR}/lib -lfesvr -o $@ $(VLT_AR) $(VLT_COBJ)
+	$(CXX) $(LDFLAGS) -std=c++14 -L ${VLT_BUILDDIR}/lib -o $@ $(VLT_COBJ) $(VLT_AR) -lfesvr -lpthread
 
 ############
 # Modelsim #

--- a/hw/system/snitch_cluster/Makefile
+++ b/hw/system/snitch_cluster/Makefile
@@ -67,13 +67,13 @@ clean-vlt-obj:
 	rm $(VLT_COBJ)
 
 # Build targets for verilator TB
-$(VLT_BUILDDIR)/tb/%.o: $(TB_DIR)/%.cc $(VLT_AR)
+$(VLT_BUILDDIR)/tb/%.o: $(TB_DIR)/%.cc $(VLT_AR) ${VLT_BUILDDIR}/lib/libfesvr.a
 	mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
 $(VLT_BUILDDIR)/vlt/%.o: $(VLT_ROOT)/include/%.cpp
 	mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
-$(VLT_BUILDDIR)/generated/%.o: generated/%.cc
+$(VLT_BUILDDIR)/generated/%.o: generated/%.cc ${VLT_BUILDDIR}/lib/libfesvr.a
 	mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
 

--- a/hw/system/snitch_cluster/Makefile
+++ b/hw/system/snitch_cluster/Makefile
@@ -15,6 +15,9 @@ CFG 		?= cfg/cluster.default.hjson
 CLUSTER_GEN ?= $(ROOT)/util/clustergen.py
 CLUSTER_GEN_SRC ?= $(wildcard $(ROOT)/util/clustergen/*.py)
 
+# Verilated and compiled snitch cluster
+VLT_AR          = ${VLT_BUILDDIR}/Vtestharness__ALL.a
+
 # uncomment, if questasim should be run in 64-bit mode
 QUESTA_64BIT	= -64
 VSIM      		= vsim ${QUESTA_64BIT}
@@ -45,32 +48,39 @@ test/bootrom.elf test/bootrom.dump test/bootrom.bin: test/bootrom.S test/bootrom
 #############
 # Verilator #
 #############
-${VLT_BUILDDIR}/verilate: ${VLT_SOURCES} ${TB_SRCS}
+$(VLT_AR): ${VLT_SOURCES} ${TB_SRCS}
 	$(call VERILATE,testharness)
+verilate: $(VLT_AR)
 
-verilate: ${VLT_BUILDDIR}/verilate
+# Required C sources for the verilator TB that are linked against the verilated model
+VLT_COBJ += $(VLT_BUILDDIR)/tb/common_lib.o
+VLT_COBJ += $(VLT_BUILDDIR)/tb/verilator_lib.o
+VLT_COBJ += $(VLT_BUILDDIR)/tb/tb_bin.o
+# Sources from verilator root
+VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated.o
+VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_dpi.o
+VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_vcd_c.o
+# Bootdata
+VLT_COBJ += $(VLT_BUILDDIR)/generated/bootdata.o
 
-bin/snitch_cluster.vlt: ${VLT_BUILDDIR}/verilate ${TB_DIR}/verilator_lib.cc ${TB_DIR}/common_lib.cc ${TB_DIR}/tb_bin.cc work/lib/libfesvr.a test/bootrom.bin generated/bootdata.cc
-	$(CXX) $(VLT_CFLAGS) -c ${TB_DIR}/common_lib.cc -o ${VLT_BUILDDIR}/common_lib.o -Itest
-	$(CXX) $(VLT_CFLAGS) -c generated/bootdata.cc -o ${VLT_BUILDDIR}/bootdata.o -Itest
-	$(CXX) $(VLT_CFLAGS) -c ${TB_DIR}/verilator_lib.cc -o ${VLT_BUILDDIR}/verilator_lib.o
-	$(CXX) $(VLT_CFLAGS) -c $(VLT_ROOT)/include/verilated.cpp -o ${VLT_BUILDDIR}/verilated.o
-	$(CXX) $(VLT_CFLAGS) -c $(VLT_ROOT)/include/verilated_dpi.cpp -o ${VLT_BUILDDIR}/verilated_dpi.o
-	$(CXX) $(VLT_CFLAGS) -c $(VLT_ROOT)/include/verilated_vcd_c.cpp -o ${VLT_BUILDDIR}/verilated_vcd_c.o
-	mkdir -p bin
-	$(LD) -o ${VLT_BUILDDIR}/snitch_cluster.o -r \
-		${VLT_BUILDDIR}/common_lib.o \
-		${VLT_BUILDDIR}/bootdata.o \
-		${VLT_BUILDDIR}/verilator_lib.o \
-		${VLT_BUILDDIR}/verilated.o \
-		${VLT_BUILDDIR}/verilated_dpi.o \
-		${VLT_BUILDDIR}/verilated_vcd_c.o \
-		${VLT_BUILDDIR}/Vtestharness__ALL.a \
-		-lfesvr \
-		-L ${VLT_BUILDDIR} \
-		-L $(FESVR)/lib
-	$(AR) rcs bin/libsnitch_cluster.a ${VLT_BUILDDIR}/snitch_cluster.o
-	$(CXX) $(VLT_CFLAGS) ${TB_DIR}/tb_bin.cc -L bin -lsnitch_cluster -o $@
+clean-vlt-obj:
+	rm $(VLT_COBJ)
+
+# Build targets for verilator TB
+$(VLT_BUILDDIR)/tb/%.o: $(TB_DIR)/%.cc $(VLT_AR)
+	mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
+$(VLT_BUILDDIR)/vlt/%.o: $(VLT_ROOT)/include/%.cpp
+	mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
+$(VLT_BUILDDIR)/generated/%.o: generated/%.cc
+	mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
+
+# Link verilated archive wich $(VLT_COBJ)
+bin/snitch_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
+	mkdir -p $(dir $@)
+	$(CXX) $(LDFLAGS) -std=c++14 -lpthread -L ${VLT_BUILDDIR}/lib -lfesvr -o $@ $(VLT_AR) $(VLT_COBJ)
 
 ############
 # Modelsim #

--- a/util/Makefrag
+++ b/util/Makefrag
@@ -3,7 +3,6 @@ BENDER		   ?= bender
 DASM 	       ?= spike-dasm
 VLT			   ?= verilator
 
-# VERILATOR_ROOT ?= $(dirname $(shell which $(VLT)))/../share/verilator
 VERILATOR_ROOT ?= $(dir $(shell which $(VLT)))/../share/verilator
 VLT_ROOT	   ?= ${VERILATOR_ROOT}
 
@@ -22,6 +21,7 @@ FESVR          ?= ${MKFILE_DIR}work
 FESVR_VERSION  ?= 35d50bc40e59ea1d5566fbd3d9226023821b1bb6
 
 VLT_BUILDDIR := work-vlt
+VLT_FESVR     = $(VLT_BUILDDIR)/riscv-isa-sim
 VLT_FLAGS    += -Wno-BLKANDNBLK
 VLT_FLAGS    += -Wno-LITENDIAN
 VLT_FLAGS    += -Wno-CASEINCOMPLETE
@@ -34,7 +34,8 @@ VLT_FLAGS    += -Wno-fatal
 VLT_FLAGS    += --unroll-count 1024
 VLT_BENDER   += -t rtl
 VLT_SOURCES  := $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
-VLT_CFLAGS   ?= -std=c++14 -pthread -I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(FESVR)/include -I $(TB_DIR)
+VLT_CFLAGS   += -std=c++14 -pthread
+VLT_CFLAGS   +=-I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I $(TB_DIR)
 
 # We need a recent LLVM installation (>11) to compile Verilator.
 # We also need to link the binaries with LLVM's libc++.
@@ -87,14 +88,14 @@ work/lib/libfesvr.a: work/${FESVR_VERSION}_unzip
 
 # Build fesvr seperately for verilator since this might use different compilers
 # and libraries than modelsim/vcs and
-$(VLT_BUILDDIR)/riscv-isa-sim/${FESVR_VERSION}_unzip:
+$(VLT_FESVR)/${FESVR_VERSION}_unzip:
 	mkdir -p $(dir $@)
 	wget -O $(dir $@)/${FESVR_VERSION} https://github.com/riscv/riscv-isa-sim/tarball/${FESVR_VERSION}
 	tar xfm $(dir $@)${FESVR_VERSION} --strip-components=1 -C $(dir $@)
 	patch -d $(dir $@) -p1 < ${ROOT}/util/patches/riscv-isa-sim/fesrv.patch
 	touch $@
 
-$(VLT_BUILDDIR)/lib/libfesvr.a: $(VLT_BUILDDIR)/riscv-isa-sim/${FESVR_VERSION}_unzip
+$(VLT_BUILDDIR)/lib/libfesvr.a: $(VLT_FESVR)/${FESVR_VERSION}_unzip
 	cd $(dir $<)/ && ./configure --prefix `pwd` \
         CC=${CC} CXX=${CXX} CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
 	$(MAKE) -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a

--- a/util/Makefrag
+++ b/util/Makefrag
@@ -3,7 +3,8 @@ BENDER		   ?= bender
 DASM 	       ?= spike-dasm
 VLT			   ?= verilator
 
-VERILATOR_ROOT ?= $$(dirname $$(which $(VLT)))/../share/verilator
+# VERILATOR_ROOT ?= $(dirname $(shell which $(VLT)))/../share/verilator
+VERILATOR_ROOT ?= $(dir $(shell which $(VLT)))/../share/verilator
 VLT_ROOT	   ?= ${VERILATOR_ROOT}
 
 MATCH_END := '/+incdir+/ s/$$/\/*\/*/'
@@ -35,6 +36,34 @@ VLT_BENDER   += -t rtl
 VLT_SOURCES  := $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
 VLT_CFLAGS   ?= -std=c++14 -pthread -I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(FESVR)/include -I $(TB_DIR)
 
+# We need a recent LLVM installation (>11) to compile Verilator.
+# We also need to link the binaries with LLVM's libc++.
+# Define CLANG_PATH to be the path of your Clang installation.
+
+ifneq (${CLANG_PATH},)
+    CLANG_CC       := $(CLANG_PATH)/bin/clang
+    CLANG_CXX      := $(CLANG_PATH)/bin/clang++
+    CLANG_CXXFLAGS := -nostdinc++ -isystem $(CLANG_PATH)/include/c++/v1
+    CLANG_LDFLAGS  := -nostdlib++ -fuse-ld=lld -L ${CLANG_PATH}/lib -Wl,-rpath,${CLANG_PATH}/lib -lc++
+else
+    CLANG_CC       ?= clang
+    CLANG_CXX      ?= clang++
+    CLANG_CXXFLAGS := ""
+    CLANG_LDFLAGS  := ""
+endif
+
+# If requested, build verilator with LLVM and add llvm c/ld flags
+ifeq ($(VLT_USE_LLVM),ON)
+    CC         = $(CLANG_CC)
+    CXX        = $(CLANG_CXX)
+    CFLAGS     = $(CLANG_CXXFLAGS)
+    CXXFLAGS   = $(CLANG_CXXFLAGS)
+    LDFLAGS    = $(CLANG_LDFLAGS)
+    VLT_FLAGS += --compiler clang
+    VLT_FLAGS += -CFLAGS "${CLANG_CXXFLAGS}"
+    VLT_FLAGS += -LDFLAGS "${CLANG_LDFLAGS}"
+endif
+
 VLOGAN_FLAGS := -assert svaext
 VLOGAN_FLAGS += -assert disable_cover
 VLOGAN_FLAGS += -full64
@@ -53,6 +82,22 @@ work/${FESVR_VERSION}_unzip:
 work/lib/libfesvr.a: work/${FESVR_VERSION}_unzip
 	cd $(dir $<)/ && ./configure --prefix `pwd`
 	make -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a
+	mkdir -p $(dir $@)
+	cp $(dir $<)libfesvr.a $@
+
+# Build fesvr seperately for verilator since this might use different compilers
+# and libraries than modelsim/vcs and
+$(VLT_BUILDDIR)/riscv-isa-sim/${FESVR_VERSION}_unzip:
+	mkdir -p $(dir $@)
+	wget -O $(dir $@)/${FESVR_VERSION} https://github.com/riscv/riscv-isa-sim/tarball/${FESVR_VERSION}
+	tar xfm $(dir $@)${FESVR_VERSION} --strip-components=1 -C $(dir $@)
+	patch -d $(dir $@) -p1 < ${ROOT}/util/patches/riscv-isa-sim/fesrv.patch
+	touch $@
+
+$(VLT_BUILDDIR)/lib/libfesvr.a: $(VLT_BUILDDIR)/riscv-isa-sim/${FESVR_VERSION}_unzip
+	cd $(dir $<)/ && ./configure --prefix `pwd` \
+        CC=${CC} CXX=${CXX} CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
+	$(MAKE) -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a
 	mkdir -p $(dir $@)
 	cp $(dir $<)libfesvr.a $@
 

--- a/util/patches/riscv-isa-sim/fesrv.patch
+++ b/util/patches/riscv-isa-sim/fesrv.patch
@@ -1,0 +1,12 @@
+diff -Naur work-orig/fesvr/context.h work/fesvr/context.h
+--- work-orig/fesvr/context.h	2021-09-28 13:43:01.948011433 +0200
++++ work/fesvr/context.h	2021-09-28 13:43:30.549093869 +0200
+@@ -7,7 +7,7 @@
+ 
+ #if defined(__GLIBC__)
+ # undef USE_UCONTEXT
+-# define USE_UCONTEXT
++// # define USE_UCONTEXT
+ # include <ucontext.h>
+ # include <memory>
+ #include <limits.h>


### PR DESCRIPTION
The main issue for it not working out-of-the-box was the use of `ucontext` in the front-end server (fesvr). Accoring [to the Linux man page](https://linux.die.net/man/3/swapcontext), this cooperative scheduling technique is removed in *POSIX.1-2008* and POSIX threads are recommended. The patch takes care of that. 

Unfortunately, i couldn't notice significant speedup in either verilate- nor run-time. I will try to make the snitch cluster hierarchically compileable and multithreaded to see if that speeds up the compilation.

## Further changes
- Disable VCD output per default, can be enabled with `--vcd` when runnint `./bin/snitch_cluster.vlt`
- Distinct build location for `fesvr` from vsim and verilator since it might linked against different libraries which would break vsim/vlt simultaneous simulation
- For LLVM: use lld linker