### PR TITLE
Fix syntax in occamy cluster and set NrMaxRules based on the number of defined cached regions

### DIFF
--- a/hw/ip/snitch/Bender.yml
+++ b/hw/ip/snitch/Bender.yml
@@ -19,7 +19,12 @@ export_include_dirs:
 
 sources:
 # Level 0:
-- src/snitch_pma_pkg.sv
+- target: not(occamy)
+  files:
+  - src/snitch_pma_pkg.sv
+- target: occamy
+  files:
+  - src/occamy_snitch_pma_pkg.sv
 - src/riscv_instr.sv
 # Level 1:
 - src/snitch_pkg.sv

--- a/hw/ip/snitch/src/occamy_snitch_pma_pkg.sv
+++ b/hw/ip/snitch/src/occamy_snitch_pma_pkg.sv
@@ -7,7 +7,7 @@
 // Description: PMA Checks for Snitch.
 package snitch_pma_pkg;
 
-  localparam int unsigned NrMaxRules = 1;
+  localparam int unsigned NrMaxRules = 4;
 
   typedef struct packed {
       logic [47:0] base; // base which needs to match

--- a/hw/ip/snitch/src/snitch_pma_pkg.sv.tpl
+++ b/hw/ip/snitch/src/snitch_pma_pkg.sv.tpl
@@ -7,7 +7,7 @@
 // Description: PMA Checks for Snitch.
 package snitch_pma_pkg;
 
-  localparam int unsigned NrMaxRules = 1;
+  localparam int unsigned NrMaxRules = ${nr_max_rules};
 
   typedef struct packed {
       logic [47:0] base; // base which needs to match

--- a/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -100,11 +100,6 @@ package ${cfg['pkg_name']};
   localparam snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '{
       NrCachedRegionRules: ${len(cfg['pmas']['cached'])},
       CachedRegion: '{
-% if (len(cfg['pmas']['cached']) < 4):
-  % for i in range(4 - len(cfg['pmas']['cached'])):
-            '{base: '0, mask: '0},
-  % endfor
-% endif
 % for i, cp in enumerate(reversed(cfg['pmas']['cached'])):
   % if (i != (len(cfg['pmas']['cached']) - 1)):
             '{base: ${to_sv_hex(cp[0], cfg['addr_width'])}, mask: ${to_sv_hex(cp[1], cfg['addr_width'])}},

--- a/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -100,10 +100,13 @@ package ${cfg['pkg_name']};
   localparam snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '{
       NrCachedRegionRules: ${len(cfg['pmas']['cached'])},
       CachedRegion: '{
-% for i, cp in enumerate(cfg['pmas']['cached']):
-          ${i}: '{base: ${to_sv_hex(cp[0], cfg['addr_width'])}, mask: ${to_sv_hex(cp[1], cfg['addr_width'])}},
+% for i, cp in enumerate(reversed(cfg['pmas']['cached'])):
+  % if (i != (len(cfg['pmas']['cached']) - 1)):
+            '{base: ${to_sv_hex(cp[0], cfg['addr_width'])}, mask: ${to_sv_hex(cp[1], cfg['addr_width'])}},
+  % else:
+            '{base: ${to_sv_hex(cp[0], cfg['addr_width'])}, mask: ${to_sv_hex(cp[1], cfg['addr_width'])}}
+  % endif
 % endfor
-          default: '0
       },
       default: 0
   };

--- a/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -102,7 +102,7 @@ package ${cfg['pkg_name']};
       CachedRegion: '{
 % if (len(cfg['pmas']['cached']) < 4):
   % for i in range(4 - len(cfg['pmas']['cached'])):
-            '{base: 48'h0, mask: 48'h0},
+            '{base: '0, mask: '0},
   % endfor
 % endif
 % for i, cp in enumerate(reversed(cfg['pmas']['cached'])):

--- a/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -100,6 +100,11 @@ package ${cfg['pkg_name']};
   localparam snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '{
       NrCachedRegionRules: ${len(cfg['pmas']['cached'])},
       CachedRegion: '{
+% if (len(cfg['pmas']['cached']) < 4):
+  % for i in range(4 - len(cfg['pmas']['cached'])):
+            '{base: '0, mask: '0},
+  % endfor
+% endif
 % for i, cp in enumerate(reversed(cfg['pmas']['cached'])):
   % if (i != (len(cfg['pmas']['cached']) - 1)):
             '{base: ${to_sv_hex(cp[0], cfg['addr_width'])}, mask: ${to_sv_hex(cp[1], cfg['addr_width'])}},

--- a/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+++ b/hw/ip/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
@@ -102,7 +102,7 @@ package ${cfg['pkg_name']};
       CachedRegion: '{
 % if (len(cfg['pmas']['cached']) < 4):
   % for i in range(4 - len(cfg['pmas']['cached'])):
-            '{base: '0, mask: '0},
+            '{base: 48'h0, mask: 48'h0},
   % endfor
 % endif
 % for i, cp in enumerate(reversed(cfg['pmas']['cached'])):

--- a/hw/system/occamy/Makefile
+++ b/hw/system/occamy/Makefile
@@ -25,6 +25,8 @@ VLOG_FLAGS 	  += -suppress 2583
 VLOG_FLAGS 	  += -suppress 13314
 VLOG_FLAGS 	  += ${QUESTA_64BIT}
 
+VSIM_BENDER 	  += -t occamy
+
 CFG ?= src/occamy_cfg.hjson
 CDEF = ${ROOT}/sw/snRuntime/include/occamy_soc_peripheral.h
 

--- a/hw/system/occamy/src/occamy_cluster_wrapper.sv
+++ b/hw/system/occamy/src/occamy_cluster_wrapper.sv
@@ -76,11 +76,10 @@ package occamy_cluster_pkg;
   localparam snitch_pma_pkg::snitch_pma_t SnitchPMACfg = '{
       NrCachedRegionRules: 4,
       CachedRegion: '{
-          0: '{base: 48'h80000000, mask: 48'hffff80000000},
-          1: '{base: 48'h1000000000, mask: 48'hfffe00000000},
-          2: '{base: 48'h70000000, mask: 48'hfffffffe0000},
-          3: '{base: 48'h1000000, mask: 48'hfffffffe0000},
-          default: '0
+            '{base: 48'h1000000, mask: 48'hfffffffe0000},
+            '{base: 48'h70000000, mask: 48'hfffffffe0000},
+            '{base: 48'h1000000000, mask: 48'hfffe00000000},
+            '{base: 48'h80000000, mask: 48'hffff80000000}
       },
       default: 0
   };

--- a/sw/banshee/src/tran.rs
+++ b/sw/banshee/src/tran.rs
@@ -295,9 +295,7 @@ impl<'a> ElfTranslator<'a> {
         for (addr, inst) in self.all_instructions() {
             match inst {
                 riscv::Format::Imm12RdRs1(
-                    fmt
-                    @
-                    riscv::FormatImm12RdRs1 {
+                    fmt @ riscv::FormatImm12RdRs1 {
                         op: riscv::OpcodeImm12RdRs1::Jalr,
                         ..
                     },
@@ -311,9 +309,7 @@ impl<'a> ElfTranslator<'a> {
                     }
                 }
                 riscv::Format::Jimm20Rd(
-                    fmt
-                    @
-                    riscv::FormatJimm20Rd {
+                    fmt @ riscv::FormatJimm20Rd {
                         op: riscv::OpcodeJimm20Rd::Jal,
                         ..
                     },

--- a/util/clustergen/cluster.py
+++ b/util/clustergen/cluster.py
@@ -370,6 +370,21 @@ class SnitchClusterTB(Generator):
         pma_cfg.add_region_length(PMA.CACHED, self.cfg['dram']['address'],
                                   self.cfg['dram']['length'],
                                   self.cfg['cluster']['addr_width'])
+
+        # Update snitch_pma_pkg.sv::NrMaxRules
+        nr_max_rules = '  localparam int unsigned NrMaxRules = {};\n'.format(len(pma_cfg.regions))
+        old_nr_max_rules = '  localparam int unsigned NrMaxRules ='
+        new_pkg = ''
+        with open('../../ip/snitch/src/snitch_pma_pkg.sv.tpl', "r") as f:
+            for line in f:
+                if old_nr_max_rules in line:
+                    new_pkg += nr_max_rules
+                else:
+                    new_pkg += line
+        snitch_pma_pkg_file = open('../../ip/snitch/src/snitch_pma_pkg.sv', "w")
+        snitch_pma_pkg_file.write(new_pkg)
+        snitch_pma_pkg_file.close()
+
         self.cfg['cluster']['tie_ports'] = True
         # Store Snitch cluster config in separate variable
         self.cluster = SnitchCluster(cfg["cluster"], pma_cfg)

--- a/util/clustergen/cluster.py
+++ b/util/clustergen/cluster.py
@@ -371,17 +371,20 @@ class SnitchClusterTB(Generator):
                                   self.cfg['dram']['length'],
                                   self.cfg['cluster']['addr_width'])
 
-        # Update snitch_pma_pkg.sv::NrMaxRules
+        # Update snitch_pma_pkg::NrMaxRules in snitch_pma_pkg.sv
+        file_path = pathlib.Path(__file__).parent
+        snitch_pma_pkg_tpl_path = file_path / "../../hw/ip/snitch/src/snitch_pma_pkg.sv.tpl"
+        snitch_pma_pkg_path = file_path / "../../hw/ip/snitch/src/snitch_pma_pkg.sv"
         nr_max_rules = '  localparam int unsigned NrMaxRules = {};\n'.format(len(pma_cfg.regions))
         old_nr_max_rules = '  localparam int unsigned NrMaxRules ='
         new_pkg = ''
-        with open('../../ip/snitch/src/snitch_pma_pkg.sv.tpl', "r") as f:
+        with open(snitch_pma_pkg_tpl_path, "r") as f:
             for line in f:
                 if old_nr_max_rules in line:
                     new_pkg += nr_max_rules
                 else:
                     new_pkg += line
-        snitch_pma_pkg_file = open('../../ip/snitch/src/snitch_pma_pkg.sv', "w")
+        snitch_pma_pkg_file = open(snitch_pma_pkg_path, "w")
         snitch_pma_pkg_file.write(new_pkg)
         snitch_pma_pkg_file.close()
 

--- a/util/clustergen/occamy.py
+++ b/util/clustergen/occamy.py
@@ -5,6 +5,7 @@
 from .cluster import Generator, PMA, PMACfg, SnitchCluster, clog2
 import pathlib
 
+
 class Occamy(Generator):
     """
     Generate an Occamy system.

--- a/util/clustergen/occamy.py
+++ b/util/clustergen/occamy.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .cluster import Generator, PMA, PMACfg, SnitchCluster, clog2
-
+import pathlib
 
 class Occamy(Generator):
     """
@@ -38,18 +38,21 @@ class Occamy(Generator):
                                   cfg["rom"]["address"],
                                   cfg["rom"]["length"],
                                   addr_width)
-        
-        # Update snitch_pma_pkg.sv::NrMaxRules
+
+        # Update snitch_pma_pkg::NrMaxRules in occamy_snitch_pma_pkg.sv
+        file_path = pathlib.Path(__file__).parent
+        snitch_pma_pkg_tpl_path = file_path / "../../hw/ip/snitch/src/snitch_pma_pkg.sv.tpl"
+        occamy_snitch_pma_pkg_path = file_path / "../../hw/ip/snitch/src/occamy_snitch_pma_pkg.sv"
         nr_max_rules = '  localparam int unsigned NrMaxRules = {};\n'.format(len(pma_cfg.regions))
         old_nr_max_rules = '  localparam int unsigned NrMaxRules ='
         new_pkg = ''
-        with open('../../ip/snitch/src/snitch_pma_pkg.sv.tpl', "r") as f:
+        with open(snitch_pma_pkg_tpl_path, "r") as f:
             for line in f:
                 if old_nr_max_rules in line:
                     new_pkg += nr_max_rules
                 else:
                     new_pkg += line
-        occamy_snitch_pma_pkg_file = open('../../ip/snitch/src/occamy_snitch_pma_pkg.sv', "w")
+        occamy_snitch_pma_pkg_file = open(occamy_snitch_pma_pkg_path, "w")
         occamy_snitch_pma_pkg_file.write(new_pkg)
         occamy_snitch_pma_pkg_file.close()
 

--- a/util/clustergen/occamy.py
+++ b/util/clustergen/occamy.py
@@ -38,6 +38,20 @@ class Occamy(Generator):
                                   cfg["rom"]["address"],
                                   cfg["rom"]["length"],
                                   addr_width)
+        
+        # Update snitch_pma_pkg.sv::NrMaxRules
+        nr_max_rules = '  localparam int unsigned NrMaxRules = {};\n'.format(len(pma_cfg.regions))
+        old_nr_max_rules = '  localparam int unsigned NrMaxRules ='
+        new_pkg = ''
+        with open('../../ip/snitch/src/snitch_pma_pkg.sv.tpl', "r") as f:
+            for line in f:
+                if old_nr_max_rules in line:
+                    new_pkg += nr_max_rules
+                else:
+                    new_pkg += line
+        occamy_snitch_pma_pkg_file = open('../../ip/snitch/src/occamy_snitch_pma_pkg.sv', "w")
+        occamy_snitch_pma_pkg_file.write(new_pkg)
+        occamy_snitch_pma_pkg_file.close()
 
         # Store Snitch cluster config in separate variable
         self.cluster = SnitchCluster(cfg["cluster"], pma_cfg)


### PR DESCRIPTION
The previous assignment pattern in `occamy_cluster_wrapper.sv` was not supported by some tools.
* This PR fixes that assignment
* `NrMaxRules` set in `snitch_pma_pkg` is now computed from the number of cached regions defined in `occamy.py` and `cluster.py`. Two separate files containing a `snitch_pma_pkg`, one for occamy (`occamy_snitch_pma_pkg.sv`) and one for snitch (`snitch_pma_pkg.sv`), are generated. --> lint checks complain about that
* A target was inserted in the `Bender.yml` file to select the right file containing a `snitch_pma_pkg` to be included in the scripts generated by Bender. The correspondent flag was added in the `Makefile` used to generate the occamy system