### PR TITLE
icache: Code improvements

### DIFF
--- a/hw/ip/snitch_icache/src/snitch_icache.sv
+++ b/hw/ip/snitch_icache/src/snitch_icache.sv
@@ -73,13 +73,14 @@ module snitch_icache #(
 
     // Bundle the parameters up into a proper configuration struct that we can
     // pass to submodules.
+    localparam int PendingCount = 2;
     localparam snitch_icache_pkg::config_t CFG = '{
         NR_FETCH_PORTS:     NR_FETCH_PORTS,
         LINE_WIDTH:         LINE_WIDTH,
         LINE_COUNT:         LINE_COUNT,
         L0_LINE_COUNT:      L0_LINE_COUNT,
         SET_COUNT:          SET_COUNT,
-        PENDING_COUNT:      2,
+        PENDING_COUNT:      PendingCount,
         FETCH_AW:           FETCH_AW,
         FETCH_DW:           FETCH_DW,
         FILL_AW:            FILL_AW,
@@ -99,7 +100,7 @@ module snitch_icache #(
           (L0_EARLY_TAG_WIDTH == -1) ? FETCH_AW - $clog2(LINE_WIDTH/8) : L0_EARLY_TAG_WIDTH,
         ID_WIDTH_REQ: $clog2(NR_FETCH_PORTS) + 1,
         ID_WIDTH_RESP: 2*NR_FETCH_PORTS,
-        PENDING_IW:  $clog2(2)
+        PENDING_IW:  $clog2(PendingCount)
     };
 
     // pragma translate_off

--- a/hw/ip/snitch_icache/src/snitch_icache_lookup.sv
+++ b/hw/ip/snitch_icache/src/snitch_icache_lookup.sv
@@ -86,7 +86,7 @@ module snitch_icache_lookup #(
             ram_wtag   = '0;
         end else  if (write_valid_i) begin
             ram_addr   = write_addr_i;
-            ram_enable = $unsigned(1 << write_set_i);
+            ram_enable = CFG.SET_COUNT > 1 ? $unsigned(1 << write_set_i) : 1'b1;
             ram_write  = 1'b1;
             write_ready_o = 1'b1;
         end else if (out_ready_i) begin


### PR DESCRIPTION
Two minor code improvements in the icache:

- Change a duplicated, hardcoded value into a parameter
- Fix the refill in the lookup for a cache with a single set. This is a performance bug where we ignored half of the refills in such a configuration. AFAIK, we always have at least two sets at the moment, so nothing should change.