### PR TITLE
ssr: Add backpressure to config writes when job outstanding

### DIFF
--- a/hw/ip/snitch_ssr/src/snitch_ssr.sv
+++ b/hw/ip/snitch_ssr/src/snitch_ssr.sv
@@ -29,6 +29,7 @@ module snitch_ssr import snitch_ssr_pkg::*; #(
   input  logic        cfg_write_i,  // 0 = read, 1 = write
   output logic [31:0] cfg_rdata_o,
   input  logic [31:0] cfg_wdata_i,
+  output logic        cfg_wready_o,
   // Register lanes from switch.
   output data_t       lane_rdata_o,
   input  data_t       lane_wdata_i,
@@ -97,6 +98,7 @@ module snitch_ssr import snitch_ssr_pkg::*; #(
     .cfg_rdata_o,
     .cfg_wdata_i,
     .cfg_write_i,
+    .cfg_wready_o,
     .reg_rep_o      ( rep_max           ),
     .mem_addr_o     ( data_req.q.addr   ),
     .mem_zero_o     ( agen_zero         ),

--- a/hw/ip/snitch_ssr/src/snitch_ssr_addr_gen.sv
+++ b/hw/ip/snitch_ssr/src/snitch_ssr_addr_gen.sv
@@ -45,6 +45,7 @@ module snitch_ssr_addr_gen import snitch_ssr_pkg::*; #(
   output logic [31:0] cfg_rdata_o,
   input  logic [31:0] cfg_wdata_i,
   input  logic        cfg_write_i,
+  output logic        cfg_wready_o,
 
   output logic [Cfg.RptWidth-1:0] reg_rep_o,
 
@@ -433,6 +434,10 @@ module snitch_ssr_addr_gen import snitch_ssr_pkg::*; #(
 
     cfg_rdata_o = read_map[(cfg_word_i*32)+:32];
   end
+
+  // Block configuration writes iff there a pending shadowed job.
+  // This prevents job clobbering and stalls the master as needed.
+  assign cfg_wready_o = config_sq.done;
 
   // Parameter sanity checks
   `ASSERT_INIT(CheckPointerWidth, Cfg.PointerWidth <= AddrWidth);

--- a/hw/ip/snitch_ssr/test/fixture_ssr.sv
+++ b/hw/ip/snitch_ssr/test/fixture_ssr.sv
@@ -95,6 +95,7 @@ module fixture_ssr import snitch_ssr_pkg::*; #(
   logic         cfg_write_i;
   logic [31:0]  cfg_rdata_o;
   logic [31:0]  cfg_wdata_i;
+  logic         cfg_wready_o;
   logic         lane_valid_o;
   logic         lane_ready_i;
   tcdm_req_t    mem_req_o;
@@ -122,6 +123,7 @@ module fixture_ssr import snitch_ssr_pkg::*; #(
     .cfg_write_i,
     .cfg_rdata_o,
     .cfg_wdata_i,
+    .cfg_wready_o,
     .lane_rdata_o,
     .lane_wdata_i,
     .lane_valid_o,
@@ -208,7 +210,7 @@ module fixture_ssr import snitch_ssr_pkg::*; #(
   assign cfg_write_i    = cfg_bus.write;
   assign cfg_wdata_i    = cfg_bus.wdata;
   assign cfg_bus.rdata  = cfg_rdata_o;
-  assign cfg_bus.ready  = 1'b1;   // SSR always ready for config write
+  assign cfg_bus.ready  = ~cfg_bus.write | cfg_wready_o;
 
   // Register bus driver
   reg_test::reg_driver #(

--- a/hw/ip/snitch_ssr/test/fixture_ssr_streamer.sv
+++ b/hw/ip/snitch_ssr/test/fixture_ssr_streamer.sv
@@ -97,6 +97,7 @@ module fixture_ssr_streamer import snitch_ssr_pkg::*; #(
   logic                     cfg_write_i;
   logic [31:0]              cfg_rdata_o;
   logic [31:0]              cfg_wdata_i;
+  logic                     cfg_wready_o;
   logic  [RPorts-1:0][4:0]  ssr_raddr_i;
   data_t [RPorts-1:0]       ssr_rdata_o;
   logic  [RPorts-1:0]       ssr_rvalid_i;
@@ -134,6 +135,7 @@ module fixture_ssr_streamer import snitch_ssr_pkg::*; #(
     .cfg_write_i,
     .cfg_rdata_o,
     .cfg_wdata_i,
+    .cfg_wready_o,
     .ssr_raddr_i,
     .ssr_rdata_o,
     .ssr_rvalid_i,
@@ -276,7 +278,7 @@ module fixture_ssr_streamer import snitch_ssr_pkg::*; #(
   assign cfg_write_i    = cfg_bus.write;
   assign cfg_wdata_i    = cfg_bus.wdata;
   assign cfg_bus.rdata  = cfg_rdata_o;
-  assign cfg_bus.ready  = 1'b1;   // SSRs always ready for config write
+  assign cfg_bus.ready  = ~cfg_bus.write | cfg_wready_o;
 
   // Register bus driver
   reg_test::reg_driver #(


### PR DESCRIPTION
Blocks writes to the SSR configuration registers while a shadowed job is pending by adding backpressure (`cfg_wready_o`).

This enables the safe, repeated issuing of SSR jobs without any integer-FP synchronization or SSR done polling: the core can run ahead in job scheduling and is stalled as needed to prevent overwriting pending jobs until they are issued.

Note that if a faulty sequence of jobs and register accesses is programmed, this may cause semantic deadlocks between the core and SSRs; however, such deadlocks can always occur in faulty programs using SSRs.