### PR TITLE
docker: Specify bender version `0.23.2`

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 # Build Rust tools
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH "/root/.cargo/bin:${PATH}"
-RUN cargo install bender
+RUN cargo install bender --version 0.23.2
 
 # Get LLVM 12
 RUN wget https://apt.llvm.org/llvm.sh


### PR DESCRIPTION
Addresses issue #326. The CI is constantly failing because it cannot build the Hardware due to the new bender release. The fix mentioned in #326 solves this issue for now.

I would suggest specifying the old bender version and keeping the issue open.