### PR TITLE
snitch: Fix wrong enum member in DMA xbar

### DIFF
--- a/hw/ip/snitch/src/snitch_pkg.sv
+++ b/hw/ip/snitch/src/snitch_pkg.sv
@@ -138,13 +138,13 @@ package snitch_pkg;
   // Slaves on Cluster DMA AXI Bus
   typedef enum int unsigned {
     TCDMDMA   = 0,
-    SoCDMAOut = 1,
-    ICache    = 2
+    SoCDMAOut = 1
   } cluster_slave_dma_e;
 
   typedef enum int unsigned {
     SDMAMst = 32'd0,
-    SoCDMAIn = 32'd1
+    SoCDMAIn = 32'd1,
+    ICache    = 32'd2
   } cluster_master_dma_e;
 
   /// Possible interconnect implementations.


### PR DESCRIPTION
The DMA xbar has the following inputs
```
wide_axi_mst_req[SDMAMst]  // from DMA
wide_axi_mst_req[SoCDMAIn] // from SoC (ingress)
wide_axi_mst_req[ICache+i] // for each I$
```
and the outputs
```
wide_axi_slv_req[TCDMDMA]   // to the TCDM
wide_axi_slv_req[SoCDMAOut] // to the SoC (egress)
```

The `ICache` member should be in the enum with all the DMA xbar slaves (`cluster_master_dma_e`). It gets assigned the same value hence this does not change any behavior, just clears things up.