### PR TITLE
ci: Fix unintended command execution in lint message

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -239,4 +239,4 @@ jobs:
         CLANG_FORMAT: clang-format-10
       run: |
         make -C hw/system/occamy all
-        util/git-diff.py --error-msg "::error ::Found differences, run \`make -C hw/system/occamy\` all before committing."
+        util/git-diff.py --error-msg "::error ::Found differences, run \`make -C hw/system/occamy all\` before committing."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -239,4 +239,4 @@ jobs:
         CLANG_FORMAT: clang-format-10
       run: |
         make -C hw/system/occamy all
-        util/git-diff.py --error-msg "::error ::Found differences, run `make -C hw/system/occamy` all before committing."
+        util/git-diff.py --error-msg "::error ::Found differences, run \`make -C hw/system/occamy\` all before committing."


### PR DESCRIPTION
The CI check `Occamy` in `.github/workflows/lint.yml` ran the following commands:

```bash
make -C hw/system/occamy all
util/git-diff.py --error-msg "::error ::Found differences, run `make -C hw/system/occamy` all before committing."
```
The \` in the argument to the `git-diff.py` script caused the make command enclosed by \` `make -C hw/system/occamy` to be executed which broke the `git-diff.py` script.