### PR TITLE
lint: Add streamctl ports to IPU, remove parameter from FPSS

### DIFF
--- a/hw/ip/snitch_cluster/src/snitch_cc.sv
+++ b/hw/ip/snitch_cluster/src/snitch_cc.sv
@@ -398,7 +398,10 @@ module snitch_cc #(
       .ssr_wdata_o      ( /* TODO */               ),
       .ssr_wvalid_o     ( /* TODO */               ),
       .ssr_wready_i     ('0                        ),
-      .ssr_wdone_o      ( /* TODO */               )
+      .ssr_wdone_o      ( /* TODO */               ),
+      .streamctl_done_i   ( /* TODO */             ),
+      .streamctl_valid_i  ( /* TODO */             ),
+      .streamctl_ready_o  ( /* TODO */             )
     );
   end else begin : gen_no_ipu
     assign ipu_resp = '0;
@@ -425,19 +428,11 @@ module snitch_cc #(
   logic             ssr_streamctl_valid;
   logic             ssr_streamctl_ready;
 
-  function automatic bit derive_ssr_streamctl();
-    for (int i = 0; i < NumSsrs; i++)
-      if (SsrCfgs[i].IsectMaster) return 1;
-    return 0;
-  endfunction
-
   if (FPEn) begin : gen_fpu
     snitch_pkg::core_events_t fp_ss_core_events;
 
     dreq_t fpu_dreq;
     drsp_t fpu_drsp;
-
-    localparam bit SsrStreamctl = derive_ssr_streamctl();
 
     snitch_fp_ss #(
       .AddrWidth (AddrWidth),
@@ -448,7 +443,6 @@ module snitch_cc #(
       .FPUImplementation (FPUImplementation),
       .NumSsrs (NumSsrs),
       .SsrRegs (SsrRegs),
-      .SsrStreamctl (SsrStreamctl),
       .dreq_t (dreq_t),
       .drsp_t (drsp_t),
       .acc_req_t (acc_req_t),

--- a/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
+++ b/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
@@ -20,7 +20,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
   parameter bit Xssr = 1,
   parameter int unsigned NumSsrs = 0,
   parameter logic [NumSsrs-1:0][4:0]  SsrRegs = '0,
-  parameter bit SsrStreamctl = 0,
   parameter type acc_req_t = logic,
   parameter type acc_resp_t = logic,
   parameter bit RVF = 1,

--- a/hw/ip/snitch_ipu/src/snitch_int_ss.sv
+++ b/hw/ip/snitch_ipu/src/snitch_int_ss.sv
@@ -36,7 +36,11 @@ module snitch_int_ss import riscv_instr::*; import snitch_ipu_pkg::*; import sni
   output data_t [0:0]      ssr_wdata_o,
   output logic  [0:0]      ssr_wvalid_o,
   input  logic  [0:0]      ssr_wready_i,
-  output logic  [0:0]      ssr_wdone_o
+  output logic  [0:0]      ssr_wdone_o,
+  // SSR stream control interface
+  input  logic             streamctl_done_i,
+  input  logic             streamctl_valid_i,
+  output logic             streamctl_ready_o
 );
 
   logic [2:0][4:0]  int_raddr;
@@ -117,7 +121,10 @@ module snitch_int_ss import riscv_instr::*; import snitch_ipu_pkg::*; import sni
       .oup_qdata_argb_o ( acc_req.data_argb   ),
       .oup_qdata_argc_o ( acc_req.data_argc   ),
       .oup_qvalid_o     ( acc_req_valid       ),
-      .oup_qready_i     ( acc_req_ready       )
+      .oup_qready_i     ( acc_req_ready       ),
+      .streamctl_done_i,
+      .streamctl_valid_i,
+      .streamctl_ready_o
     );
   end else begin : gen_no_ipu_sequencer
     // assign sequencer_tracer_port_o = 0;


### PR DESCRIPTION
This MR fixes two lint issues regarding the FREP stream control interface:

* It adds a stream control interface to the sequencer in the WIP IPU and the IPU itself
* It removes an unused FPSS parameter `SsrStreamctl`, originally devised to indicate whether a  stream control interface is present.