### PR TITLE
Codeowners: fix typo for main codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 
-*       @pauls96
+*       @paulsc96
 
 hw @lucabertaccini
 sw @fischeti


### PR DESCRIPTION
hope this solves the default reviewer assignment from @zarubaf to @paulsc96 which was intended by #292.