### PR TITLE
fix/regtool

### DIFF
--- a/hw/vendor/patches/pulp_platform_register_interface/0002-regtool-Fix-issue-with-Solderpad-license-check.patch
+++ b/hw/vendor/patches/pulp_platform_register_interface/0002-regtool-Fix-issue-with-Solderpad-license-check.patch
@@ -1,0 +1,28 @@
+From f7a8c5c6db4f8e741d67ff2fcbc3ca35711dc8b6 Mon Sep 17 00:00:00 2001
+From: Luca Colagrande <bigcola.96@gmail.com>
+Date: Tue, 9 Nov 2021 18:36:19 +0100
+Subject: [PATCH] regtool: Fix issue with Solderpad license check
+
+---
+ vendor/lowrisc_opentitan/util/regtool.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/vendor/lowrisc_opentitan/util/regtool.py b/vendor/lowrisc_opentitan/util/regtool.py
+index aa264c5..76268c9 100755
+--- a/vendor/lowrisc_opentitan/util/regtool.py
++++ b/vendor/lowrisc_opentitan/util/regtool.py
+@@ -218,7 +218,10 @@ def main():
+         if found_lunder:
+             src_lic = found_lunder
+         if found_spdx:
+-            src_lic += '\n' + found_spdx
++            if src_lic is None:
++                src_lic = '\n' + found_spdx
++            else:
++                src_lic += '\n' + found_spdx
+ 
+         with outfile:
+             if format == 'html':
+-- 
+2.28.0
+

--- a/hw/vendor/pulp_platform_register_interface/vendor/lowrisc_opentitan/util/regtool.py
+++ b/hw/vendor/pulp_platform_register_interface/vendor/lowrisc_opentitan/util/regtool.py
@@ -218,7 +218,10 @@ def main():
         if found_lunder:
             src_lic = found_lunder
         if found_spdx:
-            src_lic += '\n' + found_spdx
+            if src_lic is None:
+                src_lic = '\n' + found_spdx
+            else:
+                src_lic += '\n' + found_spdx
 
         with outfile:
             if format == 'html':


### PR DESCRIPTION
Patch regtool to correctly generate C headers from files with Solderpad license