### PR TITLE
FPnew update: bugfix and VCS compatibility

### DIFF
--- a/hw/ip/snitch/src/snitch_lsu.sv
+++ b/hw/ip/snitch/src/snitch_lsu.sv
@@ -162,8 +162,8 @@ module snitch_lsu #(
   assign shifted_data = data_rsp_i.p.data >> {laq_out.offset, 3'b000};
   always_comb begin
     unique case (laq_out.size)
-      2'b00: ld_result = {{56{shifted_data[7] & laq_out.sign_ext}}, shifted_data[7:0]};
-      2'b01: ld_result = {{48{shifted_data[15] & laq_out.sign_ext}}, shifted_data[15:0]};
+      2'b00: ld_result = {{56{(shifted_data[7] | NaNBox) & laq_out.sign_ext}}, shifted_data[7:0]};
+      2'b01: ld_result = {{48{(shifted_data[15] | NaNBox) & laq_out.sign_ext}}, shifted_data[15:0]};
       2'b10: ld_result = {{32{(shifted_data[31] | NaNBox) & laq_out.sign_ext}}, shifted_data[31:0]};
       2'b11: ld_result = shifted_data;
       default: ld_result = shifted_data;

--- a/hw/ip/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/ip/snitch_cluster/src/snitch_cluster.sv
@@ -86,7 +86,8 @@ module snitch_cluster
   parameter bit [NrCores-1:0] Xfrep         = '0,
   /// # Core-global parameters
   /// FPU configuration.
-  parameter fpnew_pkg::fpu_implementation_t FPUImplementation [NrCores] = '{default: 0},
+  parameter fpnew_pkg::fpu_implementation_t FPUImplementation [NrCores] =
+    '{default: fpnew_pkg::fpu_implementation_t'(0)},
   /// Physical Memory Attribute Configuration
   parameter snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '0,
   /// # Per-core parameters

--- a/hw/vendor/pulp_platform_fpnew.lock.hjson
+++ b/hw/vendor/pulp_platform_fpnew.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/fpnew.git
-    rev: fbccdf1fb2291fc0145a3d98ef47546034ce4101
+    rev: 8b56b211015d4eb7c5835e362c709a25cf342e72
   }
 }

--- a/hw/vendor/pulp_platform_fpnew/src/fpnew_opgroup_multifmt_slice.sv
+++ b/hw/vendor/pulp_platform_fpnew/src/fpnew_opgroup_multifmt_slice.sv
@@ -63,7 +63,7 @@ module fpnew_opgroup_multifmt_slice #(
   // We will send the format information along with the data
   localparam int unsigned FMT_BITS =
       fpnew_pkg::maximum($clog2(NUM_FORMATS), $clog2(NUM_INT_FORMATS));
-  localparam int unsigned AUX_BITS = FMT_BITS + 3; // also add vectorial and integer flags
+  localparam int unsigned AUX_BITS = FMT_BITS + 4; // also add vectorial and integer flags
 
   logic [NUM_LANES-1:0] lane_in_ready, lane_out_valid; // Handshake signals for the lanes
   logic                 vectorial_op;
@@ -239,13 +239,13 @@ module fpnew_opgroup_multifmt_slice #(
           .busy_o          ( lane_busy[lane]     )
         );
       end else if (OpGroup == fpnew_pkg::DOTP) begin : lane_instance
-        fpnew_dotp_wrapper #(
+        fpnew_sdotp_multi_wrapper #(
           .FpFmtConfig ( LANE_FORMATS         ), // fp64 and fp32 not supported
           .NumPipeRegs ( NumPipeRegs          ),
           .PipeConfig  ( PipeConfig           ),
           .TagType     ( TagType              ),
           .AuxType     ( logic [AUX_BITS-1:0] )
-        ) i_fpnew_dotp_wrapper (
+        ) i_fpnew_sdotp_multi_wrapper (
           .clk_i,
           .rst_ni,
           .operands_i      ( local_operands[2:0] ), // 3 operands

--- a/hw/vendor/pulp_platform_fpnew/src/fpnew_sdotp_multi_wrapper.sv
+++ b/hw/vendor/pulp_platform_fpnew/src/fpnew_sdotp_multi_wrapper.sv
@@ -15,7 +15,7 @@
 
 `include "common_cells/registers.svh"
 
-module fpnew_dotp_wrapper #(
+module fpnew_sdotp_multi_wrapper #(
   parameter fpnew_pkg::fmt_logic_t   FpFmtConfig = '1,
   parameter int unsigned             NumPipeRegs = 0,
   parameter fpnew_pkg::pipe_config_t PipeConfig  = fpnew_pkg::BEFORE,
@@ -25,37 +25,38 @@ module fpnew_dotp_wrapper #(
   // Do not change
   localparam fpnew_pkg::fmt_logic_t FpSrcFmtConfig = FpFmtConfig[0] ? (FpFmtConfig & 6'b001111) : (FpFmtConfig & 6'b000101),
   localparam fpnew_pkg::fmt_logic_t FpDstFmtConfig = fpnew_pkg::get_dotp_dst_fmts(FpSrcFmtConfig),
-  localparam int unsigned SRC_WIDTH   = fpnew_pkg::max_fp_width(FpSrcFmtConfig),
-  localparam int unsigned DST_WIDTH   = 2*SRC_WIDTH, // do not change, current assumption of dotpexp_multi
-  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS
+  localparam int                     SRC_WIDTH     = fpnew_pkg::max_fp_width(FpSrcFmtConfig),
+  localparam int                     DST_WIDTH     = 2*fpnew_pkg::max_fp_width(FpSrcFmtConfig), // do not change, current assumption of sdotpex_multi
+  localparam int                     OPERAND_WIDTH = 4*fpnew_pkg::max_fp_width(FpSrcFmtConfig), // do not change, current assumption of sdotpex_multi
+  localparam int unsigned NUM_FORMATS              = fpnew_pkg::NUM_FP_FORMATS
 ) (
   input logic                      clk_i,
   input logic                      rst_ni,
   // Input signals
-  input logic [2:0][2*DST_WIDTH-1:0] operands_i, // 3 operands
-  input logic [NUM_FORMATS-1:0][2:0] is_boxed_i, // 3 operands
-  input fpnew_pkg::roundmode_e       rnd_mode_i,
-  input fpnew_pkg::operation_e       op_i,
-  input logic                        op_mod_i,
-  input fpnew_pkg::fp_format_e       src_fmt_i,
-  input fpnew_pkg::fp_format_e       dst_fmt_i,
-  input TagType                      tag_i,
-  input AuxType                      aux_i,
+  input logic [2:0][OPERAND_WIDTH-1:0] operands_i, // 3 operands
+  input logic [NUM_FORMATS-1:0][2:0]   is_boxed_i, // 3 operands
+  input fpnew_pkg::roundmode_e         rnd_mode_i,
+  input fpnew_pkg::operation_e         op_i,
+  input logic                          op_mod_i,
+  input fpnew_pkg::fp_format_e         src_fmt_i,
+  input fpnew_pkg::fp_format_e         dst_fmt_i,
+  input TagType                        tag_i,
+  input AuxType                        aux_i,
   // Input Handshake
-  input  logic                       in_valid_i,
-  output logic                       in_ready_o,
-  input  logic                       flush_i,
+  input  logic                         in_valid_i,
+  output logic                         in_ready_o,
+  input  logic                         flush_i,
   // Output signals
-  output logic [2*DST_WIDTH-1:0]     result_o,
-  output fpnew_pkg::status_t         status_o,
-  output logic                       extension_bit_o,
-  output TagType                     tag_o,
-  output AuxType                     aux_o,
+  output logic [OPERAND_WIDTH-1:0]     result_o,
+  output fpnew_pkg::status_t           status_o,
+  output logic                         extension_bit_o,
+  output TagType                       tag_o,
+  output AuxType                       aux_o,
   // Output handshake
-  output logic                       out_valid_o,
-  input  logic                       out_ready_i,
+  output logic                         out_valid_o,
+  input  logic                         out_ready_i,
   // Indication of valid data in flight
-  output logic                       busy_o
+  output logic                         busy_o
 );
 
   // ----------
@@ -73,7 +74,7 @@ module fpnew_dotp_wrapper #(
   logic                             [NUM_FORMATS-1:0][SRC_WIDTH-1:0] local_src_fmt_operand_d;  // lane-local operands
   logic                                              [DST_WIDTH-1:0] local_dst_fmt_operands;  // lane-local operands
   logic [NUM_FORMATS-1:0][N_SRC_FMT_OPERANDS+N_DST_FMT_OPERANDS-1:0] local_is_boxed;  // lane-local operands
-  logic                                            [2*DST_WIDTH-1:0] local_result;  // lane-local operands
+  logic                                          [OPERAND_WIDTH-1:0] local_result;  // lane-local operands
 
 
   // ----------------------------------


### PR DESCRIPTION
- fix a aux_data signal width
- fix parameter issues with VCS
- rename module `fpnew_dotp_wrapper` to `fpnew_sdotp_multi_wrapper`