### PR TITLE
hw: Ensure consistent reset practices and strategy

### DIFF
--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -267,27 +267,27 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   `FFNR(tvec_q, tvec_d, clk_i)
   `FFNR(epc_q, epc_d, clk_i)
   `FFNR(satp_q, satp_d, clk_i)
-  `FFSR(cause_q, cause_d, '0, clk_i, rst_i)
-  `FFSR(cause_irq_q, cause_irq_d, '0, clk_i, rst_i)
-  `FFSR(priv_lvl_q, priv_lvl_d, snitch_pkg::PrivLvlM, clk_i, rst_i)
-  `FFSR(mpp_q, mpp_d, snitch_pkg::PrivLvlU, clk_i, rst_i)
-  `FFSR(spp_q, spp_d, 1'b0, clk_i, rst_i)
-  `FFSR(ie_q, ie_d, '0, clk_i, rst_i)
-  `FFSR(pie_q, pie_d, '0, clk_i, rst_i)
+  `FFAR(cause_q, cause_d, '0, clk_i, rst_i)
+  `FFAR(cause_irq_q, cause_irq_d, '0, clk_i, rst_i)
+  `FFAR(priv_lvl_q, priv_lvl_d, snitch_pkg::PrivLvlM, clk_i, rst_i)
+  `FFAR(mpp_q, mpp_d, snitch_pkg::PrivLvlU, clk_i, rst_i)
+  `FFAR(spp_q, spp_d, 1'b0, clk_i, rst_i)
+  `FFAR(ie_q, ie_d, '0, clk_i, rst_i)
+  `FFAR(pie_q, pie_d, '0, clk_i, rst_i)
   // Interrupts
-  `FFSR(eie_q, eie_d, '0, clk_i, rst_i)
-  `FFSR(tie_q, tie_d, '0, clk_i, rst_i)
-  `FFSR(sie_q, sie_d, '0, clk_i, rst_i)
-  `FFSR(cie_q, cie_d, '0, clk_i, rst_i)
-  `FFSR(seip_q, seip_d, '0, clk_i, rst_i)
-  `FFSR(stip_q, stip_d, '0, clk_i, rst_i)
-  `FFSR(ssip_q, ssip_d, '0, clk_i, rst_i)
-  `FFSR(scip_q, scip_d, '0, clk_i, rst_i)
+  `FFAR(eie_q, eie_d, '0, clk_i, rst_i)
+  `FFAR(tie_q, tie_d, '0, clk_i, rst_i)
+  `FFAR(sie_q, sie_d, '0, clk_i, rst_i)
+  `FFAR(cie_q, cie_d, '0, clk_i, rst_i)
+  `FFAR(seip_q, seip_d, '0, clk_i, rst_i)
+  `FFAR(stip_q, stip_d, '0, clk_i, rst_i)
+  `FFAR(ssip_q, ssip_d, '0, clk_i, rst_i)
+  `FFAR(scip_q, scip_d, '0, clk_i, rst_i)
 
-  `FFSR(dcsr_q, dcsr_d, '0, clk_i, rst_i)
+  `FFAR(dcsr_q, dcsr_d, '0, clk_i, rst_i)
   `FFNR(dpc_q, dpc_d, clk_i)
   `FFNR(dscratch_q, dscratch_d, clk_i)
-  `FFSR(debug_q, debug_d, '0, clk_i, rst_i) // Debug mode
+  `FFAR(debug_q, debug_d, '0, clk_i, rst_i) // Debug mode
 
   typedef struct packed {
     fpnew_pkg::roundmode_e frm;
@@ -300,21 +300,21 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
   assign fpu_fmt_mode_o = fcsr_q.fmode;
 
   // Registers
-  `FFSR(pc_q, pc_d, BootAddr, clk_i, rst_i)
-  `FFSR(wfi_q, wfi_d, '0, clk_i, rst_i)
-  `FFSR(sb_q, sb_d, '0, clk_i, rst_i)
-  `FFSR(fcsr_q, fcsr_d, '0, clk_i, rst_i)
+  `FFAR(pc_q, pc_d, BootAddr, clk_i, rst_i)
+  `FFAR(wfi_q, wfi_d, '0, clk_i, rst_i)
+  `FFAR(sb_q, sb_d, '0, clk_i, rst_i)
+  `FFAR(fcsr_q, fcsr_d, '0, clk_i, rst_i)
 
   // performance counter
   `ifdef SNITCH_ENABLE_PERF
   logic [63:0] cycle_q;
   logic [63:0] instret_q;
-  `FFSR(cycle_q, cycle_q + 1, '0, clk_i, rst_i)
-  `FFLSR(instret_q, instret_q + 1, !stall, '0, clk_i, rst_i)
+  `FFAR(cycle_q, cycle_q + 1, '0, clk_i, rst_i)
+  `FFLAR(instret_q, instret_q + 1, !stall, '0, clk_i, rst_i)
   `endif
 
   logic [AddrWidth-32-1:0] mseg_q, mseg_d;
-  `FFSR(mseg_q, mseg_d, '0, clk_i, rst_i)
+  `FFAR(mseg_q, mseg_d, '0, clk_i, rst_i)
 
   // accelerator offloading interface
   // register int destination in scoreboard

--- a/hw/ip/snitch/src/snitch_l0_tlb.sv
+++ b/hw/ip/snitch/src/snitch_l0_tlb.sv
@@ -65,7 +65,7 @@ module snitch_l0_tlb import snitch_pkg::*; #(
 
   l0_pte_t pte;
 
-  `FFSR(tag_valid_q, tag_valid_d, '0, clk_i, rst_i)
+  `FFAR(tag_valid_q, tag_valid_d, '0, clk_i, rst_i)
   `FFNR(tag_q, tag_d, clk_i)
   `FFNR(pte_q, pte_d, clk_i)
 
@@ -73,8 +73,8 @@ module snitch_l0_tlb import snitch_pkg::*; #(
   logic miss_d, miss_q; // we got a miss
   logic refill_d, refill_q; // refill request is underway
 
-  `FFSR(miss_q, miss_d, '0, clk_i, rst_i)
-  `FFSR(refill_q, refill_d, '0, clk_i, rst_i)
+  `FFAR(miss_q, miss_d, '0, clk_i, rst_i)
+  `FFAR(refill_q, refill_d, '0, clk_i, rst_i)
 
   // Tag Comparison
   for (genvar i = 0; i < NrEntries; i++) begin : gen_tag_cmp
@@ -149,7 +149,7 @@ module snitch_l0_tlb import snitch_pkg::*; #(
 
   // Eviction strategy: round-robin
   if (NrEntries > 1) begin : gen_evict_counter
-    `FFSR(evict_q, evict_d, '0, clk_i, rst_i)
+    `FFAR(evict_q, evict_d, '0, clk_i, rst_i)
     always_comb begin
       evict_d = evict_q;
       if (valid_o && ready_i) evict_d++;

--- a/hw/ip/snitch_cluster/src/snitch_barrier.sv
+++ b/hw/ip/snitch_cluster/src/snitch_barrier.sv
@@ -74,7 +74,7 @@ module snitch_barrier
   end
 
   for (genvar i = 0; i < NrPorts; i++) begin : gen_ff
-    `FFSRN(state_q[i], state_d[i], Idle, clk_i, rst_ni)
+    `FFARN(state_q[i], state_d[i], Idle, clk_i, rst_ni)
   end
 
 endmodule

--- a/hw/ip/snitch_cluster/src/snitch_cluster.sv
+++ b/hw/ip/snitch_cluster/src/snitch_cluster.sv
@@ -1145,8 +1145,8 @@ module snitch_cluster
   // --------------------
   logic [NrTCDMPortsCores-1:0] flat_acc, flat_con;
   for (genvar i = 0; i < NrTCDMPortsCores; i++) begin  : gen_event_counter
-    `FFSRN(flat_acc[i], tcdm_req[i].q_valid, '0, clk_i, rst_ni)
-    `FFSRN(flat_con[i], tcdm_req[i].q_valid & ~tcdm_rsp[i].q_ready, '0, clk_i, rst_ni)
+    `FFARN(flat_acc[i], tcdm_req[i].q_valid, '0, clk_i, rst_ni)
+    `FFARN(flat_con[i], tcdm_req[i].q_valid & ~tcdm_rsp[i].q_ready, '0, clk_i, rst_ni)
   end
 
   popcount #(

--- a/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
+++ b/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
@@ -91,7 +91,7 @@ module snitch_fp_ss import snitch_pkg::*; #(
   logic [0:0]           fpr_wready;
 
   logic ssr_active_d, ssr_active_q;
-  `FFSR(ssr_active_q, Xssr & ssr_active_d, 1'b0, clk_i, rst_i)
+  `FFAR(ssr_active_q, Xssr & ssr_active_d, 1'b0, clk_i, rst_i)
 
   typedef struct packed {
     logic       ssr; // write-back to SSR at rd
@@ -114,7 +114,7 @@ module snitch_fp_ss import snitch_pkg::*; #(
 
   logic [31:0] sb_d, sb_q;
   logic rd_is_fp;
-  `FFSR(sb_q, sb_d, '0, clk_i, rst_i)
+  `FFAR(sb_q, sb_d, '0, clk_i, rst_i)
 
   logic csr_instr;
 

--- a/hw/ip/snitch_cluster/src/snitch_sequencer.sv
+++ b/hw/ip/snitch_cluster/src/snitch_sequencer.sv
@@ -113,11 +113,11 @@ module snitch_sequencer import snitch_pkg::*; #(
   logic [DepthBits-1:0] inst_cnt_d, inst_cnt_q;
   logic [2:0] stagger_cnt_q, stagger_cnt_d;
 
-  `FFSR(rd_pointer_q, rd_pointer_d, '0, clk_i, rst_i)
-  `FFSR(wr_pointer_q, wr_pointer_d, '0, clk_i, rst_i)
-  `FFSR(rpt_cnt_q, rpt_cnt_d, '0, clk_i, rst_i)
-  `FFSR(inst_cnt_q, inst_cnt_d, '0, clk_i, rst_i)
-  `FFSR(stagger_cnt_q, stagger_cnt_d, '0, clk_i, rst_i)
+  `FFAR(rd_pointer_q, rd_pointer_d, '0, clk_i, rst_i)
+  `FFAR(wr_pointer_q, wr_pointer_d, '0, clk_i, rst_i)
+  `FFAR(rpt_cnt_q, rpt_cnt_d, '0, clk_i, rst_i)
+  `FFAR(inst_cnt_q, inst_cnt_d, '0, clk_i, rst_i)
+  `FFAR(stagger_cnt_q, stagger_cnt_d, '0, clk_i, rst_i)
 
   // set by sequencer when done with the entire sequence
 

--- a/hw/ip/snitch_cluster/src/tcdm_shim.sv
+++ b/hw/ip/snitch_cluster/src/tcdm_shim.sv
@@ -59,7 +59,7 @@ module tcdm_shim #(
   logic               tcdm_pready;
 
   logic [$clog2(MaxOutStandingReads):0] credits_q, credits_d;
-  `FFSR(credits_q, credits_d, MaxOutStandingReads, clk_i, rst_i)
+  `FFAR(credits_q, credits_d, MaxOutStandingReads, clk_i, rst_i)
 
   fifo #(
     .FALL_THROUGH ( 1'b1                ),

--- a/hw/ip/snitch_vm/src/snitch_ptw.sv
+++ b/hw/ip/snitch_vm/src/snitch_ptw.sv
@@ -51,7 +51,7 @@ module snitch_ptw import snitch_pkg::*; #(
 
   logic [1:0] lvl_d, lvl_q;
 
-  `FFSRN(state_q, state_d, Idle, clk_i, rst_ni)
+  `FFARN(state_q, state_d, Idle, clk_i, rst_ni)
 
   pte_sv32_t pte;
   l0_pte_t pte_d, pte_q;


### PR DESCRIPTION
This ensures (hopefully) that all RTL in the repo, and particularly in the cluster, has a consistent reset style: asynchronous and (globally) active-low.

I would have preferred to verify the completeness of this in some analysis tool first, but since all of the changed registers need to be fixed anyways, we might as well merge this now and add any additional fixes later.