### PR TITLE
occamy: Improve quadrant timing through cuts on IO paths

### DIFF
--- a/hw/system/occamy/src/occamy_quadrant_s1.sv
+++ b/hw/system/occamy/src/occamy_quadrant_s1.sv
@@ -152,6 +152,26 @@ module occamy_quadrant_s1
   axi_a48_d64_i8_u0_req_t  narrow_cluster_in_iwc_req;
   axi_a48_d64_i8_u0_resp_t narrow_cluster_in_iwc_rsp;
 
+  axi_a48_d64_i8_u0_req_t  narrow_cluster_in_iwc_cut_req;
+  axi_a48_d64_i8_u0_resp_t narrow_cluster_in_iwc_cut_rsp;
+
+  axi_multicut #(
+      .NoCuts(1),
+      .aw_chan_t(axi_a48_d64_i8_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d64_i8_u0_w_chan_t),
+      .b_chan_t(axi_a48_d64_i8_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d64_i8_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d64_i8_u0_r_chan_t),
+      .req_t(axi_a48_d64_i8_u0_req_t),
+      .resp_t(axi_a48_d64_i8_u0_resp_t)
+  ) i_narrow_cluster_in_iwc_cut (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(narrow_cluster_in_iwc_req),
+      .slv_resp_o(narrow_cluster_in_iwc_rsp),
+      .mst_req_o(narrow_cluster_in_iwc_cut_req),
+      .mst_resp_i(narrow_cluster_in_iwc_cut_rsp)
+  );
   axi_a48_d64_i8_u0_req_t  narrow_cluster_in_isolate_req;
   axi_a48_d64_i8_u0_resp_t narrow_cluster_in_isolate_rsp;
 
@@ -168,8 +188,8 @@ module occamy_quadrant_s1
   ) i_narrow_cluster_in_isolate (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(narrow_cluster_in_iwc_req),
-      .slv_resp_o(narrow_cluster_in_iwc_rsp),
+      .slv_req_i(narrow_cluster_in_iwc_cut_req),
+      .slv_resp_o(narrow_cluster_in_iwc_cut_rsp),
       .mst_req_o(narrow_cluster_in_isolate_req),
       .mst_resp_i(narrow_cluster_in_isolate_rsp),
       .isolate_i(isolate_i[0]),
@@ -244,10 +264,30 @@ module occamy_quadrant_s1
       .isolated_o(isolated_o[1])
   );
 
+  axi_a48_d64_i4_u0_req_t  narrow_cluster_out_isolate_cut_req;
+  axi_a48_d64_i4_u0_resp_t narrow_cluster_out_isolate_cut_rsp;
+
+  axi_multicut #(
+      .NoCuts(1),
+      .aw_chan_t(axi_a48_d64_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d64_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d64_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d64_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d64_i4_u0_r_chan_t),
+      .req_t(axi_a48_d64_i4_u0_req_t),
+      .resp_t(axi_a48_d64_i4_u0_resp_t)
+  ) i_narrow_cluster_out_isolate_cut (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(narrow_cluster_out_isolate_req),
+      .slv_resp_o(narrow_cluster_out_isolate_rsp),
+      .mst_req_o(narrow_cluster_out_isolate_cut_req),
+      .mst_resp_i(narrow_cluster_out_isolate_cut_rsp)
+  );
 
 
-  assign quadrant_narrow_out_req_o = narrow_cluster_out_isolate_req;
-  assign narrow_cluster_out_isolate_rsp = quadrant_narrow_out_rsp_i;
+  assign quadrant_narrow_out_req_o = narrow_cluster_out_isolate_cut_req;
+  assign narrow_cluster_out_isolate_cut_rsp = quadrant_narrow_out_rsp_i;
 
   /////////////////////////////////////////
   // Wide Out + RO Cache + IW Converter  //
@@ -331,10 +371,30 @@ module occamy_quadrant_s1
       .isolated_o(isolated_o[3])
   );
 
+  axi_a48_d512_i4_u0_req_t  wide_cluster_out_isolate_cut_req;
+  axi_a48_d512_i4_u0_resp_t wide_cluster_out_isolate_cut_rsp;
+
+  axi_multicut #(
+      .NoCuts(1),
+      .aw_chan_t(axi_a48_d512_i4_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i4_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i4_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i4_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i4_u0_r_chan_t),
+      .req_t(axi_a48_d512_i4_u0_req_t),
+      .resp_t(axi_a48_d512_i4_u0_resp_t)
+  ) i_wide_cluster_out_isolate_cut (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(wide_cluster_out_isolate_req),
+      .slv_resp_o(wide_cluster_out_isolate_rsp),
+      .mst_req_o(wide_cluster_out_isolate_cut_req),
+      .mst_resp_i(wide_cluster_out_isolate_cut_rsp)
+  );
 
 
-  assign quadrant_wide_out_req_o = wide_cluster_out_isolate_req;
-  assign wide_cluster_out_isolate_rsp = quadrant_wide_out_rsp_i;
+  assign quadrant_wide_out_req_o = wide_cluster_out_isolate_cut_req;
+  assign wide_cluster_out_isolate_cut_rsp = quadrant_wide_out_rsp_i;
 
   ////////////////////
   // HBI Connection //
@@ -370,6 +430,26 @@ module occamy_quadrant_s1
   axi_a48_d512_i9_u0_req_t  wide_cluster_in_iwc_req;
   axi_a48_d512_i9_u0_resp_t wide_cluster_in_iwc_rsp;
 
+  axi_a48_d512_i9_u0_req_t  wide_cluster_in_iwc_cut_req;
+  axi_a48_d512_i9_u0_resp_t wide_cluster_in_iwc_cut_rsp;
+
+  axi_multicut #(
+      .NoCuts(1),
+      .aw_chan_t(axi_a48_d512_i9_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d512_i9_u0_w_chan_t),
+      .b_chan_t(axi_a48_d512_i9_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d512_i9_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d512_i9_u0_r_chan_t),
+      .req_t(axi_a48_d512_i9_u0_req_t),
+      .resp_t(axi_a48_d512_i9_u0_resp_t)
+  ) i_wide_cluster_in_iwc_cut (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(wide_cluster_in_iwc_req),
+      .slv_resp_o(wide_cluster_in_iwc_rsp),
+      .mst_req_o(wide_cluster_in_iwc_cut_req),
+      .mst_resp_i(wide_cluster_in_iwc_cut_rsp)
+  );
   axi_a48_d512_i9_u0_req_t  wide_cluster_in_isolate_req;
   axi_a48_d512_i9_u0_resp_t wide_cluster_in_isolate_rsp;
 
@@ -386,8 +466,8 @@ module occamy_quadrant_s1
   ) i_wide_cluster_in_isolate (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(wide_cluster_in_iwc_req),
-      .slv_resp_o(wide_cluster_in_iwc_rsp),
+      .slv_req_i(wide_cluster_in_iwc_cut_req),
+      .slv_resp_o(wide_cluster_in_iwc_cut_rsp),
       .mst_req_o(wide_cluster_in_isolate_req),
       .mst_resp_i(wide_cluster_in_isolate_rsp),
       .isolate_i(isolate_i[2]),

--- a/hw/system/occamy/src/occamy_quadrant_s1.sv.tpl
+++ b/hw/system/occamy/src/occamy_quadrant_s1.sv.tpl
@@ -66,6 +66,7 @@ module occamy_quadrant_s1
     narrow_cluster_in_iwc = soc_narrow_xbar.out_s1_quadrant_0 \
       .copy(name="narrow_cluster_in_iwc") \
       .declare(context) \
+      .cut(context, cut_width) \
       .isolate(context, "isolate_i[0]", "narrow_cluster_in_isolate", isolated="isolated_o[0]", terminated=True) \
       .change_iw(context, narrow_xbar_quadrant_s1.in_top.iw, "narrow_cluster_in_iwc", to=narrow_xbar_quadrant_s1.in_top)
   %>
@@ -77,7 +78,9 @@ module occamy_quadrant_s1
   ///////////////////////////////
   <% narrow_cluster_out_iwc = narrow_xbar_quadrant_s1.out_top \
     .change_iw(context, soc_narrow_xbar.in_s1_quadrant_0.iw, "narrow_cluster_out_iwc") \
-    .isolate(context, "isolate_i[1]", "narrow_cluster_out_isolate", isolated="isolated_o[1]") %>
+    .isolate(context, "isolate_i[1]", "narrow_cluster_out_isolate", isolated="isolated_o[1]") \
+    .cut(context, cut_width)
+   %>
 
   assign quadrant_narrow_out_req_o = ${narrow_cluster_out_iwc.req_name()};
   assign ${narrow_cluster_out_iwc.rsp_name()} = quadrant_narrow_out_rsp_i;
@@ -104,7 +107,8 @@ module occamy_quadrant_s1
       wide_cluster_out_ro_cache = wide_xbar_out_iwc
 
     wide_cluster_out_cut = wide_cluster_out_ro_cache \
-      .isolate(context, "isolate_i[3]", "wide_cluster_out_isolate", isolated="isolated_o[3]", atop_support=False)
+      .isolate(context, "isolate_i[3]", "wide_cluster_out_isolate", isolated="isolated_o[3]", atop_support=False) \
+      .cut(context, cut_width)
 
     assert soc_wide_xbar.in_s1_quadrant_0.iw == wide_cluster_out_cut.iw, "S1 Quadrant and Cluster Out IW mismatches."
   %>
@@ -129,6 +133,7 @@ module occamy_quadrant_s1
     soc_wide_xbar.out_s1_quadrant_0 \
       .copy(name="wide_cluster_in_iwc") \
       .declare(context) \
+      .cut(context, cut_width) \
       .isolate(context, "isolate_i[2]", "wide_cluster_in_isolate", isolated="isolated_o[2]", terminated=True, atop_support=False) \
       .change_iw(context, wide_xbar_quadrant_s1.in_top.iw, "wide_cluster_in_iwc", to=wide_xbar_quadrant_s1.in_top)
   %>


### PR DESCRIPTION
This pull request adds AXI cuts for each quadrant AXI port to remove input to output paths.