### PR TITLE
snRuntime: Optimize function calls via internal linkage

### DIFF
--- a/sw/snRuntime/include/snrt.h
+++ b/sw/snRuntime/include/snrt.h
@@ -68,7 +68,7 @@ extern void snrt_cluster_sw_barrier();
 extern void snrt_global_barrier();
 extern void snrt_barrier(struct snrt_barrier *barr, uint32_t n);
 
-extern uint32_t __attribute__((pure)) snrt_hartid();
+static inline uint32_t __attribute__((pure)) snrt_hartid();
 struct snrt_team_root *snrt_current_team();
 extern struct snrt_peripherals *snrt_peripherals();
 extern uint32_t snrt_global_core_base_hartid();
@@ -167,6 +167,16 @@ static inline __attribute__((noreturn)) void snrt_exit(int status) {
     (void)status;
     while (1)
         ;
+}
+
+//================================================================================
+// Team functions
+//================================================================================
+
+static inline uint32_t __attribute__((pure)) snrt_hartid() {
+    uint32_t hartid;
+    asm("csrr %0, mhartid" : "=r"(hartid));
+    return hartid;
 }
 
 //================================================================================

--- a/sw/snRuntime/src/team.c
+++ b/sw/snRuntime/src/team.c
@@ -12,12 +12,6 @@ __thread uint32_t _snrt_core_idx;
 const uint32_t _snrt_team_size __attribute__((section(".rodata"))) =
     sizeof(struct snrt_team_root);
 
-uint32_t __attribute__((pure)) snrt_hartid() {
-    uint32_t hartid;
-    asm("csrr %0, mhartid" : "=r"(hartid));
-    return hartid;
-}
-
 struct snrt_team_root *snrt_current_team() {
     return _snrt_team_current->root;
 }


### PR DESCRIPTION
Quoting the C11 standard: 
> "Any function with internal linkage can be an inline function. For a function with external linkage, the following restrictions apply: If a function is declared with an inline function specifier, then it shall also be defined in the same translation unit.". 

For performance reasons, inlining of small functions e.g. `snrt_hartid()` is desirable. This is only possible if the function definition is available in the translation unit which desires inlining.
We can achieve this by moving the function definitions into the library header.