### PR TITLE
fpu: Add `lat_comp_fp16` to system configs explicitly

### DIFF
--- a/hw/system/occamy/src/occamy_cfg.hjson
+++ b/hw/system/occamy/src/occamy_cfg.hjson
@@ -69,6 +69,7 @@
         timing: {
             lat_comp_fp32: 2,
             lat_comp_fp64: 2,
+            lat_comp_fp16: 1,
             lat_comp_fp16_alt: 1,
             lat_comp_fp8: 1,
             lat_comp_fp8_alt: 1,

--- a/hw/system/snitch_cluster/cfg/cluster.default.hjson
+++ b/hw/system/snitch_cluster/cfg/cluster.default.hjson
@@ -27,6 +27,7 @@
         timing: {
             lat_comp_fp32: 3,
             lat_comp_fp64: 3,
+            lat_comp_fp16: 2,
             lat_comp_fp16_alt: 2,
             lat_comp_fp8: 1,
             lat_comp_fp8_alt: 1,


### PR DESCRIPTION
I added the latency for FP16 FMA in the cfg files, which was missing and always set it to 1. 
The generated occamy cluster is the same, while I increase to 2 the number of pipeline registers for the snitch cluster (now matching the value for FP16ALT)