### PR TITLE
banshee: Emit float register values as float instead of hex

### DIFF
--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -968,8 +968,8 @@ impl<'a, 'b> Cpu<'a, 'b> {
             TraceAccess::RMWMem => format!("AMO:{:08x}", data as u32),
             TraceAccess::ReadReg(x) => format!("x{}:{:08x}", x, data as u32),
             TraceAccess::WriteReg(x) => format!("x{}={:08x}", x, data as u32),
-            TraceAccess::ReadFReg(x) => format!("f{}:{:4.4}", x, data),
-            TraceAccess::WriteFReg(x) => format!("f{}={:4.4}", x, data),
+            TraceAccess::ReadFReg(x) => format!("f{}:{:4.4}", x, f64::from_bits(data)),
+            TraceAccess::WriteFReg(x) => format!("f{}={:4.4}", x, f64::from_bits(data)),
         });
         let args = args.join(" ");
 

--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -970,6 +970,10 @@ impl<'a, 'b> Cpu<'a, 'b> {
             TraceAccess::WriteReg(x) => format!("x{}={:08x}", x, data as u32),
             TraceAccess::ReadFReg(x) => format!("f{:02}:{:>16.6}", x, f64::from_bits(data)),
             TraceAccess::WriteFReg(x) => format!("f{:02}={:>16.6}", x, f64::from_bits(data)),
+            TraceAccess::ReadF32Reg(x) => format!("f{:02}:{:>12.4}", x, f32::from_bits(data as u32)),
+            TraceAccess::WriteF32Reg(x) => format!("f{:02}={:>12.4}", x, f32::from_bits(data as u32)),
+            TraceAccess::Readvf64sReg(x) => format!("f{:02}:[{:>12.4}, {:>12.4}]", x, f32::from_bits((data >> 32) as u32), f32::from_bits((data) as u32)),
+            TraceAccess::Writevf64sReg(x) => format!("f{:02}=[{:>12.4}, {:>12.4}]", x, f32::from_bits((data >> 32) as u32), f32::from_bits((data) as u32)),
         });
         let args = args.join(" ");
 
@@ -1228,9 +1232,13 @@ pub enum TraceAccess {
     ReadMem,
     ReadReg(u8),
     ReadFReg(u8),
+    ReadF32Reg(u8),
+    Readvf64sReg(u8),
     WriteMem,
     WriteReg(u8),
     WriteFReg(u8),
+    WriteF32Reg(u8),
+    Writevf64sReg(u8),
     RMWMem,
 }
 

--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -968,8 +968,8 @@ impl<'a, 'b> Cpu<'a, 'b> {
             TraceAccess::RMWMem => format!("AMO:{:08x}", data as u32),
             TraceAccess::ReadReg(x) => format!("x{}:{:08x}", x, data as u32),
             TraceAccess::WriteReg(x) => format!("x{}={:08x}", x, data as u32),
-            TraceAccess::ReadFReg(x) => format!("f{}:{:4.4}", x, f64::from_bits(data)),
-            TraceAccess::WriteFReg(x) => format!("f{}={:4.4}", x, f64::from_bits(data)),
+            TraceAccess::ReadFReg(x) => format!("f{:02}:{:>16.6}", x, f64::from_bits(data)),
+            TraceAccess::WriteFReg(x) => format!("f{:02}={:>16.6}", x, f64::from_bits(data)),
         });
         let args = args.join(" ");
 

--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -968,8 +968,8 @@ impl<'a, 'b> Cpu<'a, 'b> {
             TraceAccess::RMWMem => format!("AMO:{:08x}", data as u32),
             TraceAccess::ReadReg(x) => format!("x{}:{:08x}", x, data as u32),
             TraceAccess::WriteReg(x) => format!("x{}={:08x}", x, data as u32),
-            TraceAccess::ReadFReg(x) => format!("f{}:{:016x}", x, data),
-            TraceAccess::WriteFReg(x) => format!("f{}={:016x}", x, data),
+            TraceAccess::ReadFReg(x) => format!("f{}:{:4.4}", x, data),
+            TraceAccess::WriteFReg(x) => format!("f{}={:4.4}", x, data),
         });
         let args = args.join(" ");
 

--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -970,10 +970,24 @@ impl<'a, 'b> Cpu<'a, 'b> {
             TraceAccess::WriteReg(x) => format!("x{}={:08x}", x, data as u32),
             TraceAccess::ReadFReg(x) => format!("f{:02}:{:>16.6}", x, f64::from_bits(data)),
             TraceAccess::WriteFReg(x) => format!("f{:02}={:>16.6}", x, f64::from_bits(data)),
-            TraceAccess::ReadF32Reg(x) => format!("f{:02}:{:>12.4}", x, f32::from_bits(data as u32)),
-            TraceAccess::WriteF32Reg(x) => format!("f{:02}={:>12.4}", x, f32::from_bits(data as u32)),
-            TraceAccess::Readvf64sReg(x) => format!("f{:02}:[{:>12.4}, {:>12.4}]", x, f32::from_bits((data >> 32) as u32), f32::from_bits((data) as u32)),
-            TraceAccess::Writevf64sReg(x) => format!("f{:02}=[{:>12.4}, {:>12.4}]", x, f32::from_bits((data >> 32) as u32), f32::from_bits((data) as u32)),
+            TraceAccess::ReadF32Reg(x) => {
+                format!("f{:02}:{:>12.4}", x, f32::from_bits(data as u32))
+            }
+            TraceAccess::WriteF32Reg(x) => {
+                format!("f{:02}={:>12.4}", x, f32::from_bits(data as u32))
+            }
+            TraceAccess::Readvf64sReg(x) => format!(
+                "f{:02}:[{:>12.4}, {:>12.4}]",
+                x,
+                f32::from_bits((data >> 32) as u32),
+                f32::from_bits((data) as u32)
+            ),
+            TraceAccess::Writevf64sReg(x) => format!(
+                "f{:02}=[{:>12.4}, {:>12.4}]",
+                x,
+                f32::from_bits((data >> 32) as u32),
+                f32::from_bits((data) as u32)
+            ),
         });
         let args = args.join(" ");
 


### PR DESCRIPTION
In banshee, register values in the traces are always encoded as hex values. For floats, it makes sense to format it as such. This increases readability and makes debugging much easier, e.g., SSR streams. I also added support for printing SIMD vectors. The traces will look like this:

```
00000000 00000734 0000 80003648  x8:0011fee0 RA:0011fe90 x10=0011fd70    # lw      a0, -80(s0)
00000000 00000735 0000 8000364c  x10:0011fd70 RA:0011fd70 RA:0011fd74 f03=        0.000000  # fld     ft3, 0(a0)
00000000 00000736 0000 80003650  x10:0011fd70 RA:0011fd78 RA:0011fd7c f04=        0.000000  # fld     ft4, 8(a0)
00000000 00000737 0000 80003654  x10:0011fd70 RA:0011fd80 RA:0011fd84 f05=        0.000000  # fld     ft5, 16(a0)
00000000 00000738 0000 80003658  x23:0011fd50 RA:0011fd50 f06=     -0.4387  # flw     ft6, 0(s7)
00000000 00000739 0000 8000365c  x23:0011fd50 RA:0011fd54 f07=      0.3098  # flw     ft7, 4(s7)
00000000 00000740 0000 80003660  x23:0011fd50 RA:0011fd58 f10=     -1.4471  # flw     fa0, 8(s7)
00000000 00000741 0000 80003664  x9:00000005                             # frep.o  s1, 2, 0, 0b0000
00000000 00000742 0000 80003668  f00:[      0.0000,       0.0000] f01:[      0.9604,       0.7281] f03:[      0.0000,       0.0000] f03=[      0.0000,       0.0000]  # vfmac.s ft3, ft0, ft1
00000000 00000743 0000 8000366c  f00:[      1.9269,       0.0000] f01:[      0.9604,       0.7281] f04:[      0.0000,       0.0000] f04=[      1.8507,       0.0000]  # vfmac.s ft4, ft0, ft1
00000000 00000744 0000 80003670  f00:[     -0.4974,       0.0000] f01:[      0.9604,       0.7281] f05:[      0.0000,       0.0000] f05=[     -0.4777,       0.0000]  # vfmac.s ft5, ft0, ft1
00000000 00000745 0000 80003668  f00:[      0.0000,       0.0000] f01:[      1.2683,      -0.4976] f03:[      0.0000,       0.0000] f03=[      0.0000,       0.0000]  # vfmac.s ft3, ft0, ft1
00000000 00000746 0000 8000366c  f00:[     -0.0431,      -2.1055] f01:[      1.2683,      -0.4976] f04:[      1.8507,       0.0000] f04=[      1.7961,       1.0478]  # vfmac.s ft4, ft0, ft1
00000000 00000747 0000 80003670  f00:[      1.2791,       1.0783] f01:[      1.2683,      -0.4976] f05:[     -0.4777,       0.0000] f05=[      1.1446,      -0.5366]  # vfmac.s ft5, ft0, ft1
00000000 00000748 0000 80003668  f00:[      1.9269,       0.0000] f01:[      0.5526,       1.7423] f03:[      0.0000,       0.0000] f03=[      1.0649,       0.0000]  # vfmac.s ft3, ft0, ft1
```

This issue was already mentioned here #322 