### PR TITLE
Double the read-only cache's cache line width

### DIFF
--- a/hw/system/occamy/src/memories.json
+++ b/hw/system/occamy/src/memories.json
@@ -28,6 +28,20 @@
         "words": 128
     },
     {
+        "byte_enable": false,
+        "byte_width": 8,
+        "density_optimized": true,
+        "description": [
+            "ro cache tag"
+        ],
+        "dual_port": false,
+        "latency": 1,
+        "ports": 1,
+        "speed_optimized": true,
+        "width": 37,
+        "words": 128
+    },
+    {
         "byte_enable": true,
         "byte_width": 8,
         "density_optimized": false,
@@ -68,20 +82,6 @@
         "speed_optimized": true,
         "width": 256,
         "words": 128
-    },
-    {
-        "byte_enable": false,
-        "byte_width": 8,
-        "density_optimized": true,
-        "description": [
-            "ro cache tag"
-        ],
-        "dual_port": false,
-        "latency": 1,
-        "ports": 1,
-        "speed_optimized": true,
-        "width": 37,
-        "words": 256
     },
     {
         "byte_enable": true,
@@ -333,7 +333,7 @@
         "latency": 1,
         "ports": 1,
         "speed_optimized": true,
-        "width": 512,
-        "words": 256
+        "width": 1024,
+        "words": 128
     }
 ]

--- a/hw/system/occamy/src/occamy_cfg.hjson
+++ b/hw/system/occamy/src/occamy_cfg.hjson
@@ -33,11 +33,11 @@
       nr_clusters: 4,
       // Disable for easier flow trials.
       ro_cache_cfg: {
-          width: 512,
-          count: 256,
+          width: 1024,
+          count: 128,
           sets: 2,
           max_trans: 8,
-          address_regions: 2,
+          address_regions: 4,
       }
       wide_xbar: {
         max_slv_trans: 4,

--- a/hw/system/occamy/src/occamy_quadrant_s1.sv
+++ b/hw/system/occamy/src/occamy_quadrant_s1.sv
@@ -25,8 +25,8 @@ module occamy_quadrant_s1
     input  logic                                                   ro_enable_i,
     input  logic                                                   ro_flush_valid_i,
     output logic                                                   ro_flush_ready_o,
-    input  logic                     [                  1:0][47:0] ro_start_addr_i,
-    input  logic                     [                  1:0][47:0] ro_end_addr_i,
+    input  logic                     [                  3:0][47:0] ro_start_addr_i,
+    input  logic                     [                  3:0][47:0] ro_end_addr_i,
     // HBI Connection
     output axi_a48_d512_i7_u0_req_t                                quadrant_hbi_out_req_o,
     input  axi_a48_d512_i7_u0_resp_t                               quadrant_hbi_out_rsp_i,
@@ -274,15 +274,15 @@ module occamy_quadrant_s1
   axi_a48_d512_i4_u0_resp_t snitch_ro_cache_rsp;
 
   snitch_read_only_cache #(
-      .LineWidth(512),
-      .LineCount(256),
+      .LineWidth(1024),
+      .LineCount(128),
       .SetCount(2),
       .AxiAddrWidth(48),
       .AxiDataWidth(512),
       .AxiIdWidth(3),
       .AxiUserWidth(1),
       .MaxTrans(8),
-      .NrAddrRules(2),
+      .NrAddrRules(4),
       .slv_req_t(axi_a48_d512_i3_u0_req_t),
       .slv_rsp_t(axi_a48_d512_i3_u0_resp_t),
       .mst_req_t(axi_a48_d512_i4_u0_req_t),

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg.hjson
@@ -293,6 +293,98 @@
         }
       ]
     }
+    { name: "RO_START_ADDR_LOW_2_QUADRANT_0",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_2_QUADRANT_0",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_2_QUADRANT_0",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_2_QUADRANT_0",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_3_QUADRANT_0",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_3_QUADRANT_0",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_3_QUADRANT_0",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_3_QUADRANT_0",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 4
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
     { name: "RO_START_ADDR_LOW_0_QUADRANT_1",
       desc: "Read-only cache start address low",
       swaccess: "rw",
@@ -378,6 +470,98 @@
       swaccess: "rw",
       hwaccess: "hro",
       resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_2_QUADRANT_1",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_2_QUADRANT_1",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_2_QUADRANT_1",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_2_QUADRANT_1",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_3_QUADRANT_1",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_3_QUADRANT_1",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_3_QUADRANT_1",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_3_QUADRANT_1",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 4
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -477,6 +661,98 @@
         }
       ]
     }
+    { name: "RO_START_ADDR_LOW_2_QUADRANT_2",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_2_QUADRANT_2",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_2_QUADRANT_2",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_2_QUADRANT_2",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_3_QUADRANT_2",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_3_QUADRANT_2",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_3_QUADRANT_2",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_3_QUADRANT_2",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 4
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
     { name: "RO_START_ADDR_LOW_0_QUADRANT_3",
       desc: "Read-only cache start address low",
       swaccess: "rw",
@@ -562,6 +838,98 @@
       swaccess: "rw",
       hwaccess: "hro",
       resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_2_QUADRANT_3",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_2_QUADRANT_3",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_2_QUADRANT_3",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_2_QUADRANT_3",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_3_QUADRANT_3",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_3_QUADRANT_3",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_3_QUADRANT_3",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_3_QUADRANT_3",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 4
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -661,6 +1029,98 @@
         }
       ]
     }
+    { name: "RO_START_ADDR_LOW_2_QUADRANT_4",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_2_QUADRANT_4",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_2_QUADRANT_4",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_2_QUADRANT_4",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_3_QUADRANT_4",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_3_QUADRANT_4",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_3_QUADRANT_4",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_3_QUADRANT_4",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 4
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
     { name: "RO_START_ADDR_LOW_0_QUADRANT_5",
       desc: "Read-only cache start address low",
       swaccess: "rw",
@@ -746,6 +1206,98 @@
       swaccess: "rw",
       hwaccess: "hro",
       resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_2_QUADRANT_5",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_2_QUADRANT_5",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_2_QUADRANT_5",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_2_QUADRANT_5",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_3_QUADRANT_5",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_3_QUADRANT_5",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_3_QUADRANT_5",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_3_QUADRANT_5",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 4
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"
@@ -845,6 +1397,98 @@
         }
       ]
     }
+    { name: "RO_START_ADDR_LOW_2_QUADRANT_6",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_2_QUADRANT_6",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_2_QUADRANT_6",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_2_QUADRANT_6",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_3_QUADRANT_6",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_3_QUADRANT_6",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_3_QUADRANT_6",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_3_QUADRANT_6",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 4
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
     { name: "RO_START_ADDR_LOW_0_QUADRANT_7",
       desc: "Read-only cache start address low",
       swaccess: "rw",
@@ -930,6 +1574,98 @@
       swaccess: "rw",
       hwaccess: "hro",
       resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_2_QUADRANT_7",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_2_QUADRANT_7",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 2
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_2_QUADRANT_7",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_2_QUADRANT_7",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_START_ADDR_LOW_3_QUADRANT_7",
+      desc: "Read-only cache start address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_START_ADDR_HIGH_3_QUADRANT_7",
+      desc: "Read-only cache start address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 3
+      fields: [
+        { bits: "15:0"
+        name: "ADDR_HIGH"
+        desc: "Higher 32-bit of read-only region."
+        }
+      ]
+    }
+    { name: "RO_END_ADDR_LOW_3_QUADRANT_7",
+      desc: "Read-only cache end address low",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "31:0"
+        name: "ADDR_LOW"
+        desc: "Lower 32-bit of read-only region."
+        }
+      ]
+    },
+    { name: "RO_END_ADDR_HIGH_3_QUADRANT_7",
+      desc: "Read-only cache end address high",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: 4
       fields: [
         { bits: "15:0"
         name: "ADDR_HIGH"

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_pkg.sv
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_pkg.sv
@@ -12,7 +12,7 @@ package occamy_soc_reg_pkg;
   parameter int NumS1Quadrants = 8;
 
   // Address widths within the block
-  parameter int BlockAw = 9;
+  parameter int BlockAw = 10;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -105,6 +105,38 @@ package occamy_soc_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_0_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_0_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_0_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_0_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_0_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_0_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_0_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_0_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
   } occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_1_reg_t;
 
   typedef struct packed {
@@ -134,6 +166,38 @@ package occamy_soc_reg_pkg;
   typedef struct packed {
     logic [15:0] q;
   } occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_1_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_1_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_1_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_1_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_1_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_1_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_1_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_1_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_1_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -169,6 +233,38 @@ package occamy_soc_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_2_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_2_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_2_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_2_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_2_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_2_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_2_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_2_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
   } occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_3_reg_t;
 
   typedef struct packed {
@@ -198,6 +294,38 @@ package occamy_soc_reg_pkg;
   typedef struct packed {
     logic [15:0] q;
   } occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_3_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_3_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_3_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_3_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_3_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_3_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_3_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_3_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_3_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -233,6 +361,38 @@ package occamy_soc_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_4_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_4_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_4_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_4_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_4_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_4_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_4_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_4_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
   } occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_5_reg_t;
 
   typedef struct packed {
@@ -262,6 +422,38 @@ package occamy_soc_reg_pkg;
   typedef struct packed {
     logic [15:0] q;
   } occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_5_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_5_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_5_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_5_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_5_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_5_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_5_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_5_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_5_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -297,6 +489,38 @@ package occamy_soc_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_6_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_6_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_6_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_6_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_6_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_6_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_6_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_6_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
   } occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_7_reg_t;
 
   typedef struct packed {
@@ -328,6 +552,38 @@ package occamy_soc_reg_pkg;
   } occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_7_reg_t;
 
   typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_7_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_7_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_7_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_7_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_7_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_7_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_7_reg_t;
+
+  typedef struct packed {
+    logic [15:0] q;
+  } occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_7_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -353,77 +609,141 @@ package occamy_soc_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    occamy_soc_reg2hw_intr_state_reg_t intr_state; // [1715:1714]
-    occamy_soc_reg2hw_intr_enable_reg_t intr_enable; // [1713:1712]
-    occamy_soc_reg2hw_intr_test_reg_t intr_test; // [1711:1708]
-    occamy_soc_reg2hw_pad_mreg_t [30:0] pad; // [1707:1584]
-    occamy_soc_reg2hw_isolate_mreg_t [7:0] isolate; // [1583:1552]
-    occamy_soc_reg2hw_ro_cache_enable_mreg_t [7:0] ro_cache_enable; // [1551:1544]
-    occamy_soc_reg2hw_ro_cache_flush_mreg_t [7:0] ro_cache_flush; // [1543:1536]
-    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_0_reg_t ro_start_addr_low_0_quadrant_0; // [1535:1504]
-    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_0_reg_t ro_start_addr_high_0_quadrant_0; // [1503:1488]
-    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_0_reg_t ro_end_addr_low_0_quadrant_0; // [1487:1456]
-    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_0_reg_t ro_end_addr_high_0_quadrant_0; // [1455:1440]
-    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_0_reg_t ro_start_addr_low_1_quadrant_0; // [1439:1408]
-    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_0_reg_t ro_start_addr_high_1_quadrant_0; // [1407:1392]
-    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_0_reg_t ro_end_addr_low_1_quadrant_0; // [1391:1360]
-    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_0_reg_t ro_end_addr_high_1_quadrant_0; // [1359:1344]
-    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_1_reg_t ro_start_addr_low_0_quadrant_1; // [1343:1312]
-    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_1_reg_t ro_start_addr_high_0_quadrant_1; // [1311:1296]
-    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_1_reg_t ro_end_addr_low_0_quadrant_1; // [1295:1264]
-    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_1_reg_t ro_end_addr_high_0_quadrant_1; // [1263:1248]
-    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_1_reg_t ro_start_addr_low_1_quadrant_1; // [1247:1216]
-    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_1_reg_t ro_start_addr_high_1_quadrant_1; // [1215:1200]
-    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_1_reg_t ro_end_addr_low_1_quadrant_1; // [1199:1168]
-    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_1_reg_t ro_end_addr_high_1_quadrant_1; // [1167:1152]
-    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_2_reg_t ro_start_addr_low_0_quadrant_2; // [1151:1120]
-    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_2_reg_t ro_start_addr_high_0_quadrant_2; // [1119:1104]
-    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_2_reg_t ro_end_addr_low_0_quadrant_2; // [1103:1072]
-    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_2_reg_t ro_end_addr_high_0_quadrant_2; // [1071:1056]
-    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_2_reg_t ro_start_addr_low_1_quadrant_2; // [1055:1024]
-    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_2_reg_t ro_start_addr_high_1_quadrant_2; // [1023:1008]
-    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_2_reg_t ro_end_addr_low_1_quadrant_2; // [1007:976]
-    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_2_reg_t ro_end_addr_high_1_quadrant_2; // [975:960]
-    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_3_reg_t ro_start_addr_low_0_quadrant_3; // [959:928]
-    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_3_reg_t ro_start_addr_high_0_quadrant_3; // [927:912]
-    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_3_reg_t ro_end_addr_low_0_quadrant_3; // [911:880]
-    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_3_reg_t ro_end_addr_high_0_quadrant_3; // [879:864]
-    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_3_reg_t ro_start_addr_low_1_quadrant_3; // [863:832]
-    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_3_reg_t ro_start_addr_high_1_quadrant_3; // [831:816]
-    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_3_reg_t ro_end_addr_low_1_quadrant_3; // [815:784]
-    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_3_reg_t ro_end_addr_high_1_quadrant_3; // [783:768]
-    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_4_reg_t ro_start_addr_low_0_quadrant_4; // [767:736]
-    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_4_reg_t ro_start_addr_high_0_quadrant_4; // [735:720]
-    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_4_reg_t ro_end_addr_low_0_quadrant_4; // [719:688]
-    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_4_reg_t ro_end_addr_high_0_quadrant_4; // [687:672]
-    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_4_reg_t ro_start_addr_low_1_quadrant_4; // [671:640]
-    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_4_reg_t ro_start_addr_high_1_quadrant_4; // [639:624]
-    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_4_reg_t ro_end_addr_low_1_quadrant_4; // [623:592]
-    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_4_reg_t ro_end_addr_high_1_quadrant_4; // [591:576]
-    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_5_reg_t ro_start_addr_low_0_quadrant_5; // [575:544]
-    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_5_reg_t ro_start_addr_high_0_quadrant_5; // [543:528]
-    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_5_reg_t ro_end_addr_low_0_quadrant_5; // [527:496]
-    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_5_reg_t ro_end_addr_high_0_quadrant_5; // [495:480]
-    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_5_reg_t ro_start_addr_low_1_quadrant_5; // [479:448]
-    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_5_reg_t ro_start_addr_high_1_quadrant_5; // [447:432]
-    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_5_reg_t ro_end_addr_low_1_quadrant_5; // [431:400]
-    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_5_reg_t ro_end_addr_high_1_quadrant_5; // [399:384]
-    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_6_reg_t ro_start_addr_low_0_quadrant_6; // [383:352]
-    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_6_reg_t ro_start_addr_high_0_quadrant_6; // [351:336]
-    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_6_reg_t ro_end_addr_low_0_quadrant_6; // [335:304]
-    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_6_reg_t ro_end_addr_high_0_quadrant_6; // [303:288]
-    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_6_reg_t ro_start_addr_low_1_quadrant_6; // [287:256]
-    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_6_reg_t ro_start_addr_high_1_quadrant_6; // [255:240]
-    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_6_reg_t ro_end_addr_low_1_quadrant_6; // [239:208]
-    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_6_reg_t ro_end_addr_high_1_quadrant_6; // [207:192]
-    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_7_reg_t ro_start_addr_low_0_quadrant_7; // [191:160]
-    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_7_reg_t ro_start_addr_high_0_quadrant_7; // [159:144]
-    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_7_reg_t ro_end_addr_low_0_quadrant_7; // [143:112]
-    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_7_reg_t ro_end_addr_high_0_quadrant_7; // [111:96]
-    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_7_reg_t ro_start_addr_low_1_quadrant_7; // [95:64]
-    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_7_reg_t ro_start_addr_high_1_quadrant_7; // [63:48]
-    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_7_reg_t ro_end_addr_low_1_quadrant_7; // [47:16]
-    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_7_reg_t ro_end_addr_high_1_quadrant_7; // [15:0]
+    occamy_soc_reg2hw_intr_state_reg_t intr_state; // [3251:3250]
+    occamy_soc_reg2hw_intr_enable_reg_t intr_enable; // [3249:3248]
+    occamy_soc_reg2hw_intr_test_reg_t intr_test; // [3247:3244]
+    occamy_soc_reg2hw_pad_mreg_t [30:0] pad; // [3243:3120]
+    occamy_soc_reg2hw_isolate_mreg_t [7:0] isolate; // [3119:3088]
+    occamy_soc_reg2hw_ro_cache_enable_mreg_t [7:0] ro_cache_enable; // [3087:3080]
+    occamy_soc_reg2hw_ro_cache_flush_mreg_t [7:0] ro_cache_flush; // [3079:3072]
+    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_0_reg_t ro_start_addr_low_0_quadrant_0; // [3071:3040]
+    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_0_reg_t ro_start_addr_high_0_quadrant_0; // [3039:3024]
+    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_0_reg_t ro_end_addr_low_0_quadrant_0; // [3023:2992]
+    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_0_reg_t ro_end_addr_high_0_quadrant_0; // [2991:2976]
+    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_0_reg_t ro_start_addr_low_1_quadrant_0; // [2975:2944]
+    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_0_reg_t ro_start_addr_high_1_quadrant_0; // [2943:2928]
+    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_0_reg_t ro_end_addr_low_1_quadrant_0; // [2927:2896]
+    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_0_reg_t ro_end_addr_high_1_quadrant_0; // [2895:2880]
+    occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_0_reg_t ro_start_addr_low_2_quadrant_0; // [2879:2848]
+    occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_0_reg_t ro_start_addr_high_2_quadrant_0; // [2847:2832]
+    occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_0_reg_t ro_end_addr_low_2_quadrant_0; // [2831:2800]
+    occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_0_reg_t ro_end_addr_high_2_quadrant_0; // [2799:2784]
+    occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_0_reg_t ro_start_addr_low_3_quadrant_0; // [2783:2752]
+    occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_0_reg_t ro_start_addr_high_3_quadrant_0; // [2751:2736]
+    occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_0_reg_t ro_end_addr_low_3_quadrant_0; // [2735:2704]
+    occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_0_reg_t ro_end_addr_high_3_quadrant_0; // [2703:2688]
+    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_1_reg_t ro_start_addr_low_0_quadrant_1; // [2687:2656]
+    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_1_reg_t ro_start_addr_high_0_quadrant_1; // [2655:2640]
+    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_1_reg_t ro_end_addr_low_0_quadrant_1; // [2639:2608]
+    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_1_reg_t ro_end_addr_high_0_quadrant_1; // [2607:2592]
+    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_1_reg_t ro_start_addr_low_1_quadrant_1; // [2591:2560]
+    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_1_reg_t ro_start_addr_high_1_quadrant_1; // [2559:2544]
+    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_1_reg_t ro_end_addr_low_1_quadrant_1; // [2543:2512]
+    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_1_reg_t ro_end_addr_high_1_quadrant_1; // [2511:2496]
+    occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_1_reg_t ro_start_addr_low_2_quadrant_1; // [2495:2464]
+    occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_1_reg_t ro_start_addr_high_2_quadrant_1; // [2463:2448]
+    occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_1_reg_t ro_end_addr_low_2_quadrant_1; // [2447:2416]
+    occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_1_reg_t ro_end_addr_high_2_quadrant_1; // [2415:2400]
+    occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_1_reg_t ro_start_addr_low_3_quadrant_1; // [2399:2368]
+    occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_1_reg_t ro_start_addr_high_3_quadrant_1; // [2367:2352]
+    occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_1_reg_t ro_end_addr_low_3_quadrant_1; // [2351:2320]
+    occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_1_reg_t ro_end_addr_high_3_quadrant_1; // [2319:2304]
+    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_2_reg_t ro_start_addr_low_0_quadrant_2; // [2303:2272]
+    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_2_reg_t ro_start_addr_high_0_quadrant_2; // [2271:2256]
+    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_2_reg_t ro_end_addr_low_0_quadrant_2; // [2255:2224]
+    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_2_reg_t ro_end_addr_high_0_quadrant_2; // [2223:2208]
+    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_2_reg_t ro_start_addr_low_1_quadrant_2; // [2207:2176]
+    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_2_reg_t ro_start_addr_high_1_quadrant_2; // [2175:2160]
+    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_2_reg_t ro_end_addr_low_1_quadrant_2; // [2159:2128]
+    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_2_reg_t ro_end_addr_high_1_quadrant_2; // [2127:2112]
+    occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_2_reg_t ro_start_addr_low_2_quadrant_2; // [2111:2080]
+    occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_2_reg_t ro_start_addr_high_2_quadrant_2; // [2079:2064]
+    occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_2_reg_t ro_end_addr_low_2_quadrant_2; // [2063:2032]
+    occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_2_reg_t ro_end_addr_high_2_quadrant_2; // [2031:2016]
+    occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_2_reg_t ro_start_addr_low_3_quadrant_2; // [2015:1984]
+    occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_2_reg_t ro_start_addr_high_3_quadrant_2; // [1983:1968]
+    occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_2_reg_t ro_end_addr_low_3_quadrant_2; // [1967:1936]
+    occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_2_reg_t ro_end_addr_high_3_quadrant_2; // [1935:1920]
+    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_3_reg_t ro_start_addr_low_0_quadrant_3; // [1919:1888]
+    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_3_reg_t ro_start_addr_high_0_quadrant_3; // [1887:1872]
+    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_3_reg_t ro_end_addr_low_0_quadrant_3; // [1871:1840]
+    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_3_reg_t ro_end_addr_high_0_quadrant_3; // [1839:1824]
+    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_3_reg_t ro_start_addr_low_1_quadrant_3; // [1823:1792]
+    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_3_reg_t ro_start_addr_high_1_quadrant_3; // [1791:1776]
+    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_3_reg_t ro_end_addr_low_1_quadrant_3; // [1775:1744]
+    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_3_reg_t ro_end_addr_high_1_quadrant_3; // [1743:1728]
+    occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_3_reg_t ro_start_addr_low_2_quadrant_3; // [1727:1696]
+    occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_3_reg_t ro_start_addr_high_2_quadrant_3; // [1695:1680]
+    occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_3_reg_t ro_end_addr_low_2_quadrant_3; // [1679:1648]
+    occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_3_reg_t ro_end_addr_high_2_quadrant_3; // [1647:1632]
+    occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_3_reg_t ro_start_addr_low_3_quadrant_3; // [1631:1600]
+    occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_3_reg_t ro_start_addr_high_3_quadrant_3; // [1599:1584]
+    occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_3_reg_t ro_end_addr_low_3_quadrant_3; // [1583:1552]
+    occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_3_reg_t ro_end_addr_high_3_quadrant_3; // [1551:1536]
+    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_4_reg_t ro_start_addr_low_0_quadrant_4; // [1535:1504]
+    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_4_reg_t ro_start_addr_high_0_quadrant_4; // [1503:1488]
+    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_4_reg_t ro_end_addr_low_0_quadrant_4; // [1487:1456]
+    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_4_reg_t ro_end_addr_high_0_quadrant_4; // [1455:1440]
+    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_4_reg_t ro_start_addr_low_1_quadrant_4; // [1439:1408]
+    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_4_reg_t ro_start_addr_high_1_quadrant_4; // [1407:1392]
+    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_4_reg_t ro_end_addr_low_1_quadrant_4; // [1391:1360]
+    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_4_reg_t ro_end_addr_high_1_quadrant_4; // [1359:1344]
+    occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_4_reg_t ro_start_addr_low_2_quadrant_4; // [1343:1312]
+    occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_4_reg_t ro_start_addr_high_2_quadrant_4; // [1311:1296]
+    occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_4_reg_t ro_end_addr_low_2_quadrant_4; // [1295:1264]
+    occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_4_reg_t ro_end_addr_high_2_quadrant_4; // [1263:1248]
+    occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_4_reg_t ro_start_addr_low_3_quadrant_4; // [1247:1216]
+    occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_4_reg_t ro_start_addr_high_3_quadrant_4; // [1215:1200]
+    occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_4_reg_t ro_end_addr_low_3_quadrant_4; // [1199:1168]
+    occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_4_reg_t ro_end_addr_high_3_quadrant_4; // [1167:1152]
+    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_5_reg_t ro_start_addr_low_0_quadrant_5; // [1151:1120]
+    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_5_reg_t ro_start_addr_high_0_quadrant_5; // [1119:1104]
+    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_5_reg_t ro_end_addr_low_0_quadrant_5; // [1103:1072]
+    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_5_reg_t ro_end_addr_high_0_quadrant_5; // [1071:1056]
+    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_5_reg_t ro_start_addr_low_1_quadrant_5; // [1055:1024]
+    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_5_reg_t ro_start_addr_high_1_quadrant_5; // [1023:1008]
+    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_5_reg_t ro_end_addr_low_1_quadrant_5; // [1007:976]
+    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_5_reg_t ro_end_addr_high_1_quadrant_5; // [975:960]
+    occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_5_reg_t ro_start_addr_low_2_quadrant_5; // [959:928]
+    occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_5_reg_t ro_start_addr_high_2_quadrant_5; // [927:912]
+    occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_5_reg_t ro_end_addr_low_2_quadrant_5; // [911:880]
+    occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_5_reg_t ro_end_addr_high_2_quadrant_5; // [879:864]
+    occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_5_reg_t ro_start_addr_low_3_quadrant_5; // [863:832]
+    occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_5_reg_t ro_start_addr_high_3_quadrant_5; // [831:816]
+    occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_5_reg_t ro_end_addr_low_3_quadrant_5; // [815:784]
+    occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_5_reg_t ro_end_addr_high_3_quadrant_5; // [783:768]
+    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_6_reg_t ro_start_addr_low_0_quadrant_6; // [767:736]
+    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_6_reg_t ro_start_addr_high_0_quadrant_6; // [735:720]
+    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_6_reg_t ro_end_addr_low_0_quadrant_6; // [719:688]
+    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_6_reg_t ro_end_addr_high_0_quadrant_6; // [687:672]
+    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_6_reg_t ro_start_addr_low_1_quadrant_6; // [671:640]
+    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_6_reg_t ro_start_addr_high_1_quadrant_6; // [639:624]
+    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_6_reg_t ro_end_addr_low_1_quadrant_6; // [623:592]
+    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_6_reg_t ro_end_addr_high_1_quadrant_6; // [591:576]
+    occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_6_reg_t ro_start_addr_low_2_quadrant_6; // [575:544]
+    occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_6_reg_t ro_start_addr_high_2_quadrant_6; // [543:528]
+    occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_6_reg_t ro_end_addr_low_2_quadrant_6; // [527:496]
+    occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_6_reg_t ro_end_addr_high_2_quadrant_6; // [495:480]
+    occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_6_reg_t ro_start_addr_low_3_quadrant_6; // [479:448]
+    occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_6_reg_t ro_start_addr_high_3_quadrant_6; // [447:432]
+    occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_6_reg_t ro_end_addr_low_3_quadrant_6; // [431:400]
+    occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_6_reg_t ro_end_addr_high_3_quadrant_6; // [399:384]
+    occamy_soc_reg2hw_ro_start_addr_low_0_quadrant_7_reg_t ro_start_addr_low_0_quadrant_7; // [383:352]
+    occamy_soc_reg2hw_ro_start_addr_high_0_quadrant_7_reg_t ro_start_addr_high_0_quadrant_7; // [351:336]
+    occamy_soc_reg2hw_ro_end_addr_low_0_quadrant_7_reg_t ro_end_addr_low_0_quadrant_7; // [335:304]
+    occamy_soc_reg2hw_ro_end_addr_high_0_quadrant_7_reg_t ro_end_addr_high_0_quadrant_7; // [303:288]
+    occamy_soc_reg2hw_ro_start_addr_low_1_quadrant_7_reg_t ro_start_addr_low_1_quadrant_7; // [287:256]
+    occamy_soc_reg2hw_ro_start_addr_high_1_quadrant_7_reg_t ro_start_addr_high_1_quadrant_7; // [255:240]
+    occamy_soc_reg2hw_ro_end_addr_low_1_quadrant_7_reg_t ro_end_addr_low_1_quadrant_7; // [239:208]
+    occamy_soc_reg2hw_ro_end_addr_high_1_quadrant_7_reg_t ro_end_addr_high_1_quadrant_7; // [207:192]
+    occamy_soc_reg2hw_ro_start_addr_low_2_quadrant_7_reg_t ro_start_addr_low_2_quadrant_7; // [191:160]
+    occamy_soc_reg2hw_ro_start_addr_high_2_quadrant_7_reg_t ro_start_addr_high_2_quadrant_7; // [159:144]
+    occamy_soc_reg2hw_ro_end_addr_low_2_quadrant_7_reg_t ro_end_addr_low_2_quadrant_7; // [143:112]
+    occamy_soc_reg2hw_ro_end_addr_high_2_quadrant_7_reg_t ro_end_addr_high_2_quadrant_7; // [111:96]
+    occamy_soc_reg2hw_ro_start_addr_low_3_quadrant_7_reg_t ro_start_addr_low_3_quadrant_7; // [95:64]
+    occamy_soc_reg2hw_ro_start_addr_high_3_quadrant_7_reg_t ro_start_addr_high_3_quadrant_7; // [63:48]
+    occamy_soc_reg2hw_ro_end_addr_low_3_quadrant_7_reg_t ro_end_addr_low_3_quadrant_7; // [47:16]
+    occamy_soc_reg2hw_ro_end_addr_high_3_quadrant_7_reg_t ro_end_addr_high_3_quadrant_7; // [15:0]
   } occamy_soc_reg2hw_t;
 
   // HW -> register type
@@ -435,114 +755,178 @@ package occamy_soc_reg_pkg;
   } occamy_soc_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_INTR_STATE_OFFSET = 9'h 0;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_INTR_ENABLE_OFFSET = 9'h 4;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_INTR_TEST_OFFSET = 9'h 8;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_VERSION_OFFSET = 9'h c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_SCRATCH_0_OFFSET = 9'h 10;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_SCRATCH_1_OFFSET = 9'h 14;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_SCRATCH_2_OFFSET = 9'h 18;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_SCRATCH_3_OFFSET = 9'h 1c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_BOOT_MODE_OFFSET = 9'h 20;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_0_OFFSET = 9'h 24;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_1_OFFSET = 9'h 28;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_2_OFFSET = 9'h 2c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_3_OFFSET = 9'h 30;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_4_OFFSET = 9'h 34;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_5_OFFSET = 9'h 38;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_6_OFFSET = 9'h 3c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_7_OFFSET = 9'h 40;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_8_OFFSET = 9'h 44;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_9_OFFSET = 9'h 48;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_10_OFFSET = 9'h 4c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_11_OFFSET = 9'h 50;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_12_OFFSET = 9'h 54;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_13_OFFSET = 9'h 58;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_14_OFFSET = 9'h 5c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_15_OFFSET = 9'h 60;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_16_OFFSET = 9'h 64;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_17_OFFSET = 9'h 68;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_18_OFFSET = 9'h 6c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_19_OFFSET = 9'h 70;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_20_OFFSET = 9'h 74;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_21_OFFSET = 9'h 78;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_22_OFFSET = 9'h 7c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_23_OFFSET = 9'h 80;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_24_OFFSET = 9'h 84;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_25_OFFSET = 9'h 88;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_26_OFFSET = 9'h 8c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_27_OFFSET = 9'h 90;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_28_OFFSET = 9'h 94;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_29_OFFSET = 9'h 98;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_30_OFFSET = 9'h 9c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_ISOLATE_OFFSET = 9'h a0;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_ISOLATED_OFFSET = 9'h a4;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_CACHE_ENABLE_OFFSET = 9'h a8;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_CACHE_FLUSH_OFFSET = 9'h ac;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_0_OFFSET = 9'h 100;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_0_OFFSET = 9'h 104;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_0_OFFSET = 9'h 108;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_0_OFFSET = 9'h 10c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_0_OFFSET = 9'h 110;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_0_OFFSET = 9'h 114;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_0_OFFSET = 9'h 118;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_0_OFFSET = 9'h 11c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_1_OFFSET = 9'h 120;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_1_OFFSET = 9'h 124;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_1_OFFSET = 9'h 128;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_1_OFFSET = 9'h 12c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_1_OFFSET = 9'h 130;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_1_OFFSET = 9'h 134;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_1_OFFSET = 9'h 138;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_1_OFFSET = 9'h 13c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_2_OFFSET = 9'h 140;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_2_OFFSET = 9'h 144;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_2_OFFSET = 9'h 148;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_2_OFFSET = 9'h 14c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_2_OFFSET = 9'h 150;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_2_OFFSET = 9'h 154;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_2_OFFSET = 9'h 158;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_2_OFFSET = 9'h 15c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_3_OFFSET = 9'h 160;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_3_OFFSET = 9'h 164;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_3_OFFSET = 9'h 168;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_3_OFFSET = 9'h 16c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_3_OFFSET = 9'h 170;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_3_OFFSET = 9'h 174;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_3_OFFSET = 9'h 178;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_3_OFFSET = 9'h 17c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_4_OFFSET = 9'h 180;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_4_OFFSET = 9'h 184;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_4_OFFSET = 9'h 188;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_4_OFFSET = 9'h 18c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_4_OFFSET = 9'h 190;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_4_OFFSET = 9'h 194;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_4_OFFSET = 9'h 198;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_4_OFFSET = 9'h 19c;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_5_OFFSET = 9'h 1a0;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_5_OFFSET = 9'h 1a4;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_5_OFFSET = 9'h 1a8;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_5_OFFSET = 9'h 1ac;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_5_OFFSET = 9'h 1b0;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_5_OFFSET = 9'h 1b4;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_5_OFFSET = 9'h 1b8;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_5_OFFSET = 9'h 1bc;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_6_OFFSET = 9'h 1c0;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_6_OFFSET = 9'h 1c4;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_6_OFFSET = 9'h 1c8;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_6_OFFSET = 9'h 1cc;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_6_OFFSET = 9'h 1d0;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_6_OFFSET = 9'h 1d4;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_6_OFFSET = 9'h 1d8;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_6_OFFSET = 9'h 1dc;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_7_OFFSET = 9'h 1e0;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_7_OFFSET = 9'h 1e4;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_7_OFFSET = 9'h 1e8;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_7_OFFSET = 9'h 1ec;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_7_OFFSET = 9'h 1f0;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_7_OFFSET = 9'h 1f4;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_7_OFFSET = 9'h 1f8;
-  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_7_OFFSET = 9'h 1fc;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_INTR_STATE_OFFSET = 10'h 0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_INTR_ENABLE_OFFSET = 10'h 4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_INTR_TEST_OFFSET = 10'h 8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_VERSION_OFFSET = 10'h c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_SCRATCH_0_OFFSET = 10'h 10;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_SCRATCH_1_OFFSET = 10'h 14;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_SCRATCH_2_OFFSET = 10'h 18;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_SCRATCH_3_OFFSET = 10'h 1c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_BOOT_MODE_OFFSET = 10'h 20;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_0_OFFSET = 10'h 24;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_1_OFFSET = 10'h 28;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_2_OFFSET = 10'h 2c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_3_OFFSET = 10'h 30;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_4_OFFSET = 10'h 34;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_5_OFFSET = 10'h 38;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_6_OFFSET = 10'h 3c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_7_OFFSET = 10'h 40;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_8_OFFSET = 10'h 44;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_9_OFFSET = 10'h 48;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_10_OFFSET = 10'h 4c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_11_OFFSET = 10'h 50;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_12_OFFSET = 10'h 54;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_13_OFFSET = 10'h 58;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_14_OFFSET = 10'h 5c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_15_OFFSET = 10'h 60;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_16_OFFSET = 10'h 64;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_17_OFFSET = 10'h 68;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_18_OFFSET = 10'h 6c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_19_OFFSET = 10'h 70;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_20_OFFSET = 10'h 74;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_21_OFFSET = 10'h 78;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_22_OFFSET = 10'h 7c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_23_OFFSET = 10'h 80;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_24_OFFSET = 10'h 84;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_25_OFFSET = 10'h 88;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_26_OFFSET = 10'h 8c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_27_OFFSET = 10'h 90;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_28_OFFSET = 10'h 94;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_29_OFFSET = 10'h 98;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_PAD_30_OFFSET = 10'h 9c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_ISOLATE_OFFSET = 10'h a0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_ISOLATED_OFFSET = 10'h a4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_CACHE_ENABLE_OFFSET = 10'h a8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_CACHE_FLUSH_OFFSET = 10'h ac;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_0_OFFSET = 10'h 100;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_0_OFFSET = 10'h 104;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_0_OFFSET = 10'h 108;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_0_OFFSET = 10'h 10c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_0_OFFSET = 10'h 110;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_0_OFFSET = 10'h 114;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_0_OFFSET = 10'h 118;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_0_OFFSET = 10'h 11c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_0_OFFSET = 10'h 120;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_0_OFFSET = 10'h 124;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_0_OFFSET = 10'h 128;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_0_OFFSET = 10'h 12c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_0_OFFSET = 10'h 130;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_0_OFFSET = 10'h 134;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_0_OFFSET = 10'h 138;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_0_OFFSET = 10'h 13c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_1_OFFSET = 10'h 140;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_1_OFFSET = 10'h 144;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_1_OFFSET = 10'h 148;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_1_OFFSET = 10'h 14c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_1_OFFSET = 10'h 150;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_1_OFFSET = 10'h 154;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_1_OFFSET = 10'h 158;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_1_OFFSET = 10'h 15c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_1_OFFSET = 10'h 160;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_1_OFFSET = 10'h 164;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_1_OFFSET = 10'h 168;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_1_OFFSET = 10'h 16c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_1_OFFSET = 10'h 170;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_1_OFFSET = 10'h 174;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_1_OFFSET = 10'h 178;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_1_OFFSET = 10'h 17c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_2_OFFSET = 10'h 180;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_2_OFFSET = 10'h 184;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_2_OFFSET = 10'h 188;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_2_OFFSET = 10'h 18c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_2_OFFSET = 10'h 190;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_2_OFFSET = 10'h 194;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_2_OFFSET = 10'h 198;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_2_OFFSET = 10'h 19c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_2_OFFSET = 10'h 1a0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_2_OFFSET = 10'h 1a4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_2_OFFSET = 10'h 1a8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_2_OFFSET = 10'h 1ac;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_2_OFFSET = 10'h 1b0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_2_OFFSET = 10'h 1b4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_2_OFFSET = 10'h 1b8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_2_OFFSET = 10'h 1bc;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_3_OFFSET = 10'h 1c0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_3_OFFSET = 10'h 1c4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_3_OFFSET = 10'h 1c8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_3_OFFSET = 10'h 1cc;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_3_OFFSET = 10'h 1d0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_3_OFFSET = 10'h 1d4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_3_OFFSET = 10'h 1d8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_3_OFFSET = 10'h 1dc;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_3_OFFSET = 10'h 1e0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_3_OFFSET = 10'h 1e4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_3_OFFSET = 10'h 1e8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_3_OFFSET = 10'h 1ec;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_3_OFFSET = 10'h 1f0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_3_OFFSET = 10'h 1f4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_3_OFFSET = 10'h 1f8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_3_OFFSET = 10'h 1fc;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_4_OFFSET = 10'h 200;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_4_OFFSET = 10'h 204;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_4_OFFSET = 10'h 208;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_4_OFFSET = 10'h 20c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_4_OFFSET = 10'h 210;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_4_OFFSET = 10'h 214;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_4_OFFSET = 10'h 218;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_4_OFFSET = 10'h 21c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_4_OFFSET = 10'h 220;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_4_OFFSET = 10'h 224;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_4_OFFSET = 10'h 228;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_4_OFFSET = 10'h 22c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_4_OFFSET = 10'h 230;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_4_OFFSET = 10'h 234;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_4_OFFSET = 10'h 238;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_4_OFFSET = 10'h 23c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_5_OFFSET = 10'h 240;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_5_OFFSET = 10'h 244;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_5_OFFSET = 10'h 248;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_5_OFFSET = 10'h 24c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_5_OFFSET = 10'h 250;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_5_OFFSET = 10'h 254;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_5_OFFSET = 10'h 258;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_5_OFFSET = 10'h 25c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_5_OFFSET = 10'h 260;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_5_OFFSET = 10'h 264;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_5_OFFSET = 10'h 268;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_5_OFFSET = 10'h 26c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_5_OFFSET = 10'h 270;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_5_OFFSET = 10'h 274;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_5_OFFSET = 10'h 278;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_5_OFFSET = 10'h 27c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_6_OFFSET = 10'h 280;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_6_OFFSET = 10'h 284;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_6_OFFSET = 10'h 288;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_6_OFFSET = 10'h 28c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_6_OFFSET = 10'h 290;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_6_OFFSET = 10'h 294;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_6_OFFSET = 10'h 298;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_6_OFFSET = 10'h 29c;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_6_OFFSET = 10'h 2a0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_6_OFFSET = 10'h 2a4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_6_OFFSET = 10'h 2a8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_6_OFFSET = 10'h 2ac;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_6_OFFSET = 10'h 2b0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_6_OFFSET = 10'h 2b4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_6_OFFSET = 10'h 2b8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_6_OFFSET = 10'h 2bc;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_7_OFFSET = 10'h 2c0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_7_OFFSET = 10'h 2c4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_7_OFFSET = 10'h 2c8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_7_OFFSET = 10'h 2cc;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_7_OFFSET = 10'h 2d0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_7_OFFSET = 10'h 2d4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_7_OFFSET = 10'h 2d8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_7_OFFSET = 10'h 2dc;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_7_OFFSET = 10'h 2e0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_7_OFFSET = 10'h 2e4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_7_OFFSET = 10'h 2e8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_7_OFFSET = 10'h 2ec;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_7_OFFSET = 10'h 2f0;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_7_OFFSET = 10'h 2f4;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_7_OFFSET = 10'h 2f8;
+  parameter logic [BlockAw-1:0] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_7_OFFSET = 10'h 2fc;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] OCCAMY_SOC_INTR_TEST_RESVAL = 2'h 0;
@@ -613,6 +997,14 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_0,
     OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_0,
     OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_0,
+    OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_0,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_0,
+    OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_0,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_0,
+    OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_0,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_0,
+    OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_0,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_0,
     OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_1,
     OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_1,
     OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_1,
@@ -621,6 +1013,14 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_1,
     OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_1,
     OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_1,
+    OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_1,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_1,
+    OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_1,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_1,
+    OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_1,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_1,
+    OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_1,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_1,
     OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_2,
     OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_2,
     OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_2,
@@ -629,6 +1029,14 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_2,
     OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_2,
     OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_2,
+    OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_2,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_2,
+    OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_2,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_2,
+    OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_2,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_2,
+    OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_2,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_2,
     OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_3,
     OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_3,
     OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_3,
@@ -637,6 +1045,14 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_3,
     OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_3,
     OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_3,
+    OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_3,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_3,
+    OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_3,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_3,
+    OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_3,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_3,
+    OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_3,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_3,
     OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_4,
     OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_4,
     OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_4,
@@ -645,6 +1061,14 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_4,
     OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_4,
     OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_4,
+    OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_4,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_4,
+    OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_4,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_4,
+    OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_4,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_4,
+    OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_4,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_4,
     OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_5,
     OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_5,
     OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_5,
@@ -653,6 +1077,14 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_5,
     OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_5,
     OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_5,
+    OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_5,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_5,
+    OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_5,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_5,
+    OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_5,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_5,
+    OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_5,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_5,
     OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_6,
     OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_6,
     OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_6,
@@ -661,6 +1093,14 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_6,
     OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_6,
     OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_6,
+    OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_6,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_6,
+    OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_6,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_6,
+    OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_6,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_6,
+    OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_6,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_6,
     OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_7,
     OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_7,
     OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_7,
@@ -668,11 +1108,19 @@ package occamy_soc_reg_pkg;
     OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_7,
     OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_7,
     OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_7,
-    OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_7
+    OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_7,
+    OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_7,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_7,
+    OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_7,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_7,
+    OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_7,
+    OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_7,
+    OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_7,
+    OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_7
   } occamy_soc_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] OCCAMY_SOC_PERMIT [108] = '{
+  parameter logic [3:0] OCCAMY_SOC_PERMIT [172] = '{
     4'b 0001, // index[  0] OCCAMY_SOC_INTR_STATE
     4'b 0001, // index[  1] OCCAMY_SOC_INTR_ENABLE
     4'b 0001, // index[  2] OCCAMY_SOC_INTR_TEST
@@ -725,62 +1173,126 @@ package occamy_soc_reg_pkg;
     4'b 0011, // index[ 49] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_0
     4'b 1111, // index[ 50] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_0
     4'b 0011, // index[ 51] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_0
-    4'b 1111, // index[ 52] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_1
-    4'b 0011, // index[ 53] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_1
-    4'b 1111, // index[ 54] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_1
-    4'b 0011, // index[ 55] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_1
-    4'b 1111, // index[ 56] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_1
-    4'b 0011, // index[ 57] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_1
-    4'b 1111, // index[ 58] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_1
-    4'b 0011, // index[ 59] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_1
-    4'b 1111, // index[ 60] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_2
-    4'b 0011, // index[ 61] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_2
-    4'b 1111, // index[ 62] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_2
-    4'b 0011, // index[ 63] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_2
-    4'b 1111, // index[ 64] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_2
-    4'b 0011, // index[ 65] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_2
-    4'b 1111, // index[ 66] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_2
-    4'b 0011, // index[ 67] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_2
-    4'b 1111, // index[ 68] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_3
-    4'b 0011, // index[ 69] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_3
-    4'b 1111, // index[ 70] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_3
-    4'b 0011, // index[ 71] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_3
-    4'b 1111, // index[ 72] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_3
-    4'b 0011, // index[ 73] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_3
-    4'b 1111, // index[ 74] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_3
-    4'b 0011, // index[ 75] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_3
-    4'b 1111, // index[ 76] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_4
-    4'b 0011, // index[ 77] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_4
-    4'b 1111, // index[ 78] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_4
-    4'b 0011, // index[ 79] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_4
-    4'b 1111, // index[ 80] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_4
-    4'b 0011, // index[ 81] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_4
-    4'b 1111, // index[ 82] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_4
-    4'b 0011, // index[ 83] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_4
-    4'b 1111, // index[ 84] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_5
-    4'b 0011, // index[ 85] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_5
-    4'b 1111, // index[ 86] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_5
-    4'b 0011, // index[ 87] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_5
-    4'b 1111, // index[ 88] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_5
-    4'b 0011, // index[ 89] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_5
-    4'b 1111, // index[ 90] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_5
-    4'b 0011, // index[ 91] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_5
-    4'b 1111, // index[ 92] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_6
-    4'b 0011, // index[ 93] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_6
-    4'b 1111, // index[ 94] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_6
-    4'b 0011, // index[ 95] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_6
-    4'b 1111, // index[ 96] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_6
-    4'b 0011, // index[ 97] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_6
-    4'b 1111, // index[ 98] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_6
-    4'b 0011, // index[ 99] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_6
-    4'b 1111, // index[100] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_7
-    4'b 0011, // index[101] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_7
-    4'b 1111, // index[102] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_7
-    4'b 0011, // index[103] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_7
-    4'b 1111, // index[104] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_7
-    4'b 0011, // index[105] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_7
-    4'b 1111, // index[106] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_7
-    4'b 0011  // index[107] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_7
+    4'b 1111, // index[ 52] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_0
+    4'b 0011, // index[ 53] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_0
+    4'b 1111, // index[ 54] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_0
+    4'b 0011, // index[ 55] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_0
+    4'b 1111, // index[ 56] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_0
+    4'b 0011, // index[ 57] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_0
+    4'b 1111, // index[ 58] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_0
+    4'b 0011, // index[ 59] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_0
+    4'b 1111, // index[ 60] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_1
+    4'b 0011, // index[ 61] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_1
+    4'b 1111, // index[ 62] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_1
+    4'b 0011, // index[ 63] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_1
+    4'b 1111, // index[ 64] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_1
+    4'b 0011, // index[ 65] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_1
+    4'b 1111, // index[ 66] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_1
+    4'b 0011, // index[ 67] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_1
+    4'b 1111, // index[ 68] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_1
+    4'b 0011, // index[ 69] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_1
+    4'b 1111, // index[ 70] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_1
+    4'b 0011, // index[ 71] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_1
+    4'b 1111, // index[ 72] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_1
+    4'b 0011, // index[ 73] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_1
+    4'b 1111, // index[ 74] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_1
+    4'b 0011, // index[ 75] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_1
+    4'b 1111, // index[ 76] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_2
+    4'b 0011, // index[ 77] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_2
+    4'b 1111, // index[ 78] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_2
+    4'b 0011, // index[ 79] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_2
+    4'b 1111, // index[ 80] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_2
+    4'b 0011, // index[ 81] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_2
+    4'b 1111, // index[ 82] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_2
+    4'b 0011, // index[ 83] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_2
+    4'b 1111, // index[ 84] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_2
+    4'b 0011, // index[ 85] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_2
+    4'b 1111, // index[ 86] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_2
+    4'b 0011, // index[ 87] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_2
+    4'b 1111, // index[ 88] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_2
+    4'b 0011, // index[ 89] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_2
+    4'b 1111, // index[ 90] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_2
+    4'b 0011, // index[ 91] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_2
+    4'b 1111, // index[ 92] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_3
+    4'b 0011, // index[ 93] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_3
+    4'b 1111, // index[ 94] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_3
+    4'b 0011, // index[ 95] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_3
+    4'b 1111, // index[ 96] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_3
+    4'b 0011, // index[ 97] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_3
+    4'b 1111, // index[ 98] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_3
+    4'b 0011, // index[ 99] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_3
+    4'b 1111, // index[100] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_3
+    4'b 0011, // index[101] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_3
+    4'b 1111, // index[102] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_3
+    4'b 0011, // index[103] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_3
+    4'b 1111, // index[104] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_3
+    4'b 0011, // index[105] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_3
+    4'b 1111, // index[106] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_3
+    4'b 0011, // index[107] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_3
+    4'b 1111, // index[108] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_4
+    4'b 0011, // index[109] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_4
+    4'b 1111, // index[110] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_4
+    4'b 0011, // index[111] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_4
+    4'b 1111, // index[112] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_4
+    4'b 0011, // index[113] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_4
+    4'b 1111, // index[114] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_4
+    4'b 0011, // index[115] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_4
+    4'b 1111, // index[116] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_4
+    4'b 0011, // index[117] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_4
+    4'b 1111, // index[118] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_4
+    4'b 0011, // index[119] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_4
+    4'b 1111, // index[120] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_4
+    4'b 0011, // index[121] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_4
+    4'b 1111, // index[122] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_4
+    4'b 0011, // index[123] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_4
+    4'b 1111, // index[124] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_5
+    4'b 0011, // index[125] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_5
+    4'b 1111, // index[126] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_5
+    4'b 0011, // index[127] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_5
+    4'b 1111, // index[128] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_5
+    4'b 0011, // index[129] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_5
+    4'b 1111, // index[130] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_5
+    4'b 0011, // index[131] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_5
+    4'b 1111, // index[132] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_5
+    4'b 0011, // index[133] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_5
+    4'b 1111, // index[134] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_5
+    4'b 0011, // index[135] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_5
+    4'b 1111, // index[136] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_5
+    4'b 0011, // index[137] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_5
+    4'b 1111, // index[138] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_5
+    4'b 0011, // index[139] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_5
+    4'b 1111, // index[140] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_6
+    4'b 0011, // index[141] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_6
+    4'b 1111, // index[142] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_6
+    4'b 0011, // index[143] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_6
+    4'b 1111, // index[144] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_6
+    4'b 0011, // index[145] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_6
+    4'b 1111, // index[146] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_6
+    4'b 0011, // index[147] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_6
+    4'b 1111, // index[148] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_6
+    4'b 0011, // index[149] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_6
+    4'b 1111, // index[150] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_6
+    4'b 0011, // index[151] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_6
+    4'b 1111, // index[152] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_6
+    4'b 0011, // index[153] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_6
+    4'b 1111, // index[154] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_6
+    4'b 0011, // index[155] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_6
+    4'b 1111, // index[156] OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_7
+    4'b 0011, // index[157] OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_7
+    4'b 1111, // index[158] OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_7
+    4'b 0011, // index[159] OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_7
+    4'b 1111, // index[160] OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_7
+    4'b 0011, // index[161] OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_7
+    4'b 1111, // index[162] OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_7
+    4'b 0011, // index[163] OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_7
+    4'b 1111, // index[164] OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_7
+    4'b 0011, // index[165] OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_7
+    4'b 1111, // index[166] OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_7
+    4'b 0011, // index[167] OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_7
+    4'b 1111, // index[168] OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_7
+    4'b 0011, // index[169] OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_7
+    4'b 1111, // index[170] OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_7
+    4'b 0011  // index[171] OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_7
   };
 
 endpackage

--- a/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_top.sv
+++ b/hw/system/occamy/src/occamy_soc_ctrl/occamy_soc_reg_top.sv
@@ -10,7 +10,7 @@
 module occamy_soc_reg_top #(
     parameter type reg_req_t = logic,
     parameter type reg_rsp_t = logic,
-    parameter int AW = 9
+    parameter int AW = 10
 ) (
   input clk_i,
   input rst_ni,
@@ -490,6 +490,30 @@ module occamy_soc_reg_top #(
   logic [15:0] ro_end_addr_high_1_quadrant_0_qs;
   logic [15:0] ro_end_addr_high_1_quadrant_0_wd;
   logic ro_end_addr_high_1_quadrant_0_we;
+  logic [31:0] ro_start_addr_low_2_quadrant_0_qs;
+  logic [31:0] ro_start_addr_low_2_quadrant_0_wd;
+  logic ro_start_addr_low_2_quadrant_0_we;
+  logic [15:0] ro_start_addr_high_2_quadrant_0_qs;
+  logic [15:0] ro_start_addr_high_2_quadrant_0_wd;
+  logic ro_start_addr_high_2_quadrant_0_we;
+  logic [31:0] ro_end_addr_low_2_quadrant_0_qs;
+  logic [31:0] ro_end_addr_low_2_quadrant_0_wd;
+  logic ro_end_addr_low_2_quadrant_0_we;
+  logic [15:0] ro_end_addr_high_2_quadrant_0_qs;
+  logic [15:0] ro_end_addr_high_2_quadrant_0_wd;
+  logic ro_end_addr_high_2_quadrant_0_we;
+  logic [31:0] ro_start_addr_low_3_quadrant_0_qs;
+  logic [31:0] ro_start_addr_low_3_quadrant_0_wd;
+  logic ro_start_addr_low_3_quadrant_0_we;
+  logic [15:0] ro_start_addr_high_3_quadrant_0_qs;
+  logic [15:0] ro_start_addr_high_3_quadrant_0_wd;
+  logic ro_start_addr_high_3_quadrant_0_we;
+  logic [31:0] ro_end_addr_low_3_quadrant_0_qs;
+  logic [31:0] ro_end_addr_low_3_quadrant_0_wd;
+  logic ro_end_addr_low_3_quadrant_0_we;
+  logic [15:0] ro_end_addr_high_3_quadrant_0_qs;
+  logic [15:0] ro_end_addr_high_3_quadrant_0_wd;
+  logic ro_end_addr_high_3_quadrant_0_we;
   logic [31:0] ro_start_addr_low_0_quadrant_1_qs;
   logic [31:0] ro_start_addr_low_0_quadrant_1_wd;
   logic ro_start_addr_low_0_quadrant_1_we;
@@ -514,6 +538,30 @@ module occamy_soc_reg_top #(
   logic [15:0] ro_end_addr_high_1_quadrant_1_qs;
   logic [15:0] ro_end_addr_high_1_quadrant_1_wd;
   logic ro_end_addr_high_1_quadrant_1_we;
+  logic [31:0] ro_start_addr_low_2_quadrant_1_qs;
+  logic [31:0] ro_start_addr_low_2_quadrant_1_wd;
+  logic ro_start_addr_low_2_quadrant_1_we;
+  logic [15:0] ro_start_addr_high_2_quadrant_1_qs;
+  logic [15:0] ro_start_addr_high_2_quadrant_1_wd;
+  logic ro_start_addr_high_2_quadrant_1_we;
+  logic [31:0] ro_end_addr_low_2_quadrant_1_qs;
+  logic [31:0] ro_end_addr_low_2_quadrant_1_wd;
+  logic ro_end_addr_low_2_quadrant_1_we;
+  logic [15:0] ro_end_addr_high_2_quadrant_1_qs;
+  logic [15:0] ro_end_addr_high_2_quadrant_1_wd;
+  logic ro_end_addr_high_2_quadrant_1_we;
+  logic [31:0] ro_start_addr_low_3_quadrant_1_qs;
+  logic [31:0] ro_start_addr_low_3_quadrant_1_wd;
+  logic ro_start_addr_low_3_quadrant_1_we;
+  logic [15:0] ro_start_addr_high_3_quadrant_1_qs;
+  logic [15:0] ro_start_addr_high_3_quadrant_1_wd;
+  logic ro_start_addr_high_3_quadrant_1_we;
+  logic [31:0] ro_end_addr_low_3_quadrant_1_qs;
+  logic [31:0] ro_end_addr_low_3_quadrant_1_wd;
+  logic ro_end_addr_low_3_quadrant_1_we;
+  logic [15:0] ro_end_addr_high_3_quadrant_1_qs;
+  logic [15:0] ro_end_addr_high_3_quadrant_1_wd;
+  logic ro_end_addr_high_3_quadrant_1_we;
   logic [31:0] ro_start_addr_low_0_quadrant_2_qs;
   logic [31:0] ro_start_addr_low_0_quadrant_2_wd;
   logic ro_start_addr_low_0_quadrant_2_we;
@@ -538,6 +586,30 @@ module occamy_soc_reg_top #(
   logic [15:0] ro_end_addr_high_1_quadrant_2_qs;
   logic [15:0] ro_end_addr_high_1_quadrant_2_wd;
   logic ro_end_addr_high_1_quadrant_2_we;
+  logic [31:0] ro_start_addr_low_2_quadrant_2_qs;
+  logic [31:0] ro_start_addr_low_2_quadrant_2_wd;
+  logic ro_start_addr_low_2_quadrant_2_we;
+  logic [15:0] ro_start_addr_high_2_quadrant_2_qs;
+  logic [15:0] ro_start_addr_high_2_quadrant_2_wd;
+  logic ro_start_addr_high_2_quadrant_2_we;
+  logic [31:0] ro_end_addr_low_2_quadrant_2_qs;
+  logic [31:0] ro_end_addr_low_2_quadrant_2_wd;
+  logic ro_end_addr_low_2_quadrant_2_we;
+  logic [15:0] ro_end_addr_high_2_quadrant_2_qs;
+  logic [15:0] ro_end_addr_high_2_quadrant_2_wd;
+  logic ro_end_addr_high_2_quadrant_2_we;
+  logic [31:0] ro_start_addr_low_3_quadrant_2_qs;
+  logic [31:0] ro_start_addr_low_3_quadrant_2_wd;
+  logic ro_start_addr_low_3_quadrant_2_we;
+  logic [15:0] ro_start_addr_high_3_quadrant_2_qs;
+  logic [15:0] ro_start_addr_high_3_quadrant_2_wd;
+  logic ro_start_addr_high_3_quadrant_2_we;
+  logic [31:0] ro_end_addr_low_3_quadrant_2_qs;
+  logic [31:0] ro_end_addr_low_3_quadrant_2_wd;
+  logic ro_end_addr_low_3_quadrant_2_we;
+  logic [15:0] ro_end_addr_high_3_quadrant_2_qs;
+  logic [15:0] ro_end_addr_high_3_quadrant_2_wd;
+  logic ro_end_addr_high_3_quadrant_2_we;
   logic [31:0] ro_start_addr_low_0_quadrant_3_qs;
   logic [31:0] ro_start_addr_low_0_quadrant_3_wd;
   logic ro_start_addr_low_0_quadrant_3_we;
@@ -562,6 +634,30 @@ module occamy_soc_reg_top #(
   logic [15:0] ro_end_addr_high_1_quadrant_3_qs;
   logic [15:0] ro_end_addr_high_1_quadrant_3_wd;
   logic ro_end_addr_high_1_quadrant_3_we;
+  logic [31:0] ro_start_addr_low_2_quadrant_3_qs;
+  logic [31:0] ro_start_addr_low_2_quadrant_3_wd;
+  logic ro_start_addr_low_2_quadrant_3_we;
+  logic [15:0] ro_start_addr_high_2_quadrant_3_qs;
+  logic [15:0] ro_start_addr_high_2_quadrant_3_wd;
+  logic ro_start_addr_high_2_quadrant_3_we;
+  logic [31:0] ro_end_addr_low_2_quadrant_3_qs;
+  logic [31:0] ro_end_addr_low_2_quadrant_3_wd;
+  logic ro_end_addr_low_2_quadrant_3_we;
+  logic [15:0] ro_end_addr_high_2_quadrant_3_qs;
+  logic [15:0] ro_end_addr_high_2_quadrant_3_wd;
+  logic ro_end_addr_high_2_quadrant_3_we;
+  logic [31:0] ro_start_addr_low_3_quadrant_3_qs;
+  logic [31:0] ro_start_addr_low_3_quadrant_3_wd;
+  logic ro_start_addr_low_3_quadrant_3_we;
+  logic [15:0] ro_start_addr_high_3_quadrant_3_qs;
+  logic [15:0] ro_start_addr_high_3_quadrant_3_wd;
+  logic ro_start_addr_high_3_quadrant_3_we;
+  logic [31:0] ro_end_addr_low_3_quadrant_3_qs;
+  logic [31:0] ro_end_addr_low_3_quadrant_3_wd;
+  logic ro_end_addr_low_3_quadrant_3_we;
+  logic [15:0] ro_end_addr_high_3_quadrant_3_qs;
+  logic [15:0] ro_end_addr_high_3_quadrant_3_wd;
+  logic ro_end_addr_high_3_quadrant_3_we;
   logic [31:0] ro_start_addr_low_0_quadrant_4_qs;
   logic [31:0] ro_start_addr_low_0_quadrant_4_wd;
   logic ro_start_addr_low_0_quadrant_4_we;
@@ -586,6 +682,30 @@ module occamy_soc_reg_top #(
   logic [15:0] ro_end_addr_high_1_quadrant_4_qs;
   logic [15:0] ro_end_addr_high_1_quadrant_4_wd;
   logic ro_end_addr_high_1_quadrant_4_we;
+  logic [31:0] ro_start_addr_low_2_quadrant_4_qs;
+  logic [31:0] ro_start_addr_low_2_quadrant_4_wd;
+  logic ro_start_addr_low_2_quadrant_4_we;
+  logic [15:0] ro_start_addr_high_2_quadrant_4_qs;
+  logic [15:0] ro_start_addr_high_2_quadrant_4_wd;
+  logic ro_start_addr_high_2_quadrant_4_we;
+  logic [31:0] ro_end_addr_low_2_quadrant_4_qs;
+  logic [31:0] ro_end_addr_low_2_quadrant_4_wd;
+  logic ro_end_addr_low_2_quadrant_4_we;
+  logic [15:0] ro_end_addr_high_2_quadrant_4_qs;
+  logic [15:0] ro_end_addr_high_2_quadrant_4_wd;
+  logic ro_end_addr_high_2_quadrant_4_we;
+  logic [31:0] ro_start_addr_low_3_quadrant_4_qs;
+  logic [31:0] ro_start_addr_low_3_quadrant_4_wd;
+  logic ro_start_addr_low_3_quadrant_4_we;
+  logic [15:0] ro_start_addr_high_3_quadrant_4_qs;
+  logic [15:0] ro_start_addr_high_3_quadrant_4_wd;
+  logic ro_start_addr_high_3_quadrant_4_we;
+  logic [31:0] ro_end_addr_low_3_quadrant_4_qs;
+  logic [31:0] ro_end_addr_low_3_quadrant_4_wd;
+  logic ro_end_addr_low_3_quadrant_4_we;
+  logic [15:0] ro_end_addr_high_3_quadrant_4_qs;
+  logic [15:0] ro_end_addr_high_3_quadrant_4_wd;
+  logic ro_end_addr_high_3_quadrant_4_we;
   logic [31:0] ro_start_addr_low_0_quadrant_5_qs;
   logic [31:0] ro_start_addr_low_0_quadrant_5_wd;
   logic ro_start_addr_low_0_quadrant_5_we;
@@ -610,6 +730,30 @@ module occamy_soc_reg_top #(
   logic [15:0] ro_end_addr_high_1_quadrant_5_qs;
   logic [15:0] ro_end_addr_high_1_quadrant_5_wd;
   logic ro_end_addr_high_1_quadrant_5_we;
+  logic [31:0] ro_start_addr_low_2_quadrant_5_qs;
+  logic [31:0] ro_start_addr_low_2_quadrant_5_wd;
+  logic ro_start_addr_low_2_quadrant_5_we;
+  logic [15:0] ro_start_addr_high_2_quadrant_5_qs;
+  logic [15:0] ro_start_addr_high_2_quadrant_5_wd;
+  logic ro_start_addr_high_2_quadrant_5_we;
+  logic [31:0] ro_end_addr_low_2_quadrant_5_qs;
+  logic [31:0] ro_end_addr_low_2_quadrant_5_wd;
+  logic ro_end_addr_low_2_quadrant_5_we;
+  logic [15:0] ro_end_addr_high_2_quadrant_5_qs;
+  logic [15:0] ro_end_addr_high_2_quadrant_5_wd;
+  logic ro_end_addr_high_2_quadrant_5_we;
+  logic [31:0] ro_start_addr_low_3_quadrant_5_qs;
+  logic [31:0] ro_start_addr_low_3_quadrant_5_wd;
+  logic ro_start_addr_low_3_quadrant_5_we;
+  logic [15:0] ro_start_addr_high_3_quadrant_5_qs;
+  logic [15:0] ro_start_addr_high_3_quadrant_5_wd;
+  logic ro_start_addr_high_3_quadrant_5_we;
+  logic [31:0] ro_end_addr_low_3_quadrant_5_qs;
+  logic [31:0] ro_end_addr_low_3_quadrant_5_wd;
+  logic ro_end_addr_low_3_quadrant_5_we;
+  logic [15:0] ro_end_addr_high_3_quadrant_5_qs;
+  logic [15:0] ro_end_addr_high_3_quadrant_5_wd;
+  logic ro_end_addr_high_3_quadrant_5_we;
   logic [31:0] ro_start_addr_low_0_quadrant_6_qs;
   logic [31:0] ro_start_addr_low_0_quadrant_6_wd;
   logic ro_start_addr_low_0_quadrant_6_we;
@@ -634,6 +778,30 @@ module occamy_soc_reg_top #(
   logic [15:0] ro_end_addr_high_1_quadrant_6_qs;
   logic [15:0] ro_end_addr_high_1_quadrant_6_wd;
   logic ro_end_addr_high_1_quadrant_6_we;
+  logic [31:0] ro_start_addr_low_2_quadrant_6_qs;
+  logic [31:0] ro_start_addr_low_2_quadrant_6_wd;
+  logic ro_start_addr_low_2_quadrant_6_we;
+  logic [15:0] ro_start_addr_high_2_quadrant_6_qs;
+  logic [15:0] ro_start_addr_high_2_quadrant_6_wd;
+  logic ro_start_addr_high_2_quadrant_6_we;
+  logic [31:0] ro_end_addr_low_2_quadrant_6_qs;
+  logic [31:0] ro_end_addr_low_2_quadrant_6_wd;
+  logic ro_end_addr_low_2_quadrant_6_we;
+  logic [15:0] ro_end_addr_high_2_quadrant_6_qs;
+  logic [15:0] ro_end_addr_high_2_quadrant_6_wd;
+  logic ro_end_addr_high_2_quadrant_6_we;
+  logic [31:0] ro_start_addr_low_3_quadrant_6_qs;
+  logic [31:0] ro_start_addr_low_3_quadrant_6_wd;
+  logic ro_start_addr_low_3_quadrant_6_we;
+  logic [15:0] ro_start_addr_high_3_quadrant_6_qs;
+  logic [15:0] ro_start_addr_high_3_quadrant_6_wd;
+  logic ro_start_addr_high_3_quadrant_6_we;
+  logic [31:0] ro_end_addr_low_3_quadrant_6_qs;
+  logic [31:0] ro_end_addr_low_3_quadrant_6_wd;
+  logic ro_end_addr_low_3_quadrant_6_we;
+  logic [15:0] ro_end_addr_high_3_quadrant_6_qs;
+  logic [15:0] ro_end_addr_high_3_quadrant_6_wd;
+  logic ro_end_addr_high_3_quadrant_6_we;
   logic [31:0] ro_start_addr_low_0_quadrant_7_qs;
   logic [31:0] ro_start_addr_low_0_quadrant_7_wd;
   logic ro_start_addr_low_0_quadrant_7_we;
@@ -658,6 +826,30 @@ module occamy_soc_reg_top #(
   logic [15:0] ro_end_addr_high_1_quadrant_7_qs;
   logic [15:0] ro_end_addr_high_1_quadrant_7_wd;
   logic ro_end_addr_high_1_quadrant_7_we;
+  logic [31:0] ro_start_addr_low_2_quadrant_7_qs;
+  logic [31:0] ro_start_addr_low_2_quadrant_7_wd;
+  logic ro_start_addr_low_2_quadrant_7_we;
+  logic [15:0] ro_start_addr_high_2_quadrant_7_qs;
+  logic [15:0] ro_start_addr_high_2_quadrant_7_wd;
+  logic ro_start_addr_high_2_quadrant_7_we;
+  logic [31:0] ro_end_addr_low_2_quadrant_7_qs;
+  logic [31:0] ro_end_addr_low_2_quadrant_7_wd;
+  logic ro_end_addr_low_2_quadrant_7_we;
+  logic [15:0] ro_end_addr_high_2_quadrant_7_qs;
+  logic [15:0] ro_end_addr_high_2_quadrant_7_wd;
+  logic ro_end_addr_high_2_quadrant_7_we;
+  logic [31:0] ro_start_addr_low_3_quadrant_7_qs;
+  logic [31:0] ro_start_addr_low_3_quadrant_7_wd;
+  logic ro_start_addr_low_3_quadrant_7_we;
+  logic [15:0] ro_start_addr_high_3_quadrant_7_qs;
+  logic [15:0] ro_start_addr_high_3_quadrant_7_wd;
+  logic ro_start_addr_high_3_quadrant_7_we;
+  logic [31:0] ro_end_addr_low_3_quadrant_7_qs;
+  logic [31:0] ro_end_addr_low_3_quadrant_7_wd;
+  logic ro_end_addr_low_3_quadrant_7_we;
+  logic [15:0] ro_end_addr_high_3_quadrant_7_qs;
+  logic [15:0] ro_end_addr_high_3_quadrant_7_wd;
+  logic ro_end_addr_high_3_quadrant_7_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -4425,6 +4617,222 @@ module occamy_soc_reg_top #(
   );
 
 
+  // R[ro_start_addr_low_2_quadrant_0]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_2_quadrant_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_2_quadrant_0_we),
+    .wd     (ro_start_addr_low_2_quadrant_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_2_quadrant_0.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_2_quadrant_0_qs)
+  );
+
+
+  // R[ro_start_addr_high_2_quadrant_0]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h2)
+  ) u_ro_start_addr_high_2_quadrant_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_2_quadrant_0_we),
+    .wd     (ro_start_addr_high_2_quadrant_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_2_quadrant_0.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_2_quadrant_0_qs)
+  );
+
+
+  // R[ro_end_addr_low_2_quadrant_0]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_2_quadrant_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_2_quadrant_0_we),
+    .wd     (ro_end_addr_low_2_quadrant_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_2_quadrant_0.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_2_quadrant_0_qs)
+  );
+
+
+  // R[ro_end_addr_high_2_quadrant_0]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_end_addr_high_2_quadrant_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_2_quadrant_0_we),
+    .wd     (ro_end_addr_high_2_quadrant_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_2_quadrant_0.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_2_quadrant_0_qs)
+  );
+
+
+  // R[ro_start_addr_low_3_quadrant_0]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_3_quadrant_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_3_quadrant_0_we),
+    .wd     (ro_start_addr_low_3_quadrant_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_3_quadrant_0.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_3_quadrant_0_qs)
+  );
+
+
+  // R[ro_start_addr_high_3_quadrant_0]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_start_addr_high_3_quadrant_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_3_quadrant_0_we),
+    .wd     (ro_start_addr_high_3_quadrant_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_3_quadrant_0.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_3_quadrant_0_qs)
+  );
+
+
+  // R[ro_end_addr_low_3_quadrant_0]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_3_quadrant_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_3_quadrant_0_we),
+    .wd     (ro_end_addr_low_3_quadrant_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_3_quadrant_0.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_3_quadrant_0_qs)
+  );
+
+
+  // R[ro_end_addr_high_3_quadrant_0]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h4)
+  ) u_ro_end_addr_high_3_quadrant_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_3_quadrant_0_we),
+    .wd     (ro_end_addr_high_3_quadrant_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_3_quadrant_0.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_3_quadrant_0_qs)
+  );
+
+
   // R[ro_start_addr_low_0_quadrant_1]: V(False)
 
   prim_subreg #(
@@ -4638,6 +5046,222 @@ module occamy_soc_reg_top #(
 
     // to register interface (read)
     .qs     (ro_end_addr_high_1_quadrant_1_qs)
+  );
+
+
+  // R[ro_start_addr_low_2_quadrant_1]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_2_quadrant_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_2_quadrant_1_we),
+    .wd     (ro_start_addr_low_2_quadrant_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_2_quadrant_1.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_2_quadrant_1_qs)
+  );
+
+
+  // R[ro_start_addr_high_2_quadrant_1]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h2)
+  ) u_ro_start_addr_high_2_quadrant_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_2_quadrant_1_we),
+    .wd     (ro_start_addr_high_2_quadrant_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_2_quadrant_1.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_2_quadrant_1_qs)
+  );
+
+
+  // R[ro_end_addr_low_2_quadrant_1]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_2_quadrant_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_2_quadrant_1_we),
+    .wd     (ro_end_addr_low_2_quadrant_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_2_quadrant_1.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_2_quadrant_1_qs)
+  );
+
+
+  // R[ro_end_addr_high_2_quadrant_1]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_end_addr_high_2_quadrant_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_2_quadrant_1_we),
+    .wd     (ro_end_addr_high_2_quadrant_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_2_quadrant_1.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_2_quadrant_1_qs)
+  );
+
+
+  // R[ro_start_addr_low_3_quadrant_1]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_3_quadrant_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_3_quadrant_1_we),
+    .wd     (ro_start_addr_low_3_quadrant_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_3_quadrant_1.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_3_quadrant_1_qs)
+  );
+
+
+  // R[ro_start_addr_high_3_quadrant_1]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_start_addr_high_3_quadrant_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_3_quadrant_1_we),
+    .wd     (ro_start_addr_high_3_quadrant_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_3_quadrant_1.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_3_quadrant_1_qs)
+  );
+
+
+  // R[ro_end_addr_low_3_quadrant_1]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_3_quadrant_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_3_quadrant_1_we),
+    .wd     (ro_end_addr_low_3_quadrant_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_3_quadrant_1.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_3_quadrant_1_qs)
+  );
+
+
+  // R[ro_end_addr_high_3_quadrant_1]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h4)
+  ) u_ro_end_addr_high_3_quadrant_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_3_quadrant_1_we),
+    .wd     (ro_end_addr_high_3_quadrant_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_3_quadrant_1.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_3_quadrant_1_qs)
   );
 
 
@@ -4857,6 +5481,222 @@ module occamy_soc_reg_top #(
   );
 
 
+  // R[ro_start_addr_low_2_quadrant_2]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_2_quadrant_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_2_quadrant_2_we),
+    .wd     (ro_start_addr_low_2_quadrant_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_2_quadrant_2.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_2_quadrant_2_qs)
+  );
+
+
+  // R[ro_start_addr_high_2_quadrant_2]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h2)
+  ) u_ro_start_addr_high_2_quadrant_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_2_quadrant_2_we),
+    .wd     (ro_start_addr_high_2_quadrant_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_2_quadrant_2.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_2_quadrant_2_qs)
+  );
+
+
+  // R[ro_end_addr_low_2_quadrant_2]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_2_quadrant_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_2_quadrant_2_we),
+    .wd     (ro_end_addr_low_2_quadrant_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_2_quadrant_2.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_2_quadrant_2_qs)
+  );
+
+
+  // R[ro_end_addr_high_2_quadrant_2]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_end_addr_high_2_quadrant_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_2_quadrant_2_we),
+    .wd     (ro_end_addr_high_2_quadrant_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_2_quadrant_2.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_2_quadrant_2_qs)
+  );
+
+
+  // R[ro_start_addr_low_3_quadrant_2]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_3_quadrant_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_3_quadrant_2_we),
+    .wd     (ro_start_addr_low_3_quadrant_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_3_quadrant_2.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_3_quadrant_2_qs)
+  );
+
+
+  // R[ro_start_addr_high_3_quadrant_2]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_start_addr_high_3_quadrant_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_3_quadrant_2_we),
+    .wd     (ro_start_addr_high_3_quadrant_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_3_quadrant_2.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_3_quadrant_2_qs)
+  );
+
+
+  // R[ro_end_addr_low_3_quadrant_2]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_3_quadrant_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_3_quadrant_2_we),
+    .wd     (ro_end_addr_low_3_quadrant_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_3_quadrant_2.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_3_quadrant_2_qs)
+  );
+
+
+  // R[ro_end_addr_high_3_quadrant_2]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h4)
+  ) u_ro_end_addr_high_3_quadrant_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_3_quadrant_2_we),
+    .wd     (ro_end_addr_high_3_quadrant_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_3_quadrant_2.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_3_quadrant_2_qs)
+  );
+
+
   // R[ro_start_addr_low_0_quadrant_3]: V(False)
 
   prim_subreg #(
@@ -5070,6 +5910,222 @@ module occamy_soc_reg_top #(
 
     // to register interface (read)
     .qs     (ro_end_addr_high_1_quadrant_3_qs)
+  );
+
+
+  // R[ro_start_addr_low_2_quadrant_3]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_2_quadrant_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_2_quadrant_3_we),
+    .wd     (ro_start_addr_low_2_quadrant_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_2_quadrant_3.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_2_quadrant_3_qs)
+  );
+
+
+  // R[ro_start_addr_high_2_quadrant_3]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h2)
+  ) u_ro_start_addr_high_2_quadrant_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_2_quadrant_3_we),
+    .wd     (ro_start_addr_high_2_quadrant_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_2_quadrant_3.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_2_quadrant_3_qs)
+  );
+
+
+  // R[ro_end_addr_low_2_quadrant_3]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_2_quadrant_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_2_quadrant_3_we),
+    .wd     (ro_end_addr_low_2_quadrant_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_2_quadrant_3.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_2_quadrant_3_qs)
+  );
+
+
+  // R[ro_end_addr_high_2_quadrant_3]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_end_addr_high_2_quadrant_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_2_quadrant_3_we),
+    .wd     (ro_end_addr_high_2_quadrant_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_2_quadrant_3.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_2_quadrant_3_qs)
+  );
+
+
+  // R[ro_start_addr_low_3_quadrant_3]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_3_quadrant_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_3_quadrant_3_we),
+    .wd     (ro_start_addr_low_3_quadrant_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_3_quadrant_3.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_3_quadrant_3_qs)
+  );
+
+
+  // R[ro_start_addr_high_3_quadrant_3]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_start_addr_high_3_quadrant_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_3_quadrant_3_we),
+    .wd     (ro_start_addr_high_3_quadrant_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_3_quadrant_3.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_3_quadrant_3_qs)
+  );
+
+
+  // R[ro_end_addr_low_3_quadrant_3]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_3_quadrant_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_3_quadrant_3_we),
+    .wd     (ro_end_addr_low_3_quadrant_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_3_quadrant_3.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_3_quadrant_3_qs)
+  );
+
+
+  // R[ro_end_addr_high_3_quadrant_3]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h4)
+  ) u_ro_end_addr_high_3_quadrant_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_3_quadrant_3_we),
+    .wd     (ro_end_addr_high_3_quadrant_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_3_quadrant_3.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_3_quadrant_3_qs)
   );
 
 
@@ -5289,6 +6345,222 @@ module occamy_soc_reg_top #(
   );
 
 
+  // R[ro_start_addr_low_2_quadrant_4]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_2_quadrant_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_2_quadrant_4_we),
+    .wd     (ro_start_addr_low_2_quadrant_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_2_quadrant_4.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_2_quadrant_4_qs)
+  );
+
+
+  // R[ro_start_addr_high_2_quadrant_4]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h2)
+  ) u_ro_start_addr_high_2_quadrant_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_2_quadrant_4_we),
+    .wd     (ro_start_addr_high_2_quadrant_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_2_quadrant_4.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_2_quadrant_4_qs)
+  );
+
+
+  // R[ro_end_addr_low_2_quadrant_4]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_2_quadrant_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_2_quadrant_4_we),
+    .wd     (ro_end_addr_low_2_quadrant_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_2_quadrant_4.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_2_quadrant_4_qs)
+  );
+
+
+  // R[ro_end_addr_high_2_quadrant_4]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_end_addr_high_2_quadrant_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_2_quadrant_4_we),
+    .wd     (ro_end_addr_high_2_quadrant_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_2_quadrant_4.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_2_quadrant_4_qs)
+  );
+
+
+  // R[ro_start_addr_low_3_quadrant_4]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_3_quadrant_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_3_quadrant_4_we),
+    .wd     (ro_start_addr_low_3_quadrant_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_3_quadrant_4.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_3_quadrant_4_qs)
+  );
+
+
+  // R[ro_start_addr_high_3_quadrant_4]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_start_addr_high_3_quadrant_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_3_quadrant_4_we),
+    .wd     (ro_start_addr_high_3_quadrant_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_3_quadrant_4.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_3_quadrant_4_qs)
+  );
+
+
+  // R[ro_end_addr_low_3_quadrant_4]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_3_quadrant_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_3_quadrant_4_we),
+    .wd     (ro_end_addr_low_3_quadrant_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_3_quadrant_4.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_3_quadrant_4_qs)
+  );
+
+
+  // R[ro_end_addr_high_3_quadrant_4]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h4)
+  ) u_ro_end_addr_high_3_quadrant_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_3_quadrant_4_we),
+    .wd     (ro_end_addr_high_3_quadrant_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_3_quadrant_4.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_3_quadrant_4_qs)
+  );
+
+
   // R[ro_start_addr_low_0_quadrant_5]: V(False)
 
   prim_subreg #(
@@ -5502,6 +6774,222 @@ module occamy_soc_reg_top #(
 
     // to register interface (read)
     .qs     (ro_end_addr_high_1_quadrant_5_qs)
+  );
+
+
+  // R[ro_start_addr_low_2_quadrant_5]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_2_quadrant_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_2_quadrant_5_we),
+    .wd     (ro_start_addr_low_2_quadrant_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_2_quadrant_5.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_2_quadrant_5_qs)
+  );
+
+
+  // R[ro_start_addr_high_2_quadrant_5]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h2)
+  ) u_ro_start_addr_high_2_quadrant_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_2_quadrant_5_we),
+    .wd     (ro_start_addr_high_2_quadrant_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_2_quadrant_5.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_2_quadrant_5_qs)
+  );
+
+
+  // R[ro_end_addr_low_2_quadrant_5]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_2_quadrant_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_2_quadrant_5_we),
+    .wd     (ro_end_addr_low_2_quadrant_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_2_quadrant_5.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_2_quadrant_5_qs)
+  );
+
+
+  // R[ro_end_addr_high_2_quadrant_5]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_end_addr_high_2_quadrant_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_2_quadrant_5_we),
+    .wd     (ro_end_addr_high_2_quadrant_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_2_quadrant_5.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_2_quadrant_5_qs)
+  );
+
+
+  // R[ro_start_addr_low_3_quadrant_5]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_3_quadrant_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_3_quadrant_5_we),
+    .wd     (ro_start_addr_low_3_quadrant_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_3_quadrant_5.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_3_quadrant_5_qs)
+  );
+
+
+  // R[ro_start_addr_high_3_quadrant_5]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_start_addr_high_3_quadrant_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_3_quadrant_5_we),
+    .wd     (ro_start_addr_high_3_quadrant_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_3_quadrant_5.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_3_quadrant_5_qs)
+  );
+
+
+  // R[ro_end_addr_low_3_quadrant_5]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_3_quadrant_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_3_quadrant_5_we),
+    .wd     (ro_end_addr_low_3_quadrant_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_3_quadrant_5.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_3_quadrant_5_qs)
+  );
+
+
+  // R[ro_end_addr_high_3_quadrant_5]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h4)
+  ) u_ro_end_addr_high_3_quadrant_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_3_quadrant_5_we),
+    .wd     (ro_end_addr_high_3_quadrant_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_3_quadrant_5.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_3_quadrant_5_qs)
   );
 
 
@@ -5721,6 +7209,222 @@ module occamy_soc_reg_top #(
   );
 
 
+  // R[ro_start_addr_low_2_quadrant_6]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_2_quadrant_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_2_quadrant_6_we),
+    .wd     (ro_start_addr_low_2_quadrant_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_2_quadrant_6.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_2_quadrant_6_qs)
+  );
+
+
+  // R[ro_start_addr_high_2_quadrant_6]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h2)
+  ) u_ro_start_addr_high_2_quadrant_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_2_quadrant_6_we),
+    .wd     (ro_start_addr_high_2_quadrant_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_2_quadrant_6.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_2_quadrant_6_qs)
+  );
+
+
+  // R[ro_end_addr_low_2_quadrant_6]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_2_quadrant_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_2_quadrant_6_we),
+    .wd     (ro_end_addr_low_2_quadrant_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_2_quadrant_6.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_2_quadrant_6_qs)
+  );
+
+
+  // R[ro_end_addr_high_2_quadrant_6]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_end_addr_high_2_quadrant_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_2_quadrant_6_we),
+    .wd     (ro_end_addr_high_2_quadrant_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_2_quadrant_6.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_2_quadrant_6_qs)
+  );
+
+
+  // R[ro_start_addr_low_3_quadrant_6]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_3_quadrant_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_3_quadrant_6_we),
+    .wd     (ro_start_addr_low_3_quadrant_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_3_quadrant_6.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_3_quadrant_6_qs)
+  );
+
+
+  // R[ro_start_addr_high_3_quadrant_6]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_start_addr_high_3_quadrant_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_3_quadrant_6_we),
+    .wd     (ro_start_addr_high_3_quadrant_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_3_quadrant_6.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_3_quadrant_6_qs)
+  );
+
+
+  // R[ro_end_addr_low_3_quadrant_6]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_3_quadrant_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_3_quadrant_6_we),
+    .wd     (ro_end_addr_low_3_quadrant_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_3_quadrant_6.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_3_quadrant_6_qs)
+  );
+
+
+  // R[ro_end_addr_high_3_quadrant_6]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h4)
+  ) u_ro_end_addr_high_3_quadrant_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_3_quadrant_6_we),
+    .wd     (ro_end_addr_high_3_quadrant_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_3_quadrant_6.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_3_quadrant_6_qs)
+  );
+
+
   // R[ro_start_addr_low_0_quadrant_7]: V(False)
 
   prim_subreg #(
@@ -5937,9 +7641,225 @@ module occamy_soc_reg_top #(
   );
 
 
+  // R[ro_start_addr_low_2_quadrant_7]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_2_quadrant_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_2_quadrant_7_we),
+    .wd     (ro_start_addr_low_2_quadrant_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_2_quadrant_7.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_2_quadrant_7_qs)
+  );
 
 
-  logic [107:0] addr_hit;
+  // R[ro_start_addr_high_2_quadrant_7]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h2)
+  ) u_ro_start_addr_high_2_quadrant_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_2_quadrant_7_we),
+    .wd     (ro_start_addr_high_2_quadrant_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_2_quadrant_7.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_2_quadrant_7_qs)
+  );
+
+
+  // R[ro_end_addr_low_2_quadrant_7]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_2_quadrant_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_2_quadrant_7_we),
+    .wd     (ro_end_addr_low_2_quadrant_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_2_quadrant_7.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_2_quadrant_7_qs)
+  );
+
+
+  // R[ro_end_addr_high_2_quadrant_7]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_end_addr_high_2_quadrant_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_2_quadrant_7_we),
+    .wd     (ro_end_addr_high_2_quadrant_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_2_quadrant_7.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_2_quadrant_7_qs)
+  );
+
+
+  // R[ro_start_addr_low_3_quadrant_7]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_start_addr_low_3_quadrant_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_low_3_quadrant_7_we),
+    .wd     (ro_start_addr_low_3_quadrant_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_low_3_quadrant_7.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_low_3_quadrant_7_qs)
+  );
+
+
+  // R[ro_start_addr_high_3_quadrant_7]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h3)
+  ) u_ro_start_addr_high_3_quadrant_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_start_addr_high_3_quadrant_7_we),
+    .wd     (ro_start_addr_high_3_quadrant_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_start_addr_high_3_quadrant_7.q ),
+
+    // to register interface (read)
+    .qs     (ro_start_addr_high_3_quadrant_7_qs)
+  );
+
+
+  // R[ro_end_addr_low_3_quadrant_7]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_ro_end_addr_low_3_quadrant_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_low_3_quadrant_7_we),
+    .wd     (ro_end_addr_low_3_quadrant_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_low_3_quadrant_7.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_low_3_quadrant_7_qs)
+  );
+
+
+  // R[ro_end_addr_high_3_quadrant_7]: V(False)
+
+  prim_subreg #(
+    .DW      (16),
+    .SWACCESS("RW"),
+    .RESVAL  (16'h4)
+  ) u_ro_end_addr_high_3_quadrant_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ro_end_addr_high_3_quadrant_7_we),
+    .wd     (ro_end_addr_high_3_quadrant_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ro_end_addr_high_3_quadrant_7.q ),
+
+    // to register interface (read)
+    .qs     (ro_end_addr_high_3_quadrant_7_qs)
+  );
+
+
+
+
+  logic [171:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[  0] = (reg_addr == OCCAMY_SOC_INTR_STATE_OFFSET);
@@ -5994,62 +7914,126 @@ module occamy_soc_reg_top #(
     addr_hit[ 49] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_0_OFFSET);
     addr_hit[ 50] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_0_OFFSET);
     addr_hit[ 51] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_0_OFFSET);
-    addr_hit[ 52] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_1_OFFSET);
-    addr_hit[ 53] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_1_OFFSET);
-    addr_hit[ 54] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_1_OFFSET);
-    addr_hit[ 55] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_1_OFFSET);
-    addr_hit[ 56] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_1_OFFSET);
-    addr_hit[ 57] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_1_OFFSET);
-    addr_hit[ 58] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_1_OFFSET);
-    addr_hit[ 59] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_1_OFFSET);
-    addr_hit[ 60] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_2_OFFSET);
-    addr_hit[ 61] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_2_OFFSET);
-    addr_hit[ 62] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_2_OFFSET);
-    addr_hit[ 63] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_2_OFFSET);
-    addr_hit[ 64] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_2_OFFSET);
-    addr_hit[ 65] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_2_OFFSET);
-    addr_hit[ 66] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_2_OFFSET);
-    addr_hit[ 67] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_2_OFFSET);
-    addr_hit[ 68] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_3_OFFSET);
-    addr_hit[ 69] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_3_OFFSET);
-    addr_hit[ 70] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_3_OFFSET);
-    addr_hit[ 71] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_3_OFFSET);
-    addr_hit[ 72] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_3_OFFSET);
-    addr_hit[ 73] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_3_OFFSET);
-    addr_hit[ 74] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_3_OFFSET);
-    addr_hit[ 75] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_3_OFFSET);
-    addr_hit[ 76] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_4_OFFSET);
-    addr_hit[ 77] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_4_OFFSET);
-    addr_hit[ 78] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_4_OFFSET);
-    addr_hit[ 79] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_4_OFFSET);
-    addr_hit[ 80] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_4_OFFSET);
-    addr_hit[ 81] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_4_OFFSET);
-    addr_hit[ 82] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_4_OFFSET);
-    addr_hit[ 83] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_4_OFFSET);
-    addr_hit[ 84] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_5_OFFSET);
-    addr_hit[ 85] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_5_OFFSET);
-    addr_hit[ 86] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_5_OFFSET);
-    addr_hit[ 87] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_5_OFFSET);
-    addr_hit[ 88] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_5_OFFSET);
-    addr_hit[ 89] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_5_OFFSET);
-    addr_hit[ 90] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_5_OFFSET);
-    addr_hit[ 91] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_5_OFFSET);
-    addr_hit[ 92] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_6_OFFSET);
-    addr_hit[ 93] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_6_OFFSET);
-    addr_hit[ 94] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_6_OFFSET);
-    addr_hit[ 95] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_6_OFFSET);
-    addr_hit[ 96] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_6_OFFSET);
-    addr_hit[ 97] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_6_OFFSET);
-    addr_hit[ 98] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_6_OFFSET);
-    addr_hit[ 99] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_6_OFFSET);
-    addr_hit[100] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_7_OFFSET);
-    addr_hit[101] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_7_OFFSET);
-    addr_hit[102] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_7_OFFSET);
-    addr_hit[103] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_7_OFFSET);
-    addr_hit[104] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_7_OFFSET);
-    addr_hit[105] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_7_OFFSET);
-    addr_hit[106] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_7_OFFSET);
-    addr_hit[107] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_7_OFFSET);
+    addr_hit[ 52] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_0_OFFSET);
+    addr_hit[ 53] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_0_OFFSET);
+    addr_hit[ 54] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_0_OFFSET);
+    addr_hit[ 55] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_0_OFFSET);
+    addr_hit[ 56] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_0_OFFSET);
+    addr_hit[ 57] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_0_OFFSET);
+    addr_hit[ 58] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_0_OFFSET);
+    addr_hit[ 59] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_0_OFFSET);
+    addr_hit[ 60] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_1_OFFSET);
+    addr_hit[ 61] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_1_OFFSET);
+    addr_hit[ 62] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_1_OFFSET);
+    addr_hit[ 63] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_1_OFFSET);
+    addr_hit[ 64] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_1_OFFSET);
+    addr_hit[ 65] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_1_OFFSET);
+    addr_hit[ 66] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_1_OFFSET);
+    addr_hit[ 67] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_1_OFFSET);
+    addr_hit[ 68] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_1_OFFSET);
+    addr_hit[ 69] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_1_OFFSET);
+    addr_hit[ 70] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_1_OFFSET);
+    addr_hit[ 71] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_1_OFFSET);
+    addr_hit[ 72] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_1_OFFSET);
+    addr_hit[ 73] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_1_OFFSET);
+    addr_hit[ 74] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_1_OFFSET);
+    addr_hit[ 75] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_1_OFFSET);
+    addr_hit[ 76] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_2_OFFSET);
+    addr_hit[ 77] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_2_OFFSET);
+    addr_hit[ 78] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_2_OFFSET);
+    addr_hit[ 79] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_2_OFFSET);
+    addr_hit[ 80] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_2_OFFSET);
+    addr_hit[ 81] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_2_OFFSET);
+    addr_hit[ 82] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_2_OFFSET);
+    addr_hit[ 83] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_2_OFFSET);
+    addr_hit[ 84] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_2_OFFSET);
+    addr_hit[ 85] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_2_OFFSET);
+    addr_hit[ 86] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_2_OFFSET);
+    addr_hit[ 87] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_2_OFFSET);
+    addr_hit[ 88] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_2_OFFSET);
+    addr_hit[ 89] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_2_OFFSET);
+    addr_hit[ 90] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_2_OFFSET);
+    addr_hit[ 91] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_2_OFFSET);
+    addr_hit[ 92] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_3_OFFSET);
+    addr_hit[ 93] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_3_OFFSET);
+    addr_hit[ 94] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_3_OFFSET);
+    addr_hit[ 95] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_3_OFFSET);
+    addr_hit[ 96] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_3_OFFSET);
+    addr_hit[ 97] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_3_OFFSET);
+    addr_hit[ 98] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_3_OFFSET);
+    addr_hit[ 99] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_3_OFFSET);
+    addr_hit[100] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_3_OFFSET);
+    addr_hit[101] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_3_OFFSET);
+    addr_hit[102] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_3_OFFSET);
+    addr_hit[103] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_3_OFFSET);
+    addr_hit[104] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_3_OFFSET);
+    addr_hit[105] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_3_OFFSET);
+    addr_hit[106] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_3_OFFSET);
+    addr_hit[107] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_3_OFFSET);
+    addr_hit[108] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_4_OFFSET);
+    addr_hit[109] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_4_OFFSET);
+    addr_hit[110] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_4_OFFSET);
+    addr_hit[111] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_4_OFFSET);
+    addr_hit[112] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_4_OFFSET);
+    addr_hit[113] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_4_OFFSET);
+    addr_hit[114] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_4_OFFSET);
+    addr_hit[115] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_4_OFFSET);
+    addr_hit[116] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_4_OFFSET);
+    addr_hit[117] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_4_OFFSET);
+    addr_hit[118] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_4_OFFSET);
+    addr_hit[119] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_4_OFFSET);
+    addr_hit[120] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_4_OFFSET);
+    addr_hit[121] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_4_OFFSET);
+    addr_hit[122] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_4_OFFSET);
+    addr_hit[123] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_4_OFFSET);
+    addr_hit[124] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_5_OFFSET);
+    addr_hit[125] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_5_OFFSET);
+    addr_hit[126] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_5_OFFSET);
+    addr_hit[127] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_5_OFFSET);
+    addr_hit[128] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_5_OFFSET);
+    addr_hit[129] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_5_OFFSET);
+    addr_hit[130] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_5_OFFSET);
+    addr_hit[131] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_5_OFFSET);
+    addr_hit[132] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_5_OFFSET);
+    addr_hit[133] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_5_OFFSET);
+    addr_hit[134] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_5_OFFSET);
+    addr_hit[135] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_5_OFFSET);
+    addr_hit[136] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_5_OFFSET);
+    addr_hit[137] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_5_OFFSET);
+    addr_hit[138] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_5_OFFSET);
+    addr_hit[139] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_5_OFFSET);
+    addr_hit[140] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_6_OFFSET);
+    addr_hit[141] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_6_OFFSET);
+    addr_hit[142] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_6_OFFSET);
+    addr_hit[143] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_6_OFFSET);
+    addr_hit[144] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_6_OFFSET);
+    addr_hit[145] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_6_OFFSET);
+    addr_hit[146] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_6_OFFSET);
+    addr_hit[147] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_6_OFFSET);
+    addr_hit[148] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_6_OFFSET);
+    addr_hit[149] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_6_OFFSET);
+    addr_hit[150] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_6_OFFSET);
+    addr_hit[151] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_6_OFFSET);
+    addr_hit[152] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_6_OFFSET);
+    addr_hit[153] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_6_OFFSET);
+    addr_hit[154] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_6_OFFSET);
+    addr_hit[155] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_6_OFFSET);
+    addr_hit[156] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_0_QUADRANT_7_OFFSET);
+    addr_hit[157] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_0_QUADRANT_7_OFFSET);
+    addr_hit[158] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_0_QUADRANT_7_OFFSET);
+    addr_hit[159] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_0_QUADRANT_7_OFFSET);
+    addr_hit[160] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_1_QUADRANT_7_OFFSET);
+    addr_hit[161] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_1_QUADRANT_7_OFFSET);
+    addr_hit[162] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_1_QUADRANT_7_OFFSET);
+    addr_hit[163] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_1_QUADRANT_7_OFFSET);
+    addr_hit[164] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_2_QUADRANT_7_OFFSET);
+    addr_hit[165] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_2_QUADRANT_7_OFFSET);
+    addr_hit[166] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_2_QUADRANT_7_OFFSET);
+    addr_hit[167] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_2_QUADRANT_7_OFFSET);
+    addr_hit[168] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_LOW_3_QUADRANT_7_OFFSET);
+    addr_hit[169] = (reg_addr == OCCAMY_SOC_RO_START_ADDR_HIGH_3_QUADRANT_7_OFFSET);
+    addr_hit[170] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_LOW_3_QUADRANT_7_OFFSET);
+    addr_hit[171] = (reg_addr == OCCAMY_SOC_RO_END_ADDR_HIGH_3_QUADRANT_7_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -6164,7 +8148,71 @@ module occamy_soc_reg_top #(
                (addr_hit[104] & (|(OCCAMY_SOC_PERMIT[104] & ~reg_be))) |
                (addr_hit[105] & (|(OCCAMY_SOC_PERMIT[105] & ~reg_be))) |
                (addr_hit[106] & (|(OCCAMY_SOC_PERMIT[106] & ~reg_be))) |
-               (addr_hit[107] & (|(OCCAMY_SOC_PERMIT[107] & ~reg_be)))));
+               (addr_hit[107] & (|(OCCAMY_SOC_PERMIT[107] & ~reg_be))) |
+               (addr_hit[108] & (|(OCCAMY_SOC_PERMIT[108] & ~reg_be))) |
+               (addr_hit[109] & (|(OCCAMY_SOC_PERMIT[109] & ~reg_be))) |
+               (addr_hit[110] & (|(OCCAMY_SOC_PERMIT[110] & ~reg_be))) |
+               (addr_hit[111] & (|(OCCAMY_SOC_PERMIT[111] & ~reg_be))) |
+               (addr_hit[112] & (|(OCCAMY_SOC_PERMIT[112] & ~reg_be))) |
+               (addr_hit[113] & (|(OCCAMY_SOC_PERMIT[113] & ~reg_be))) |
+               (addr_hit[114] & (|(OCCAMY_SOC_PERMIT[114] & ~reg_be))) |
+               (addr_hit[115] & (|(OCCAMY_SOC_PERMIT[115] & ~reg_be))) |
+               (addr_hit[116] & (|(OCCAMY_SOC_PERMIT[116] & ~reg_be))) |
+               (addr_hit[117] & (|(OCCAMY_SOC_PERMIT[117] & ~reg_be))) |
+               (addr_hit[118] & (|(OCCAMY_SOC_PERMIT[118] & ~reg_be))) |
+               (addr_hit[119] & (|(OCCAMY_SOC_PERMIT[119] & ~reg_be))) |
+               (addr_hit[120] & (|(OCCAMY_SOC_PERMIT[120] & ~reg_be))) |
+               (addr_hit[121] & (|(OCCAMY_SOC_PERMIT[121] & ~reg_be))) |
+               (addr_hit[122] & (|(OCCAMY_SOC_PERMIT[122] & ~reg_be))) |
+               (addr_hit[123] & (|(OCCAMY_SOC_PERMIT[123] & ~reg_be))) |
+               (addr_hit[124] & (|(OCCAMY_SOC_PERMIT[124] & ~reg_be))) |
+               (addr_hit[125] & (|(OCCAMY_SOC_PERMIT[125] & ~reg_be))) |
+               (addr_hit[126] & (|(OCCAMY_SOC_PERMIT[126] & ~reg_be))) |
+               (addr_hit[127] & (|(OCCAMY_SOC_PERMIT[127] & ~reg_be))) |
+               (addr_hit[128] & (|(OCCAMY_SOC_PERMIT[128] & ~reg_be))) |
+               (addr_hit[129] & (|(OCCAMY_SOC_PERMIT[129] & ~reg_be))) |
+               (addr_hit[130] & (|(OCCAMY_SOC_PERMIT[130] & ~reg_be))) |
+               (addr_hit[131] & (|(OCCAMY_SOC_PERMIT[131] & ~reg_be))) |
+               (addr_hit[132] & (|(OCCAMY_SOC_PERMIT[132] & ~reg_be))) |
+               (addr_hit[133] & (|(OCCAMY_SOC_PERMIT[133] & ~reg_be))) |
+               (addr_hit[134] & (|(OCCAMY_SOC_PERMIT[134] & ~reg_be))) |
+               (addr_hit[135] & (|(OCCAMY_SOC_PERMIT[135] & ~reg_be))) |
+               (addr_hit[136] & (|(OCCAMY_SOC_PERMIT[136] & ~reg_be))) |
+               (addr_hit[137] & (|(OCCAMY_SOC_PERMIT[137] & ~reg_be))) |
+               (addr_hit[138] & (|(OCCAMY_SOC_PERMIT[138] & ~reg_be))) |
+               (addr_hit[139] & (|(OCCAMY_SOC_PERMIT[139] & ~reg_be))) |
+               (addr_hit[140] & (|(OCCAMY_SOC_PERMIT[140] & ~reg_be))) |
+               (addr_hit[141] & (|(OCCAMY_SOC_PERMIT[141] & ~reg_be))) |
+               (addr_hit[142] & (|(OCCAMY_SOC_PERMIT[142] & ~reg_be))) |
+               (addr_hit[143] & (|(OCCAMY_SOC_PERMIT[143] & ~reg_be))) |
+               (addr_hit[144] & (|(OCCAMY_SOC_PERMIT[144] & ~reg_be))) |
+               (addr_hit[145] & (|(OCCAMY_SOC_PERMIT[145] & ~reg_be))) |
+               (addr_hit[146] & (|(OCCAMY_SOC_PERMIT[146] & ~reg_be))) |
+               (addr_hit[147] & (|(OCCAMY_SOC_PERMIT[147] & ~reg_be))) |
+               (addr_hit[148] & (|(OCCAMY_SOC_PERMIT[148] & ~reg_be))) |
+               (addr_hit[149] & (|(OCCAMY_SOC_PERMIT[149] & ~reg_be))) |
+               (addr_hit[150] & (|(OCCAMY_SOC_PERMIT[150] & ~reg_be))) |
+               (addr_hit[151] & (|(OCCAMY_SOC_PERMIT[151] & ~reg_be))) |
+               (addr_hit[152] & (|(OCCAMY_SOC_PERMIT[152] & ~reg_be))) |
+               (addr_hit[153] & (|(OCCAMY_SOC_PERMIT[153] & ~reg_be))) |
+               (addr_hit[154] & (|(OCCAMY_SOC_PERMIT[154] & ~reg_be))) |
+               (addr_hit[155] & (|(OCCAMY_SOC_PERMIT[155] & ~reg_be))) |
+               (addr_hit[156] & (|(OCCAMY_SOC_PERMIT[156] & ~reg_be))) |
+               (addr_hit[157] & (|(OCCAMY_SOC_PERMIT[157] & ~reg_be))) |
+               (addr_hit[158] & (|(OCCAMY_SOC_PERMIT[158] & ~reg_be))) |
+               (addr_hit[159] & (|(OCCAMY_SOC_PERMIT[159] & ~reg_be))) |
+               (addr_hit[160] & (|(OCCAMY_SOC_PERMIT[160] & ~reg_be))) |
+               (addr_hit[161] & (|(OCCAMY_SOC_PERMIT[161] & ~reg_be))) |
+               (addr_hit[162] & (|(OCCAMY_SOC_PERMIT[162] & ~reg_be))) |
+               (addr_hit[163] & (|(OCCAMY_SOC_PERMIT[163] & ~reg_be))) |
+               (addr_hit[164] & (|(OCCAMY_SOC_PERMIT[164] & ~reg_be))) |
+               (addr_hit[165] & (|(OCCAMY_SOC_PERMIT[165] & ~reg_be))) |
+               (addr_hit[166] & (|(OCCAMY_SOC_PERMIT[166] & ~reg_be))) |
+               (addr_hit[167] & (|(OCCAMY_SOC_PERMIT[167] & ~reg_be))) |
+               (addr_hit[168] & (|(OCCAMY_SOC_PERMIT[168] & ~reg_be))) |
+               (addr_hit[169] & (|(OCCAMY_SOC_PERMIT[169] & ~reg_be))) |
+               (addr_hit[170] & (|(OCCAMY_SOC_PERMIT[170] & ~reg_be))) |
+               (addr_hit[171] & (|(OCCAMY_SOC_PERMIT[171] & ~reg_be)))));
   end
 
   assign intr_state_ecc_uncorrectable_we = addr_hit[0] & reg_we & !reg_error;
@@ -6590,173 +8638,365 @@ module occamy_soc_reg_top #(
   assign ro_end_addr_high_1_quadrant_0_we = addr_hit[51] & reg_we & !reg_error;
   assign ro_end_addr_high_1_quadrant_0_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_0_quadrant_1_we = addr_hit[52] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_0_we = addr_hit[52] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_0_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_2_quadrant_0_we = addr_hit[53] & reg_we & !reg_error;
+  assign ro_start_addr_high_2_quadrant_0_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_2_quadrant_0_we = addr_hit[54] & reg_we & !reg_error;
+  assign ro_end_addr_low_2_quadrant_0_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_2_quadrant_0_we = addr_hit[55] & reg_we & !reg_error;
+  assign ro_end_addr_high_2_quadrant_0_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_3_quadrant_0_we = addr_hit[56] & reg_we & !reg_error;
+  assign ro_start_addr_low_3_quadrant_0_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_3_quadrant_0_we = addr_hit[57] & reg_we & !reg_error;
+  assign ro_start_addr_high_3_quadrant_0_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_3_quadrant_0_we = addr_hit[58] & reg_we & !reg_error;
+  assign ro_end_addr_low_3_quadrant_0_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_3_quadrant_0_we = addr_hit[59] & reg_we & !reg_error;
+  assign ro_end_addr_high_3_quadrant_0_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_0_quadrant_1_we = addr_hit[60] & reg_we & !reg_error;
   assign ro_start_addr_low_0_quadrant_1_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_0_quadrant_1_we = addr_hit[53] & reg_we & !reg_error;
+  assign ro_start_addr_high_0_quadrant_1_we = addr_hit[61] & reg_we & !reg_error;
   assign ro_start_addr_high_0_quadrant_1_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_0_quadrant_1_we = addr_hit[54] & reg_we & !reg_error;
+  assign ro_end_addr_low_0_quadrant_1_we = addr_hit[62] & reg_we & !reg_error;
   assign ro_end_addr_low_0_quadrant_1_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_0_quadrant_1_we = addr_hit[55] & reg_we & !reg_error;
+  assign ro_end_addr_high_0_quadrant_1_we = addr_hit[63] & reg_we & !reg_error;
   assign ro_end_addr_high_0_quadrant_1_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_1_quadrant_1_we = addr_hit[56] & reg_we & !reg_error;
+  assign ro_start_addr_low_1_quadrant_1_we = addr_hit[64] & reg_we & !reg_error;
   assign ro_start_addr_low_1_quadrant_1_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_1_quadrant_1_we = addr_hit[57] & reg_we & !reg_error;
+  assign ro_start_addr_high_1_quadrant_1_we = addr_hit[65] & reg_we & !reg_error;
   assign ro_start_addr_high_1_quadrant_1_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_1_quadrant_1_we = addr_hit[58] & reg_we & !reg_error;
+  assign ro_end_addr_low_1_quadrant_1_we = addr_hit[66] & reg_we & !reg_error;
   assign ro_end_addr_low_1_quadrant_1_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_1_quadrant_1_we = addr_hit[59] & reg_we & !reg_error;
+  assign ro_end_addr_high_1_quadrant_1_we = addr_hit[67] & reg_we & !reg_error;
   assign ro_end_addr_high_1_quadrant_1_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_0_quadrant_2_we = addr_hit[60] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_1_we = addr_hit[68] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_1_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_2_quadrant_1_we = addr_hit[69] & reg_we & !reg_error;
+  assign ro_start_addr_high_2_quadrant_1_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_2_quadrant_1_we = addr_hit[70] & reg_we & !reg_error;
+  assign ro_end_addr_low_2_quadrant_1_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_2_quadrant_1_we = addr_hit[71] & reg_we & !reg_error;
+  assign ro_end_addr_high_2_quadrant_1_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_3_quadrant_1_we = addr_hit[72] & reg_we & !reg_error;
+  assign ro_start_addr_low_3_quadrant_1_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_3_quadrant_1_we = addr_hit[73] & reg_we & !reg_error;
+  assign ro_start_addr_high_3_quadrant_1_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_3_quadrant_1_we = addr_hit[74] & reg_we & !reg_error;
+  assign ro_end_addr_low_3_quadrant_1_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_3_quadrant_1_we = addr_hit[75] & reg_we & !reg_error;
+  assign ro_end_addr_high_3_quadrant_1_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_0_quadrant_2_we = addr_hit[76] & reg_we & !reg_error;
   assign ro_start_addr_low_0_quadrant_2_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_0_quadrant_2_we = addr_hit[61] & reg_we & !reg_error;
+  assign ro_start_addr_high_0_quadrant_2_we = addr_hit[77] & reg_we & !reg_error;
   assign ro_start_addr_high_0_quadrant_2_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_0_quadrant_2_we = addr_hit[62] & reg_we & !reg_error;
+  assign ro_end_addr_low_0_quadrant_2_we = addr_hit[78] & reg_we & !reg_error;
   assign ro_end_addr_low_0_quadrant_2_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_0_quadrant_2_we = addr_hit[63] & reg_we & !reg_error;
+  assign ro_end_addr_high_0_quadrant_2_we = addr_hit[79] & reg_we & !reg_error;
   assign ro_end_addr_high_0_quadrant_2_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_1_quadrant_2_we = addr_hit[64] & reg_we & !reg_error;
+  assign ro_start_addr_low_1_quadrant_2_we = addr_hit[80] & reg_we & !reg_error;
   assign ro_start_addr_low_1_quadrant_2_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_1_quadrant_2_we = addr_hit[65] & reg_we & !reg_error;
+  assign ro_start_addr_high_1_quadrant_2_we = addr_hit[81] & reg_we & !reg_error;
   assign ro_start_addr_high_1_quadrant_2_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_1_quadrant_2_we = addr_hit[66] & reg_we & !reg_error;
+  assign ro_end_addr_low_1_quadrant_2_we = addr_hit[82] & reg_we & !reg_error;
   assign ro_end_addr_low_1_quadrant_2_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_1_quadrant_2_we = addr_hit[67] & reg_we & !reg_error;
+  assign ro_end_addr_high_1_quadrant_2_we = addr_hit[83] & reg_we & !reg_error;
   assign ro_end_addr_high_1_quadrant_2_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_0_quadrant_3_we = addr_hit[68] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_2_we = addr_hit[84] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_2_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_2_quadrant_2_we = addr_hit[85] & reg_we & !reg_error;
+  assign ro_start_addr_high_2_quadrant_2_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_2_quadrant_2_we = addr_hit[86] & reg_we & !reg_error;
+  assign ro_end_addr_low_2_quadrant_2_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_2_quadrant_2_we = addr_hit[87] & reg_we & !reg_error;
+  assign ro_end_addr_high_2_quadrant_2_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_3_quadrant_2_we = addr_hit[88] & reg_we & !reg_error;
+  assign ro_start_addr_low_3_quadrant_2_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_3_quadrant_2_we = addr_hit[89] & reg_we & !reg_error;
+  assign ro_start_addr_high_3_quadrant_2_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_3_quadrant_2_we = addr_hit[90] & reg_we & !reg_error;
+  assign ro_end_addr_low_3_quadrant_2_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_3_quadrant_2_we = addr_hit[91] & reg_we & !reg_error;
+  assign ro_end_addr_high_3_quadrant_2_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_0_quadrant_3_we = addr_hit[92] & reg_we & !reg_error;
   assign ro_start_addr_low_0_quadrant_3_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_0_quadrant_3_we = addr_hit[69] & reg_we & !reg_error;
+  assign ro_start_addr_high_0_quadrant_3_we = addr_hit[93] & reg_we & !reg_error;
   assign ro_start_addr_high_0_quadrant_3_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_0_quadrant_3_we = addr_hit[70] & reg_we & !reg_error;
+  assign ro_end_addr_low_0_quadrant_3_we = addr_hit[94] & reg_we & !reg_error;
   assign ro_end_addr_low_0_quadrant_3_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_0_quadrant_3_we = addr_hit[71] & reg_we & !reg_error;
+  assign ro_end_addr_high_0_quadrant_3_we = addr_hit[95] & reg_we & !reg_error;
   assign ro_end_addr_high_0_quadrant_3_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_1_quadrant_3_we = addr_hit[72] & reg_we & !reg_error;
+  assign ro_start_addr_low_1_quadrant_3_we = addr_hit[96] & reg_we & !reg_error;
   assign ro_start_addr_low_1_quadrant_3_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_1_quadrant_3_we = addr_hit[73] & reg_we & !reg_error;
+  assign ro_start_addr_high_1_quadrant_3_we = addr_hit[97] & reg_we & !reg_error;
   assign ro_start_addr_high_1_quadrant_3_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_1_quadrant_3_we = addr_hit[74] & reg_we & !reg_error;
+  assign ro_end_addr_low_1_quadrant_3_we = addr_hit[98] & reg_we & !reg_error;
   assign ro_end_addr_low_1_quadrant_3_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_1_quadrant_3_we = addr_hit[75] & reg_we & !reg_error;
+  assign ro_end_addr_high_1_quadrant_3_we = addr_hit[99] & reg_we & !reg_error;
   assign ro_end_addr_high_1_quadrant_3_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_0_quadrant_4_we = addr_hit[76] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_3_we = addr_hit[100] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_3_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_2_quadrant_3_we = addr_hit[101] & reg_we & !reg_error;
+  assign ro_start_addr_high_2_quadrant_3_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_2_quadrant_3_we = addr_hit[102] & reg_we & !reg_error;
+  assign ro_end_addr_low_2_quadrant_3_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_2_quadrant_3_we = addr_hit[103] & reg_we & !reg_error;
+  assign ro_end_addr_high_2_quadrant_3_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_3_quadrant_3_we = addr_hit[104] & reg_we & !reg_error;
+  assign ro_start_addr_low_3_quadrant_3_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_3_quadrant_3_we = addr_hit[105] & reg_we & !reg_error;
+  assign ro_start_addr_high_3_quadrant_3_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_3_quadrant_3_we = addr_hit[106] & reg_we & !reg_error;
+  assign ro_end_addr_low_3_quadrant_3_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_3_quadrant_3_we = addr_hit[107] & reg_we & !reg_error;
+  assign ro_end_addr_high_3_quadrant_3_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_0_quadrant_4_we = addr_hit[108] & reg_we & !reg_error;
   assign ro_start_addr_low_0_quadrant_4_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_0_quadrant_4_we = addr_hit[77] & reg_we & !reg_error;
+  assign ro_start_addr_high_0_quadrant_4_we = addr_hit[109] & reg_we & !reg_error;
   assign ro_start_addr_high_0_quadrant_4_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_0_quadrant_4_we = addr_hit[78] & reg_we & !reg_error;
+  assign ro_end_addr_low_0_quadrant_4_we = addr_hit[110] & reg_we & !reg_error;
   assign ro_end_addr_low_0_quadrant_4_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_0_quadrant_4_we = addr_hit[79] & reg_we & !reg_error;
+  assign ro_end_addr_high_0_quadrant_4_we = addr_hit[111] & reg_we & !reg_error;
   assign ro_end_addr_high_0_quadrant_4_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_1_quadrant_4_we = addr_hit[80] & reg_we & !reg_error;
+  assign ro_start_addr_low_1_quadrant_4_we = addr_hit[112] & reg_we & !reg_error;
   assign ro_start_addr_low_1_quadrant_4_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_1_quadrant_4_we = addr_hit[81] & reg_we & !reg_error;
+  assign ro_start_addr_high_1_quadrant_4_we = addr_hit[113] & reg_we & !reg_error;
   assign ro_start_addr_high_1_quadrant_4_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_1_quadrant_4_we = addr_hit[82] & reg_we & !reg_error;
+  assign ro_end_addr_low_1_quadrant_4_we = addr_hit[114] & reg_we & !reg_error;
   assign ro_end_addr_low_1_quadrant_4_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_1_quadrant_4_we = addr_hit[83] & reg_we & !reg_error;
+  assign ro_end_addr_high_1_quadrant_4_we = addr_hit[115] & reg_we & !reg_error;
   assign ro_end_addr_high_1_quadrant_4_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_0_quadrant_5_we = addr_hit[84] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_4_we = addr_hit[116] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_4_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_2_quadrant_4_we = addr_hit[117] & reg_we & !reg_error;
+  assign ro_start_addr_high_2_quadrant_4_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_2_quadrant_4_we = addr_hit[118] & reg_we & !reg_error;
+  assign ro_end_addr_low_2_quadrant_4_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_2_quadrant_4_we = addr_hit[119] & reg_we & !reg_error;
+  assign ro_end_addr_high_2_quadrant_4_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_3_quadrant_4_we = addr_hit[120] & reg_we & !reg_error;
+  assign ro_start_addr_low_3_quadrant_4_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_3_quadrant_4_we = addr_hit[121] & reg_we & !reg_error;
+  assign ro_start_addr_high_3_quadrant_4_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_3_quadrant_4_we = addr_hit[122] & reg_we & !reg_error;
+  assign ro_end_addr_low_3_quadrant_4_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_3_quadrant_4_we = addr_hit[123] & reg_we & !reg_error;
+  assign ro_end_addr_high_3_quadrant_4_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_0_quadrant_5_we = addr_hit[124] & reg_we & !reg_error;
   assign ro_start_addr_low_0_quadrant_5_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_0_quadrant_5_we = addr_hit[85] & reg_we & !reg_error;
+  assign ro_start_addr_high_0_quadrant_5_we = addr_hit[125] & reg_we & !reg_error;
   assign ro_start_addr_high_0_quadrant_5_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_0_quadrant_5_we = addr_hit[86] & reg_we & !reg_error;
+  assign ro_end_addr_low_0_quadrant_5_we = addr_hit[126] & reg_we & !reg_error;
   assign ro_end_addr_low_0_quadrant_5_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_0_quadrant_5_we = addr_hit[87] & reg_we & !reg_error;
+  assign ro_end_addr_high_0_quadrant_5_we = addr_hit[127] & reg_we & !reg_error;
   assign ro_end_addr_high_0_quadrant_5_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_1_quadrant_5_we = addr_hit[88] & reg_we & !reg_error;
+  assign ro_start_addr_low_1_quadrant_5_we = addr_hit[128] & reg_we & !reg_error;
   assign ro_start_addr_low_1_quadrant_5_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_1_quadrant_5_we = addr_hit[89] & reg_we & !reg_error;
+  assign ro_start_addr_high_1_quadrant_5_we = addr_hit[129] & reg_we & !reg_error;
   assign ro_start_addr_high_1_quadrant_5_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_1_quadrant_5_we = addr_hit[90] & reg_we & !reg_error;
+  assign ro_end_addr_low_1_quadrant_5_we = addr_hit[130] & reg_we & !reg_error;
   assign ro_end_addr_low_1_quadrant_5_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_1_quadrant_5_we = addr_hit[91] & reg_we & !reg_error;
+  assign ro_end_addr_high_1_quadrant_5_we = addr_hit[131] & reg_we & !reg_error;
   assign ro_end_addr_high_1_quadrant_5_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_0_quadrant_6_we = addr_hit[92] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_5_we = addr_hit[132] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_5_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_2_quadrant_5_we = addr_hit[133] & reg_we & !reg_error;
+  assign ro_start_addr_high_2_quadrant_5_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_2_quadrant_5_we = addr_hit[134] & reg_we & !reg_error;
+  assign ro_end_addr_low_2_quadrant_5_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_2_quadrant_5_we = addr_hit[135] & reg_we & !reg_error;
+  assign ro_end_addr_high_2_quadrant_5_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_3_quadrant_5_we = addr_hit[136] & reg_we & !reg_error;
+  assign ro_start_addr_low_3_quadrant_5_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_3_quadrant_5_we = addr_hit[137] & reg_we & !reg_error;
+  assign ro_start_addr_high_3_quadrant_5_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_3_quadrant_5_we = addr_hit[138] & reg_we & !reg_error;
+  assign ro_end_addr_low_3_quadrant_5_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_3_quadrant_5_we = addr_hit[139] & reg_we & !reg_error;
+  assign ro_end_addr_high_3_quadrant_5_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_0_quadrant_6_we = addr_hit[140] & reg_we & !reg_error;
   assign ro_start_addr_low_0_quadrant_6_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_0_quadrant_6_we = addr_hit[93] & reg_we & !reg_error;
+  assign ro_start_addr_high_0_quadrant_6_we = addr_hit[141] & reg_we & !reg_error;
   assign ro_start_addr_high_0_quadrant_6_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_0_quadrant_6_we = addr_hit[94] & reg_we & !reg_error;
+  assign ro_end_addr_low_0_quadrant_6_we = addr_hit[142] & reg_we & !reg_error;
   assign ro_end_addr_low_0_quadrant_6_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_0_quadrant_6_we = addr_hit[95] & reg_we & !reg_error;
+  assign ro_end_addr_high_0_quadrant_6_we = addr_hit[143] & reg_we & !reg_error;
   assign ro_end_addr_high_0_quadrant_6_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_1_quadrant_6_we = addr_hit[96] & reg_we & !reg_error;
+  assign ro_start_addr_low_1_quadrant_6_we = addr_hit[144] & reg_we & !reg_error;
   assign ro_start_addr_low_1_quadrant_6_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_1_quadrant_6_we = addr_hit[97] & reg_we & !reg_error;
+  assign ro_start_addr_high_1_quadrant_6_we = addr_hit[145] & reg_we & !reg_error;
   assign ro_start_addr_high_1_quadrant_6_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_1_quadrant_6_we = addr_hit[98] & reg_we & !reg_error;
+  assign ro_end_addr_low_1_quadrant_6_we = addr_hit[146] & reg_we & !reg_error;
   assign ro_end_addr_low_1_quadrant_6_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_1_quadrant_6_we = addr_hit[99] & reg_we & !reg_error;
+  assign ro_end_addr_high_1_quadrant_6_we = addr_hit[147] & reg_we & !reg_error;
   assign ro_end_addr_high_1_quadrant_6_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_0_quadrant_7_we = addr_hit[100] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_6_we = addr_hit[148] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_6_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_2_quadrant_6_we = addr_hit[149] & reg_we & !reg_error;
+  assign ro_start_addr_high_2_quadrant_6_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_2_quadrant_6_we = addr_hit[150] & reg_we & !reg_error;
+  assign ro_end_addr_low_2_quadrant_6_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_2_quadrant_6_we = addr_hit[151] & reg_we & !reg_error;
+  assign ro_end_addr_high_2_quadrant_6_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_3_quadrant_6_we = addr_hit[152] & reg_we & !reg_error;
+  assign ro_start_addr_low_3_quadrant_6_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_3_quadrant_6_we = addr_hit[153] & reg_we & !reg_error;
+  assign ro_start_addr_high_3_quadrant_6_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_3_quadrant_6_we = addr_hit[154] & reg_we & !reg_error;
+  assign ro_end_addr_low_3_quadrant_6_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_3_quadrant_6_we = addr_hit[155] & reg_we & !reg_error;
+  assign ro_end_addr_high_3_quadrant_6_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_0_quadrant_7_we = addr_hit[156] & reg_we & !reg_error;
   assign ro_start_addr_low_0_quadrant_7_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_0_quadrant_7_we = addr_hit[101] & reg_we & !reg_error;
+  assign ro_start_addr_high_0_quadrant_7_we = addr_hit[157] & reg_we & !reg_error;
   assign ro_start_addr_high_0_quadrant_7_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_0_quadrant_7_we = addr_hit[102] & reg_we & !reg_error;
+  assign ro_end_addr_low_0_quadrant_7_we = addr_hit[158] & reg_we & !reg_error;
   assign ro_end_addr_low_0_quadrant_7_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_0_quadrant_7_we = addr_hit[103] & reg_we & !reg_error;
+  assign ro_end_addr_high_0_quadrant_7_we = addr_hit[159] & reg_we & !reg_error;
   assign ro_end_addr_high_0_quadrant_7_wd = reg_wdata[15:0];
 
-  assign ro_start_addr_low_1_quadrant_7_we = addr_hit[104] & reg_we & !reg_error;
+  assign ro_start_addr_low_1_quadrant_7_we = addr_hit[160] & reg_we & !reg_error;
   assign ro_start_addr_low_1_quadrant_7_wd = reg_wdata[31:0];
 
-  assign ro_start_addr_high_1_quadrant_7_we = addr_hit[105] & reg_we & !reg_error;
+  assign ro_start_addr_high_1_quadrant_7_we = addr_hit[161] & reg_we & !reg_error;
   assign ro_start_addr_high_1_quadrant_7_wd = reg_wdata[15:0];
 
-  assign ro_end_addr_low_1_quadrant_7_we = addr_hit[106] & reg_we & !reg_error;
+  assign ro_end_addr_low_1_quadrant_7_we = addr_hit[162] & reg_we & !reg_error;
   assign ro_end_addr_low_1_quadrant_7_wd = reg_wdata[31:0];
 
-  assign ro_end_addr_high_1_quadrant_7_we = addr_hit[107] & reg_we & !reg_error;
+  assign ro_end_addr_high_1_quadrant_7_we = addr_hit[163] & reg_we & !reg_error;
   assign ro_end_addr_high_1_quadrant_7_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_2_quadrant_7_we = addr_hit[164] & reg_we & !reg_error;
+  assign ro_start_addr_low_2_quadrant_7_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_2_quadrant_7_we = addr_hit[165] & reg_we & !reg_error;
+  assign ro_start_addr_high_2_quadrant_7_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_2_quadrant_7_we = addr_hit[166] & reg_we & !reg_error;
+  assign ro_end_addr_low_2_quadrant_7_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_2_quadrant_7_we = addr_hit[167] & reg_we & !reg_error;
+  assign ro_end_addr_high_2_quadrant_7_wd = reg_wdata[15:0];
+
+  assign ro_start_addr_low_3_quadrant_7_we = addr_hit[168] & reg_we & !reg_error;
+  assign ro_start_addr_low_3_quadrant_7_wd = reg_wdata[31:0];
+
+  assign ro_start_addr_high_3_quadrant_7_we = addr_hit[169] & reg_we & !reg_error;
+  assign ro_start_addr_high_3_quadrant_7_wd = reg_wdata[15:0];
+
+  assign ro_end_addr_low_3_quadrant_7_we = addr_hit[170] & reg_we & !reg_error;
+  assign ro_end_addr_low_3_quadrant_7_wd = reg_wdata[31:0];
+
+  assign ro_end_addr_high_3_quadrant_7_we = addr_hit[171] & reg_we & !reg_error;
+  assign ro_end_addr_high_3_quadrant_7_wd = reg_wdata[15:0];
 
   // Read data return
   always_comb begin
@@ -7064,227 +9304,483 @@ module occamy_soc_reg_top #(
       end
 
       addr_hit[52]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_1_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_2_quadrant_0_qs;
       end
 
       addr_hit[53]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_1_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_2_quadrant_0_qs;
       end
 
       addr_hit[54]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_1_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_2_quadrant_0_qs;
       end
 
       addr_hit[55]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_1_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_2_quadrant_0_qs;
       end
 
       addr_hit[56]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_1_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_3_quadrant_0_qs;
       end
 
       addr_hit[57]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_1_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_3_quadrant_0_qs;
       end
 
       addr_hit[58]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_1_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_3_quadrant_0_qs;
       end
 
       addr_hit[59]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_1_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_3_quadrant_0_qs;
       end
 
       addr_hit[60]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_2_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_1_qs;
       end
 
       addr_hit[61]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_2_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_1_qs;
       end
 
       addr_hit[62]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_2_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_1_qs;
       end
 
       addr_hit[63]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_2_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_1_qs;
       end
 
       addr_hit[64]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_2_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_1_qs;
       end
 
       addr_hit[65]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_2_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_1_qs;
       end
 
       addr_hit[66]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_2_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_1_qs;
       end
 
       addr_hit[67]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_2_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_1_qs;
       end
 
       addr_hit[68]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_3_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_2_quadrant_1_qs;
       end
 
       addr_hit[69]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_3_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_2_quadrant_1_qs;
       end
 
       addr_hit[70]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_3_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_2_quadrant_1_qs;
       end
 
       addr_hit[71]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_3_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_2_quadrant_1_qs;
       end
 
       addr_hit[72]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_3_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_3_quadrant_1_qs;
       end
 
       addr_hit[73]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_3_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_3_quadrant_1_qs;
       end
 
       addr_hit[74]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_3_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_3_quadrant_1_qs;
       end
 
       addr_hit[75]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_3_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_3_quadrant_1_qs;
       end
 
       addr_hit[76]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_4_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_2_qs;
       end
 
       addr_hit[77]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_4_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_2_qs;
       end
 
       addr_hit[78]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_4_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_2_qs;
       end
 
       addr_hit[79]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_4_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_2_qs;
       end
 
       addr_hit[80]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_4_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_2_qs;
       end
 
       addr_hit[81]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_4_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_2_qs;
       end
 
       addr_hit[82]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_4_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_2_qs;
       end
 
       addr_hit[83]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_4_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_2_qs;
       end
 
       addr_hit[84]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_5_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_2_quadrant_2_qs;
       end
 
       addr_hit[85]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_5_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_2_quadrant_2_qs;
       end
 
       addr_hit[86]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_5_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_2_quadrant_2_qs;
       end
 
       addr_hit[87]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_5_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_2_quadrant_2_qs;
       end
 
       addr_hit[88]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_5_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_3_quadrant_2_qs;
       end
 
       addr_hit[89]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_5_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_3_quadrant_2_qs;
       end
 
       addr_hit[90]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_5_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_3_quadrant_2_qs;
       end
 
       addr_hit[91]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_5_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_3_quadrant_2_qs;
       end
 
       addr_hit[92]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_6_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_3_qs;
       end
 
       addr_hit[93]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_6_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_3_qs;
       end
 
       addr_hit[94]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_6_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_3_qs;
       end
 
       addr_hit[95]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_6_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_3_qs;
       end
 
       addr_hit[96]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_6_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_3_qs;
       end
 
       addr_hit[97]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_6_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_3_qs;
       end
 
       addr_hit[98]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_6_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_3_qs;
       end
 
       addr_hit[99]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_6_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_3_qs;
       end
 
       addr_hit[100]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_7_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_2_quadrant_3_qs;
       end
 
       addr_hit[101]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_7_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_2_quadrant_3_qs;
       end
 
       addr_hit[102]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_7_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_2_quadrant_3_qs;
       end
 
       addr_hit[103]: begin
-        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_7_qs;
+        reg_rdata_next[15:0] = ro_end_addr_high_2_quadrant_3_qs;
       end
 
       addr_hit[104]: begin
-        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_7_qs;
+        reg_rdata_next[31:0] = ro_start_addr_low_3_quadrant_3_qs;
       end
 
       addr_hit[105]: begin
-        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_7_qs;
+        reg_rdata_next[15:0] = ro_start_addr_high_3_quadrant_3_qs;
       end
 
       addr_hit[106]: begin
-        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_7_qs;
+        reg_rdata_next[31:0] = ro_end_addr_low_3_quadrant_3_qs;
       end
 
       addr_hit[107]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_3_quadrant_3_qs;
+      end
+
+      addr_hit[108]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_4_qs;
+      end
+
+      addr_hit[109]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_4_qs;
+      end
+
+      addr_hit[110]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_4_qs;
+      end
+
+      addr_hit[111]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_4_qs;
+      end
+
+      addr_hit[112]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_4_qs;
+      end
+
+      addr_hit[113]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_4_qs;
+      end
+
+      addr_hit[114]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_4_qs;
+      end
+
+      addr_hit[115]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_4_qs;
+      end
+
+      addr_hit[116]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_2_quadrant_4_qs;
+      end
+
+      addr_hit[117]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_2_quadrant_4_qs;
+      end
+
+      addr_hit[118]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_2_quadrant_4_qs;
+      end
+
+      addr_hit[119]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_2_quadrant_4_qs;
+      end
+
+      addr_hit[120]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_3_quadrant_4_qs;
+      end
+
+      addr_hit[121]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_3_quadrant_4_qs;
+      end
+
+      addr_hit[122]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_3_quadrant_4_qs;
+      end
+
+      addr_hit[123]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_3_quadrant_4_qs;
+      end
+
+      addr_hit[124]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_5_qs;
+      end
+
+      addr_hit[125]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_5_qs;
+      end
+
+      addr_hit[126]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_5_qs;
+      end
+
+      addr_hit[127]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_5_qs;
+      end
+
+      addr_hit[128]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_5_qs;
+      end
+
+      addr_hit[129]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_5_qs;
+      end
+
+      addr_hit[130]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_5_qs;
+      end
+
+      addr_hit[131]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_5_qs;
+      end
+
+      addr_hit[132]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_2_quadrant_5_qs;
+      end
+
+      addr_hit[133]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_2_quadrant_5_qs;
+      end
+
+      addr_hit[134]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_2_quadrant_5_qs;
+      end
+
+      addr_hit[135]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_2_quadrant_5_qs;
+      end
+
+      addr_hit[136]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_3_quadrant_5_qs;
+      end
+
+      addr_hit[137]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_3_quadrant_5_qs;
+      end
+
+      addr_hit[138]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_3_quadrant_5_qs;
+      end
+
+      addr_hit[139]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_3_quadrant_5_qs;
+      end
+
+      addr_hit[140]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_6_qs;
+      end
+
+      addr_hit[141]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_6_qs;
+      end
+
+      addr_hit[142]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_6_qs;
+      end
+
+      addr_hit[143]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_6_qs;
+      end
+
+      addr_hit[144]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_6_qs;
+      end
+
+      addr_hit[145]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_6_qs;
+      end
+
+      addr_hit[146]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_6_qs;
+      end
+
+      addr_hit[147]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_6_qs;
+      end
+
+      addr_hit[148]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_2_quadrant_6_qs;
+      end
+
+      addr_hit[149]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_2_quadrant_6_qs;
+      end
+
+      addr_hit[150]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_2_quadrant_6_qs;
+      end
+
+      addr_hit[151]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_2_quadrant_6_qs;
+      end
+
+      addr_hit[152]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_3_quadrant_6_qs;
+      end
+
+      addr_hit[153]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_3_quadrant_6_qs;
+      end
+
+      addr_hit[154]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_3_quadrant_6_qs;
+      end
+
+      addr_hit[155]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_3_quadrant_6_qs;
+      end
+
+      addr_hit[156]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_0_quadrant_7_qs;
+      end
+
+      addr_hit[157]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_0_quadrant_7_qs;
+      end
+
+      addr_hit[158]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_0_quadrant_7_qs;
+      end
+
+      addr_hit[159]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_0_quadrant_7_qs;
+      end
+
+      addr_hit[160]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_1_quadrant_7_qs;
+      end
+
+      addr_hit[161]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_1_quadrant_7_qs;
+      end
+
+      addr_hit[162]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_1_quadrant_7_qs;
+      end
+
+      addr_hit[163]: begin
         reg_rdata_next[15:0] = ro_end_addr_high_1_quadrant_7_qs;
+      end
+
+      addr_hit[164]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_2_quadrant_7_qs;
+      end
+
+      addr_hit[165]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_2_quadrant_7_qs;
+      end
+
+      addr_hit[166]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_2_quadrant_7_qs;
+      end
+
+      addr_hit[167]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_2_quadrant_7_qs;
+      end
+
+      addr_hit[168]: begin
+        reg_rdata_next[31:0] = ro_start_addr_low_3_quadrant_7_qs;
+      end
+
+      addr_hit[169]: begin
+        reg_rdata_next[15:0] = ro_start_addr_high_3_quadrant_7_qs;
+      end
+
+      addr_hit[170]: begin
+        reg_rdata_next[31:0] = ro_end_addr_low_3_quadrant_7_qs;
+      end
+
+      addr_hit[171]: begin
+        reg_rdata_next[15:0] = ro_end_addr_high_3_quadrant_7_qs;
       end
 
       default: begin

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -711,7 +711,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   // Assemble address from `soc_ctrl` regs.
-  logic [1:0][47:0] start_addr_0, end_addr_0;
+  logic [3:0][47:0] start_addr_0, end_addr_0;
   assign start_addr_0[0] = {
     soc_ctrl_out.ro_start_addr_high_0_quadrant_0.q, soc_ctrl_out.ro_start_addr_low_0_quadrant_0.q
   };
@@ -723,6 +723,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   };
   assign end_addr_0[1] = {
     soc_ctrl_out.ro_end_addr_high_1_quadrant_0.q, soc_ctrl_out.ro_end_addr_low_1_quadrant_0.q
+  };
+  assign start_addr_0[2] = {
+    soc_ctrl_out.ro_start_addr_high_2_quadrant_0.q, soc_ctrl_out.ro_start_addr_low_2_quadrant_0.q
+  };
+  assign end_addr_0[2] = {
+    soc_ctrl_out.ro_end_addr_high_2_quadrant_0.q, soc_ctrl_out.ro_end_addr_low_2_quadrant_0.q
+  };
+  assign start_addr_0[3] = {
+    soc_ctrl_out.ro_start_addr_high_3_quadrant_0.q, soc_ctrl_out.ro_start_addr_low_3_quadrant_0.q
+  };
+  assign end_addr_0[3] = {
+    soc_ctrl_out.ro_end_addr_high_3_quadrant_0.q, soc_ctrl_out.ro_end_addr_low_3_quadrant_0.q
   };
   assign soc_ctrl_in.ro_cache_flush[0].de = soc_ctrl_out.ro_cache_flush[0].q & soc_ctrl_in.ro_cache_flush[0].d;
 
@@ -867,7 +879,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   // Assemble address from `soc_ctrl` regs.
-  logic [1:0][47:0] start_addr_1, end_addr_1;
+  logic [3:0][47:0] start_addr_1, end_addr_1;
   assign start_addr_1[0] = {
     soc_ctrl_out.ro_start_addr_high_0_quadrant_1.q, soc_ctrl_out.ro_start_addr_low_0_quadrant_1.q
   };
@@ -879,6 +891,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   };
   assign end_addr_1[1] = {
     soc_ctrl_out.ro_end_addr_high_1_quadrant_1.q, soc_ctrl_out.ro_end_addr_low_1_quadrant_1.q
+  };
+  assign start_addr_1[2] = {
+    soc_ctrl_out.ro_start_addr_high_2_quadrant_1.q, soc_ctrl_out.ro_start_addr_low_2_quadrant_1.q
+  };
+  assign end_addr_1[2] = {
+    soc_ctrl_out.ro_end_addr_high_2_quadrant_1.q, soc_ctrl_out.ro_end_addr_low_2_quadrant_1.q
+  };
+  assign start_addr_1[3] = {
+    soc_ctrl_out.ro_start_addr_high_3_quadrant_1.q, soc_ctrl_out.ro_start_addr_low_3_quadrant_1.q
+  };
+  assign end_addr_1[3] = {
+    soc_ctrl_out.ro_end_addr_high_3_quadrant_1.q, soc_ctrl_out.ro_end_addr_low_3_quadrant_1.q
   };
   assign soc_ctrl_in.ro_cache_flush[1].de = soc_ctrl_out.ro_cache_flush[1].q & soc_ctrl_in.ro_cache_flush[1].d;
 
@@ -1023,7 +1047,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   // Assemble address from `soc_ctrl` regs.
-  logic [1:0][47:0] start_addr_2, end_addr_2;
+  logic [3:0][47:0] start_addr_2, end_addr_2;
   assign start_addr_2[0] = {
     soc_ctrl_out.ro_start_addr_high_0_quadrant_2.q, soc_ctrl_out.ro_start_addr_low_0_quadrant_2.q
   };
@@ -1035,6 +1059,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   };
   assign end_addr_2[1] = {
     soc_ctrl_out.ro_end_addr_high_1_quadrant_2.q, soc_ctrl_out.ro_end_addr_low_1_quadrant_2.q
+  };
+  assign start_addr_2[2] = {
+    soc_ctrl_out.ro_start_addr_high_2_quadrant_2.q, soc_ctrl_out.ro_start_addr_low_2_quadrant_2.q
+  };
+  assign end_addr_2[2] = {
+    soc_ctrl_out.ro_end_addr_high_2_quadrant_2.q, soc_ctrl_out.ro_end_addr_low_2_quadrant_2.q
+  };
+  assign start_addr_2[3] = {
+    soc_ctrl_out.ro_start_addr_high_3_quadrant_2.q, soc_ctrl_out.ro_start_addr_low_3_quadrant_2.q
+  };
+  assign end_addr_2[3] = {
+    soc_ctrl_out.ro_end_addr_high_3_quadrant_2.q, soc_ctrl_out.ro_end_addr_low_3_quadrant_2.q
   };
   assign soc_ctrl_in.ro_cache_flush[2].de = soc_ctrl_out.ro_cache_flush[2].q & soc_ctrl_in.ro_cache_flush[2].d;
 
@@ -1179,7 +1215,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   // Assemble address from `soc_ctrl` regs.
-  logic [1:0][47:0] start_addr_3, end_addr_3;
+  logic [3:0][47:0] start_addr_3, end_addr_3;
   assign start_addr_3[0] = {
     soc_ctrl_out.ro_start_addr_high_0_quadrant_3.q, soc_ctrl_out.ro_start_addr_low_0_quadrant_3.q
   };
@@ -1191,6 +1227,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   };
   assign end_addr_3[1] = {
     soc_ctrl_out.ro_end_addr_high_1_quadrant_3.q, soc_ctrl_out.ro_end_addr_low_1_quadrant_3.q
+  };
+  assign start_addr_3[2] = {
+    soc_ctrl_out.ro_start_addr_high_2_quadrant_3.q, soc_ctrl_out.ro_start_addr_low_2_quadrant_3.q
+  };
+  assign end_addr_3[2] = {
+    soc_ctrl_out.ro_end_addr_high_2_quadrant_3.q, soc_ctrl_out.ro_end_addr_low_2_quadrant_3.q
+  };
+  assign start_addr_3[3] = {
+    soc_ctrl_out.ro_start_addr_high_3_quadrant_3.q, soc_ctrl_out.ro_start_addr_low_3_quadrant_3.q
+  };
+  assign end_addr_3[3] = {
+    soc_ctrl_out.ro_end_addr_high_3_quadrant_3.q, soc_ctrl_out.ro_end_addr_low_3_quadrant_3.q
   };
   assign soc_ctrl_in.ro_cache_flush[3].de = soc_ctrl_out.ro_cache_flush[3].q & soc_ctrl_in.ro_cache_flush[3].d;
 
@@ -1335,7 +1383,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   // Assemble address from `soc_ctrl` regs.
-  logic [1:0][47:0] start_addr_4, end_addr_4;
+  logic [3:0][47:0] start_addr_4, end_addr_4;
   assign start_addr_4[0] = {
     soc_ctrl_out.ro_start_addr_high_0_quadrant_4.q, soc_ctrl_out.ro_start_addr_low_0_quadrant_4.q
   };
@@ -1347,6 +1395,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   };
   assign end_addr_4[1] = {
     soc_ctrl_out.ro_end_addr_high_1_quadrant_4.q, soc_ctrl_out.ro_end_addr_low_1_quadrant_4.q
+  };
+  assign start_addr_4[2] = {
+    soc_ctrl_out.ro_start_addr_high_2_quadrant_4.q, soc_ctrl_out.ro_start_addr_low_2_quadrant_4.q
+  };
+  assign end_addr_4[2] = {
+    soc_ctrl_out.ro_end_addr_high_2_quadrant_4.q, soc_ctrl_out.ro_end_addr_low_2_quadrant_4.q
+  };
+  assign start_addr_4[3] = {
+    soc_ctrl_out.ro_start_addr_high_3_quadrant_4.q, soc_ctrl_out.ro_start_addr_low_3_quadrant_4.q
+  };
+  assign end_addr_4[3] = {
+    soc_ctrl_out.ro_end_addr_high_3_quadrant_4.q, soc_ctrl_out.ro_end_addr_low_3_quadrant_4.q
   };
   assign soc_ctrl_in.ro_cache_flush[4].de = soc_ctrl_out.ro_cache_flush[4].q & soc_ctrl_in.ro_cache_flush[4].d;
 
@@ -1491,7 +1551,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   // Assemble address from `soc_ctrl` regs.
-  logic [1:0][47:0] start_addr_5, end_addr_5;
+  logic [3:0][47:0] start_addr_5, end_addr_5;
   assign start_addr_5[0] = {
     soc_ctrl_out.ro_start_addr_high_0_quadrant_5.q, soc_ctrl_out.ro_start_addr_low_0_quadrant_5.q
   };
@@ -1503,6 +1563,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   };
   assign end_addr_5[1] = {
     soc_ctrl_out.ro_end_addr_high_1_quadrant_5.q, soc_ctrl_out.ro_end_addr_low_1_quadrant_5.q
+  };
+  assign start_addr_5[2] = {
+    soc_ctrl_out.ro_start_addr_high_2_quadrant_5.q, soc_ctrl_out.ro_start_addr_low_2_quadrant_5.q
+  };
+  assign end_addr_5[2] = {
+    soc_ctrl_out.ro_end_addr_high_2_quadrant_5.q, soc_ctrl_out.ro_end_addr_low_2_quadrant_5.q
+  };
+  assign start_addr_5[3] = {
+    soc_ctrl_out.ro_start_addr_high_3_quadrant_5.q, soc_ctrl_out.ro_start_addr_low_3_quadrant_5.q
+  };
+  assign end_addr_5[3] = {
+    soc_ctrl_out.ro_end_addr_high_3_quadrant_5.q, soc_ctrl_out.ro_end_addr_low_3_quadrant_5.q
   };
   assign soc_ctrl_in.ro_cache_flush[5].de = soc_ctrl_out.ro_cache_flush[5].q & soc_ctrl_in.ro_cache_flush[5].d;
 
@@ -1647,7 +1719,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   // Assemble address from `soc_ctrl` regs.
-  logic [1:0][47:0] start_addr_6, end_addr_6;
+  logic [3:0][47:0] start_addr_6, end_addr_6;
   assign start_addr_6[0] = {
     soc_ctrl_out.ro_start_addr_high_0_quadrant_6.q, soc_ctrl_out.ro_start_addr_low_0_quadrant_6.q
   };
@@ -1659,6 +1731,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   };
   assign end_addr_6[1] = {
     soc_ctrl_out.ro_end_addr_high_1_quadrant_6.q, soc_ctrl_out.ro_end_addr_low_1_quadrant_6.q
+  };
+  assign start_addr_6[2] = {
+    soc_ctrl_out.ro_start_addr_high_2_quadrant_6.q, soc_ctrl_out.ro_start_addr_low_2_quadrant_6.q
+  };
+  assign end_addr_6[2] = {
+    soc_ctrl_out.ro_end_addr_high_2_quadrant_6.q, soc_ctrl_out.ro_end_addr_low_2_quadrant_6.q
+  };
+  assign start_addr_6[3] = {
+    soc_ctrl_out.ro_start_addr_high_3_quadrant_6.q, soc_ctrl_out.ro_start_addr_low_3_quadrant_6.q
+  };
+  assign end_addr_6[3] = {
+    soc_ctrl_out.ro_end_addr_high_3_quadrant_6.q, soc_ctrl_out.ro_end_addr_low_3_quadrant_6.q
   };
   assign soc_ctrl_in.ro_cache_flush[6].de = soc_ctrl_out.ro_cache_flush[6].q & soc_ctrl_in.ro_cache_flush[6].d;
 
@@ -1803,7 +1887,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
 
   // Assemble address from `soc_ctrl` regs.
-  logic [1:0][47:0] start_addr_7, end_addr_7;
+  logic [3:0][47:0] start_addr_7, end_addr_7;
   assign start_addr_7[0] = {
     soc_ctrl_out.ro_start_addr_high_0_quadrant_7.q, soc_ctrl_out.ro_start_addr_low_0_quadrant_7.q
   };
@@ -1815,6 +1899,18 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
   };
   assign end_addr_7[1] = {
     soc_ctrl_out.ro_end_addr_high_1_quadrant_7.q, soc_ctrl_out.ro_end_addr_low_1_quadrant_7.q
+  };
+  assign start_addr_7[2] = {
+    soc_ctrl_out.ro_start_addr_high_2_quadrant_7.q, soc_ctrl_out.ro_start_addr_low_2_quadrant_7.q
+  };
+  assign end_addr_7[2] = {
+    soc_ctrl_out.ro_end_addr_high_2_quadrant_7.q, soc_ctrl_out.ro_end_addr_low_2_quadrant_7.q
+  };
+  assign start_addr_7[3] = {
+    soc_ctrl_out.ro_start_addr_high_3_quadrant_7.q, soc_ctrl_out.ro_start_addr_low_3_quadrant_7.q
+  };
+  assign end_addr_7[3] = {
+    soc_ctrl_out.ro_end_addr_high_3_quadrant_7.q, soc_ctrl_out.ro_end_addr_low_3_quadrant_7.q
   };
   assign soc_ctrl_in.ro_cache_flush[7].de = soc_ctrl_out.ro_cache_flush[7].q & soc_ctrl_in.ro_cache_flush[7].d;
 


### PR DESCRIPTION
Increase the read-only cache's line width and the number of supported address regions.

- [x] The latest version of Verible seems to screw up the formatting of structs that have comments in them and introduces a lot of whitespace changes. Which version of Verible are you using? Does someone have the CI's version 0.0-807-g10e7c71 working at ETH? Because this version does not work on my machine...

