### PR TITLE
occamy: Preserve ID widths until atomic adapters, add ATOP filters

### DIFF
--- a/hw/system/occamy/src/occamy_soc.sv
+++ b/hw/system/occamy/src/occamy_soc.sv
@@ -784,84 +784,64 @@ module occamy_soc
       .mst_req_o(hbm_xbar_in_req[HBM_XBAR_IN_WIDE_XBAR]),
       .mst_resp_i(hbm_xbar_in_rsp[HBM_XBAR_IN_WIDE_XBAR])
   );
-  axi_a48_d64_i4_u0_req_t  soc_narrow_wide_iwc_req;
-  axi_a48_d64_i4_u0_resp_t soc_narrow_wide_iwc_rsp;
-
-  axi_id_remap #(
-      .AxiSlvPortIdWidth(8),
-      .AxiSlvPortMaxUniqIds(16),
-      .AxiMaxTxnsPerId(4),
-      .AxiMstPortIdWidth(4),
-      .slv_req_t(axi_a48_d64_i8_u0_req_t),
-      .slv_resp_t(axi_a48_d64_i8_u0_resp_t),
-      .mst_req_t(axi_a48_d64_i4_u0_req_t),
-      .mst_resp_t(axi_a48_d64_i4_u0_resp_t)
-  ) i_soc_narrow_wide_iwc (
-      .clk_i(clk_i),
-      .rst_ni(rst_ni),
-      .slv_req_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE]),
-      .slv_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE]),
-      .mst_req_o(soc_narrow_wide_iwc_req),
-      .mst_resp_i(soc_narrow_wide_iwc_rsp)
-  );
-  axi_a48_d64_i4_u0_req_t  soc_narrow_wide_amo_adapter_req;
-  axi_a48_d64_i4_u0_resp_t soc_narrow_wide_amo_adapter_rsp;
+  axi_a48_d64_i8_u0_req_t  soc_narrow_wide_amo_adapter_req;
+  axi_a48_d64_i8_u0_resp_t soc_narrow_wide_amo_adapter_rsp;
 
   axi_riscv_atomics #(
       .AXI_ADDR_WIDTH(48),
       .AXI_DATA_WIDTH(64),
-      .AXI_ID_WIDTH(4),
+      .AXI_ID_WIDTH(8),
       .AXI_USER_WIDTH(1),
       .AXI_MAX_WRITE_TXNS(16),
       .RISCV_WORD_WIDTH(64)
   ) i_soc_narrow_wide_amo_adapter (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_aw_addr_i(soc_narrow_wide_iwc_req.aw.addr),
-      .slv_aw_prot_i(soc_narrow_wide_iwc_req.aw.prot),
-      .slv_aw_region_i(soc_narrow_wide_iwc_req.aw.region),
-      .slv_aw_atop_i(soc_narrow_wide_iwc_req.aw.atop),
-      .slv_aw_len_i(soc_narrow_wide_iwc_req.aw.len),
-      .slv_aw_size_i(soc_narrow_wide_iwc_req.aw.size),
-      .slv_aw_burst_i(soc_narrow_wide_iwc_req.aw.burst),
-      .slv_aw_lock_i(soc_narrow_wide_iwc_req.aw.lock),
-      .slv_aw_cache_i(soc_narrow_wide_iwc_req.aw.cache),
-      .slv_aw_qos_i(soc_narrow_wide_iwc_req.aw.qos),
-      .slv_aw_id_i(soc_narrow_wide_iwc_req.aw.id),
-      .slv_aw_user_i(soc_narrow_wide_iwc_req.aw.user),
-      .slv_aw_ready_o(soc_narrow_wide_iwc_rsp.aw_ready),
-      .slv_aw_valid_i(soc_narrow_wide_iwc_req.aw_valid),
-      .slv_ar_addr_i(soc_narrow_wide_iwc_req.ar.addr),
-      .slv_ar_prot_i(soc_narrow_wide_iwc_req.ar.prot),
-      .slv_ar_region_i(soc_narrow_wide_iwc_req.ar.region),
-      .slv_ar_len_i(soc_narrow_wide_iwc_req.ar.len),
-      .slv_ar_size_i(soc_narrow_wide_iwc_req.ar.size),
-      .slv_ar_burst_i(soc_narrow_wide_iwc_req.ar.burst),
-      .slv_ar_lock_i(soc_narrow_wide_iwc_req.ar.lock),
-      .slv_ar_cache_i(soc_narrow_wide_iwc_req.ar.cache),
-      .slv_ar_qos_i(soc_narrow_wide_iwc_req.ar.qos),
-      .slv_ar_id_i(soc_narrow_wide_iwc_req.ar.id),
-      .slv_ar_user_i(soc_narrow_wide_iwc_req.ar.user),
-      .slv_ar_ready_o(soc_narrow_wide_iwc_rsp.ar_ready),
-      .slv_ar_valid_i(soc_narrow_wide_iwc_req.ar_valid),
-      .slv_w_data_i(soc_narrow_wide_iwc_req.w.data),
-      .slv_w_strb_i(soc_narrow_wide_iwc_req.w.strb),
-      .slv_w_user_i(soc_narrow_wide_iwc_req.w.user),
-      .slv_w_last_i(soc_narrow_wide_iwc_req.w.last),
-      .slv_w_ready_o(soc_narrow_wide_iwc_rsp.w_ready),
-      .slv_w_valid_i(soc_narrow_wide_iwc_req.w_valid),
-      .slv_r_data_o(soc_narrow_wide_iwc_rsp.r.data),
-      .slv_r_resp_o(soc_narrow_wide_iwc_rsp.r.resp),
-      .slv_r_last_o(soc_narrow_wide_iwc_rsp.r.last),
-      .slv_r_id_o(soc_narrow_wide_iwc_rsp.r.id),
-      .slv_r_user_o(soc_narrow_wide_iwc_rsp.r.user),
-      .slv_r_ready_i(soc_narrow_wide_iwc_req.r_ready),
-      .slv_r_valid_o(soc_narrow_wide_iwc_rsp.r_valid),
-      .slv_b_resp_o(soc_narrow_wide_iwc_rsp.b.resp),
-      .slv_b_id_o(soc_narrow_wide_iwc_rsp.b.id),
-      .slv_b_user_o(soc_narrow_wide_iwc_rsp.b.user),
-      .slv_b_ready_i(soc_narrow_wide_iwc_req.b_ready),
-      .slv_b_valid_o(soc_narrow_wide_iwc_rsp.b_valid),
+      .slv_aw_addr_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.addr),
+      .slv_aw_prot_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.prot),
+      .slv_aw_region_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.region),
+      .slv_aw_atop_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.atop),
+      .slv_aw_len_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.len),
+      .slv_aw_size_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.size),
+      .slv_aw_burst_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.burst),
+      .slv_aw_lock_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.lock),
+      .slv_aw_cache_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.cache),
+      .slv_aw_qos_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.qos),
+      .slv_aw_id_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.id),
+      .slv_aw_user_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw.user),
+      .slv_aw_ready_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw_ready),
+      .slv_aw_valid_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].aw_valid),
+      .slv_ar_addr_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.addr),
+      .slv_ar_prot_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.prot),
+      .slv_ar_region_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.region),
+      .slv_ar_len_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.len),
+      .slv_ar_size_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.size),
+      .slv_ar_burst_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.burst),
+      .slv_ar_lock_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.lock),
+      .slv_ar_cache_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.cache),
+      .slv_ar_qos_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.qos),
+      .slv_ar_id_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.id),
+      .slv_ar_user_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar.user),
+      .slv_ar_ready_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar_ready),
+      .slv_ar_valid_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].ar_valid),
+      .slv_w_data_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].w.data),
+      .slv_w_strb_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].w.strb),
+      .slv_w_user_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].w.user),
+      .slv_w_last_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].w.last),
+      .slv_w_ready_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].w_ready),
+      .slv_w_valid_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].w_valid),
+      .slv_r_data_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].r.data),
+      .slv_r_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].r.resp),
+      .slv_r_last_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].r.last),
+      .slv_r_id_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].r.id),
+      .slv_r_user_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].r.user),
+      .slv_r_ready_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].r_ready),
+      .slv_r_valid_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].r_valid),
+      .slv_b_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].b.resp),
+      .slv_b_id_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].b.id),
+      .slv_b_user_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].b.user),
+      .slv_b_ready_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SOC_WIDE].b_ready),
+      .slv_b_valid_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SOC_WIDE].b_valid),
 
       .mst_aw_addr_o(soc_narrow_wide_amo_adapter_req.aw.addr),
       .mst_aw_prot_o(soc_narrow_wide_amo_adapter_req.aw.prot),
@@ -910,6 +890,26 @@ module occamy_soc
       .mst_b_valid_i(soc_narrow_wide_amo_adapter_rsp.b_valid)
   );
 
+  axi_a48_d64_i4_u0_req_t  soc_narrow_wide_iwc_req;
+  axi_a48_d64_i4_u0_resp_t soc_narrow_wide_iwc_rsp;
+
+  axi_id_remap #(
+      .AxiSlvPortIdWidth(8),
+      .AxiSlvPortMaxUniqIds(16),
+      .AxiMaxTxnsPerId(4),
+      .AxiMstPortIdWidth(4),
+      .slv_req_t(axi_a48_d64_i8_u0_req_t),
+      .slv_resp_t(axi_a48_d64_i8_u0_resp_t),
+      .mst_req_t(axi_a48_d64_i4_u0_req_t),
+      .mst_resp_t(axi_a48_d64_i4_u0_resp_t)
+  ) i_soc_narrow_wide_iwc (
+      .clk_i(clk_i),
+      .rst_ni(rst_ni),
+      .slv_req_i(soc_narrow_wide_amo_adapter_req),
+      .slv_resp_o(soc_narrow_wide_amo_adapter_rsp),
+      .mst_req_o(soc_narrow_wide_iwc_req),
+      .mst_resp_i(soc_narrow_wide_iwc_rsp)
+  );
   axi_dw_converter #(
       .AxiSlvPortDataWidth(64),
       .AxiMstPortDataWidth(512),
@@ -929,8 +929,8 @@ module occamy_soc
   ) i_soc_narrow_wide_dw (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(soc_narrow_wide_amo_adapter_req),
-      .slv_resp_o(soc_narrow_wide_amo_adapter_rsp),
+      .slv_req_i(soc_narrow_wide_iwc_req),
+      .slv_resp_o(soc_narrow_wide_iwc_rsp),
       .mst_req_o(soc_wide_xbar_in_req[SOC_WIDE_XBAR_IN_SOC_NARROW]),
       .mst_resp_i(soc_wide_xbar_in_rsp[SOC_WIDE_XBAR_IN_SOC_NARROW])
   );

--- a/hw/system/occamy/src/occamy_soc.sv
+++ b/hw/system/occamy/src/occamy_soc.sv
@@ -2180,89 +2180,64 @@ module occamy_soc
   //////////
   // SPM //
   //////////
-  axi_a48_d64_i1_u0_req_t  spm_serialize_req;
-  axi_a48_d64_i1_u0_resp_t spm_serialize_rsp;
-
-  axi_id_serialize #(
-      .AtopSupport(1),
-      .AxiSlvPortIdWidth(8),
-      .AxiSlvPortMaxTxns(4),
-      .AxiMstPortIdWidth(1),
-      .AxiMstPortMaxUniqIds(2),
-      .AxiMstPortMaxTxnsPerId(2),
-      .AxiAddrWidth(48),
-      .AxiDataWidth(64),
-      .AxiUserWidth(1),
-      .slv_req_t(axi_a48_d64_i8_u0_req_t),
-      .slv_resp_t(axi_a48_d64_i8_u0_resp_t),
-      .mst_req_t(axi_a48_d64_i1_u0_req_t),
-      .mst_resp_t(axi_a48_d64_i1_u0_resp_t)
-  ) i_spm_serialize (
-      .clk_i(clk_i),
-      .rst_ni(rst_ni),
-      .slv_req_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM]),
-      .slv_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM]),
-      .mst_req_o(spm_serialize_req),
-      .mst_resp_i(spm_serialize_rsp)
-  );
-  axi_a48_d64_i1_u0_req_t  spm_amo_adapter_req;
-  axi_a48_d64_i1_u0_resp_t spm_amo_adapter_rsp;
+  axi_a48_d64_i8_u0_req_t  spm_amo_adapter_req;
+  axi_a48_d64_i8_u0_resp_t spm_amo_adapter_rsp;
 
   axi_riscv_atomics #(
       .AXI_ADDR_WIDTH(48),
       .AXI_DATA_WIDTH(64),
-      .AXI_ID_WIDTH(1),
+      .AXI_ID_WIDTH(8),
       .AXI_USER_WIDTH(1),
       .AXI_MAX_WRITE_TXNS(16),
       .RISCV_WORD_WIDTH(64)
   ) i_spm_amo_adapter (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_aw_addr_i(spm_serialize_req.aw.addr),
-      .slv_aw_prot_i(spm_serialize_req.aw.prot),
-      .slv_aw_region_i(spm_serialize_req.aw.region),
-      .slv_aw_atop_i(spm_serialize_req.aw.atop),
-      .slv_aw_len_i(spm_serialize_req.aw.len),
-      .slv_aw_size_i(spm_serialize_req.aw.size),
-      .slv_aw_burst_i(spm_serialize_req.aw.burst),
-      .slv_aw_lock_i(spm_serialize_req.aw.lock),
-      .slv_aw_cache_i(spm_serialize_req.aw.cache),
-      .slv_aw_qos_i(spm_serialize_req.aw.qos),
-      .slv_aw_id_i(spm_serialize_req.aw.id),
-      .slv_aw_user_i(spm_serialize_req.aw.user),
-      .slv_aw_ready_o(spm_serialize_rsp.aw_ready),
-      .slv_aw_valid_i(spm_serialize_req.aw_valid),
-      .slv_ar_addr_i(spm_serialize_req.ar.addr),
-      .slv_ar_prot_i(spm_serialize_req.ar.prot),
-      .slv_ar_region_i(spm_serialize_req.ar.region),
-      .slv_ar_len_i(spm_serialize_req.ar.len),
-      .slv_ar_size_i(spm_serialize_req.ar.size),
-      .slv_ar_burst_i(spm_serialize_req.ar.burst),
-      .slv_ar_lock_i(spm_serialize_req.ar.lock),
-      .slv_ar_cache_i(spm_serialize_req.ar.cache),
-      .slv_ar_qos_i(spm_serialize_req.ar.qos),
-      .slv_ar_id_i(spm_serialize_req.ar.id),
-      .slv_ar_user_i(spm_serialize_req.ar.user),
-      .slv_ar_ready_o(spm_serialize_rsp.ar_ready),
-      .slv_ar_valid_i(spm_serialize_req.ar_valid),
-      .slv_w_data_i(spm_serialize_req.w.data),
-      .slv_w_strb_i(spm_serialize_req.w.strb),
-      .slv_w_user_i(spm_serialize_req.w.user),
-      .slv_w_last_i(spm_serialize_req.w.last),
-      .slv_w_ready_o(spm_serialize_rsp.w_ready),
-      .slv_w_valid_i(spm_serialize_req.w_valid),
-      .slv_r_data_o(spm_serialize_rsp.r.data),
-      .slv_r_resp_o(spm_serialize_rsp.r.resp),
-      .slv_r_last_o(spm_serialize_rsp.r.last),
-      .slv_r_id_o(spm_serialize_rsp.r.id),
-      .slv_r_user_o(spm_serialize_rsp.r.user),
-      .slv_r_ready_i(spm_serialize_req.r_ready),
-      .slv_r_valid_o(spm_serialize_rsp.r_valid),
-      .slv_b_resp_o(spm_serialize_rsp.b.resp),
-      .slv_b_id_o(spm_serialize_rsp.b.id),
-      .slv_b_user_o(spm_serialize_rsp.b.user),
-      .slv_b_ready_i(spm_serialize_req.b_ready),
-      .slv_b_valid_o(spm_serialize_rsp.b_valid),
+      .slv_aw_addr_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.addr),
+      .slv_aw_prot_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.prot),
+      .slv_aw_region_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.region),
+      .slv_aw_atop_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.atop),
+      .slv_aw_len_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.len),
+      .slv_aw_size_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.size),
+      .slv_aw_burst_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.burst),
+      .slv_aw_lock_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.lock),
+      .slv_aw_cache_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.cache),
+      .slv_aw_qos_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.qos),
+      .slv_aw_id_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.id),
+      .slv_aw_user_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw.user),
+      .slv_aw_ready_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].aw_ready),
+      .slv_aw_valid_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].aw_valid),
+      .slv_ar_addr_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.addr),
+      .slv_ar_prot_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.prot),
+      .slv_ar_region_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.region),
+      .slv_ar_len_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.len),
+      .slv_ar_size_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.size),
+      .slv_ar_burst_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.burst),
+      .slv_ar_lock_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.lock),
+      .slv_ar_cache_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.cache),
+      .slv_ar_qos_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.qos),
+      .slv_ar_id_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.id),
+      .slv_ar_user_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar.user),
+      .slv_ar_ready_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].ar_ready),
+      .slv_ar_valid_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].ar_valid),
+      .slv_w_data_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].w.data),
+      .slv_w_strb_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].w.strb),
+      .slv_w_user_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].w.user),
+      .slv_w_last_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].w.last),
+      .slv_w_ready_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].w_ready),
+      .slv_w_valid_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].w_valid),
+      .slv_r_data_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].r.data),
+      .slv_r_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].r.resp),
+      .slv_r_last_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].r.last),
+      .slv_r_id_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].r.id),
+      .slv_r_user_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].r.user),
+      .slv_r_ready_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].r_ready),
+      .slv_r_valid_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].r_valid),
+      .slv_b_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].b.resp),
+      .slv_b_id_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].b.id),
+      .slv_b_user_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].b.user),
+      .slv_b_ready_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_SPM].b_ready),
+      .slv_b_valid_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_SPM].b_valid),
 
       .mst_aw_addr_o(spm_amo_adapter_req.aw.addr),
       .mst_aw_prot_o(spm_amo_adapter_req.aw.prot),
@@ -2311,18 +2286,18 @@ module occamy_soc
       .mst_b_valid_i(spm_amo_adapter_rsp.b_valid)
   );
 
-  axi_a48_d64_i1_u0_req_t  spm_amo_adapter_cut_req;
-  axi_a48_d64_i1_u0_resp_t spm_amo_adapter_cut_rsp;
+  axi_a48_d64_i8_u0_req_t  spm_amo_adapter_cut_req;
+  axi_a48_d64_i8_u0_resp_t spm_amo_adapter_cut_rsp;
 
   axi_multicut #(
       .NoCuts(1),
-      .aw_chan_t(axi_a48_d64_i1_u0_aw_chan_t),
-      .w_chan_t(axi_a48_d64_i1_u0_w_chan_t),
-      .b_chan_t(axi_a48_d64_i1_u0_b_chan_t),
-      .ar_chan_t(axi_a48_d64_i1_u0_ar_chan_t),
-      .r_chan_t(axi_a48_d64_i1_u0_r_chan_t),
-      .req_t(axi_a48_d64_i1_u0_req_t),
-      .resp_t(axi_a48_d64_i1_u0_resp_t)
+      .aw_chan_t(axi_a48_d64_i8_u0_aw_chan_t),
+      .w_chan_t(axi_a48_d64_i8_u0_w_chan_t),
+      .b_chan_t(axi_a48_d64_i8_u0_b_chan_t),
+      .ar_chan_t(axi_a48_d64_i8_u0_ar_chan_t),
+      .r_chan_t(axi_a48_d64_i8_u0_r_chan_t),
+      .req_t(axi_a48_d64_i8_u0_req_t),
+      .resp_t(axi_a48_d64_i8_u0_resp_t)
   ) i_spm_amo_adapter_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
@@ -2343,11 +2318,11 @@ module occamy_soc
   mem_strb_t spm_strb;
 
   axi_to_mem #(
-      .axi_req_t(axi_a48_d64_i1_u0_req_t),
-      .axi_resp_t(axi_a48_d64_i1_u0_resp_t),
+      .axi_req_t(axi_a48_d64_i8_u0_req_t),
+      .axi_resp_t(axi_a48_d64_i8_u0_resp_t),
       .AddrWidth(17),
       .DataWidth(64),
-      .IdWidth(1),
+      .IdWidth(8),
       .NumBanks(1),
       .BufDepth(1)
   ) i_axi_to_mem (

--- a/hw/system/occamy/src/occamy_soc.sv
+++ b/hw/system/occamy/src/occamy_soc.sv
@@ -990,6 +990,23 @@ module occamy_soc
   //////////
   // PCIe //
   //////////
+  axi_a48_d64_i8_u0_req_t  pcie_out_noatop_req;
+  axi_a48_d64_i8_u0_resp_t pcie_out_noatop_rsp;
+
+  axi_atop_filter #(
+      .AxiIdWidth(8),
+      .AxiMaxWriteTxns(32),
+      .req_t(axi_a48_d64_i8_u0_req_t),
+      .resp_t(axi_a48_d64_i8_u0_resp_t)
+  ) i_axi_atop_filter (
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_PCIE]),
+      .slv_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_PCIE]),
+      .mst_req_o (pcie_out_noatop_req),
+      .mst_resp_i(pcie_out_noatop_rsp)
+  );
+
   axi_a48_d64_i8_u0_req_t  pcie_out_req;
   axi_a48_d64_i8_u0_resp_t pcie_out_rsp;
 
@@ -1005,8 +1022,8 @@ module occamy_soc
   ) i_pcie_out_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_PCIE]),
-      .slv_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_PCIE]),
+      .slv_req_i(pcie_out_noatop_req),
+      .slv_resp_o(pcie_out_noatop_rsp),
       .mst_req_o(pcie_out_req),
       .mst_resp_i(pcie_out_rsp)
   );
@@ -2601,6 +2618,23 @@ module occamy_soc
       .mst_resp_i(wide_to_hbi_trunc_rsp)
   );
 
+  axi_a48_d512_i6_u0_req_t  wide_to_hbi_noatop_req;
+  axi_a48_d512_i6_u0_resp_t wide_to_hbi_noatop_rsp;
+
+  axi_atop_filter #(
+      .AxiIdWidth(6),
+      .AxiMaxWriteTxns(32),
+      .req_t(axi_a48_d512_i6_u0_req_t),
+      .resp_t(axi_a48_d512_i6_u0_resp_t)
+  ) i_axi_atop_filter (
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .slv_req_i (wide_to_hbi_trunc_req),
+      .slv_resp_o(wide_to_hbi_trunc_rsp),
+      .mst_req_o (wide_to_hbi_noatop_req),
+      .mst_resp_i(wide_to_hbi_noatop_rsp)
+  );
+
   axi_a48_d512_i6_u0_req_t  wide_to_hbi_cut_req;
   axi_a48_d512_i6_u0_resp_t wide_to_hbi_cut_rsp;
 
@@ -2616,8 +2650,8 @@ module occamy_soc
   ) i_wide_to_hbi_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(wide_to_hbi_trunc_req),
-      .slv_resp_o(wide_to_hbi_trunc_rsp),
+      .slv_req_i(wide_to_hbi_noatop_req),
+      .slv_resp_o(wide_to_hbi_noatop_rsp),
       .mst_req_o(wide_to_hbi_cut_req),
       .mst_resp_i(wide_to_hbi_cut_rsp)
   );
@@ -2676,6 +2710,23 @@ module occamy_soc
   /////////////////
   // Peripherals //
   /////////////////
+  axi_a48_d64_i8_u0_req_t  periph_regbus_out_noatop_req;
+  axi_a48_d64_i8_u0_resp_t periph_regbus_out_noatop_rsp;
+
+  axi_atop_filter #(
+      .AxiIdWidth(8),
+      .AxiMaxWriteTxns(4),
+      .req_t(axi_a48_d64_i8_u0_req_t),
+      .resp_t(axi_a48_d64_i8_u0_resp_t)
+  ) i_axi_atop_filter (
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_REGBUS_PERIPH]),
+      .slv_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_REGBUS_PERIPH]),
+      .mst_req_o (periph_regbus_out_noatop_req),
+      .mst_resp_i(periph_regbus_out_noatop_rsp)
+  );
+
   axi_a48_d64_i8_u0_req_t  periph_regbus_out_req;
   axi_a48_d64_i8_u0_resp_t periph_regbus_out_rsp;
 
@@ -2691,11 +2742,28 @@ module occamy_soc
   ) i_periph_regbus_out_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_REGBUS_PERIPH]),
-      .slv_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_REGBUS_PERIPH]),
+      .slv_req_i(periph_regbus_out_noatop_req),
+      .slv_resp_o(periph_regbus_out_noatop_rsp),
       .mst_req_o(periph_regbus_out_req),
       .mst_resp_i(periph_regbus_out_rsp)
   );
+  axi_a48_d64_i8_u0_req_t  periph_axi_lite_out_noatop_req;
+  axi_a48_d64_i8_u0_resp_t periph_axi_lite_out_noatop_rsp;
+
+  axi_atop_filter #(
+      .AxiIdWidth(8),
+      .AxiMaxWriteTxns(4),
+      .req_t(axi_a48_d64_i8_u0_req_t),
+      .resp_t(axi_a48_d64_i8_u0_resp_t)
+  ) i_axi_atop_filter (
+      .clk_i     (clk_i),
+      .rst_ni    (rst_ni),
+      .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_PERIPH]),
+      .slv_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_PERIPH]),
+      .mst_req_o (periph_axi_lite_out_noatop_req),
+      .mst_resp_i(periph_axi_lite_out_noatop_rsp)
+  );
+
   axi_a48_d64_i8_u0_req_t  periph_axi_lite_out_req;
   axi_a48_d64_i8_u0_resp_t periph_axi_lite_out_rsp;
 
@@ -2711,8 +2779,8 @@ module occamy_soc
   ) i_periph_axi_lite_out_cut (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
-      .slv_req_i(soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_PERIPH]),
-      .slv_resp_o(soc_narrow_xbar_out_rsp[SOC_NARROW_XBAR_OUT_PERIPH]),
+      .slv_req_i(periph_axi_lite_out_noatop_req),
+      .slv_resp_o(periph_axi_lite_out_noatop_rsp),
       .mst_req_o(periph_axi_lite_out_req),
       .mst_resp_i(periph_axi_lite_out_rsp)
   );

--- a/hw/system/occamy/src/occamy_soc.sv.tpl
+++ b/hw/system/occamy/src/occamy_soc.sv.tpl
@@ -229,7 +229,6 @@ module ${name}_soc
   // SPM //
   //////////
   <% narrow_spm_mst = soc_narrow_xbar.out_spm \
-                      .serialize(context, "spm_serialize", iw=1) \
                       .atomic_adapter(context, max_atomics_narrow, "spm_amo_adapter") \
                       .cut(context, cuts_narrow_conv_to_spm)
   %>\

--- a/hw/system/occamy/src/occamy_soc.sv.tpl
+++ b/hw/system/occamy/src/occamy_soc.sv.tpl
@@ -136,8 +136,8 @@ module ${name}_soc
     #// narrow xbar -> wide xbar & wide xbar -> narrow xbar
     soc_narrow_xbar.out_soc_wide \
       .cut(context, cuts_narrow_and_wide) \
-      .change_iw(context, soc_wide_xbar.in_soc_narrow.iw, "soc_narrow_wide_iwc", max_txns_per_id=txns_narrow_and_wide) \
       .atomic_adapter(context, max_atomics_narrow, "soc_narrow_wide_amo_adapter") \
+      .change_iw(context, soc_wide_xbar.in_soc_narrow.iw, "soc_narrow_wide_iwc", max_txns_per_id=txns_narrow_and_wide) \
       .change_dw(context, soc_wide_xbar.in_soc_narrow.dw, "soc_narrow_wide_dw", to=soc_wide_xbar.in_soc_narrow)
     soc_wide_xbar.out_soc_narrow \
       .change_iw(context, soc_narrow_xbar.in_soc_wide.iw, "soc_wide_narrow_iwc", max_txns_per_id=txns_narrow_and_wide) \

--- a/util/solder/solder.axi_atop_filter.sv.tpl
+++ b/util/solder/solder.axi_atop_filter.sv.tpl
@@ -1,0 +1,13 @@
+  axi_atop_filter #(
+    .AxiIdWidth (${bus_in.iw}),
+    .AxiMaxWriteTxns (${max_trans}),
+    .req_t (${bus_in.req_type()}),
+    .resp_t (${bus_in.rsp_type()})
+  ) i_axi_atop_filter (
+    .clk_i     (${bus_in.clk}),
+    .rst_ni    (${bus_in.rst}),
+    .slv_req_i (${bus_in.req_name()}),
+    .slv_resp_o(${bus_in.rsp_name()}),
+    .mst_req_o (${bus_out.req_name()}),
+    .mst_resp_i(${bus_out.rsp_name()})
+  );

--- a/util/solder/solder.py
+++ b/util/solder/solder.py
@@ -800,9 +800,12 @@ class AxiBus(Bus):
                        max_trans=1,
                        name=None,
                        inst_name=None,
-                       to=None):
+                       to=None,
+                       # Instantiate filter instead, blocking atomics
+                       filter=False):
 
-        name = name or "{}_atomic_adapter".format(self.name)
+        name = name or ("{}_atomic_adapter" if not filter else
+                        "{}_atop_filter").format(self.name)
 
         # Generate the new bus.
         if to is None:
@@ -823,7 +826,8 @@ class AxiBus(Bus):
 
         # Emit the cut instance.
         bus.declare(context)
-        tpl = templates.get_template("solder.axi_atomic_adapter.sv.tpl")
+        tpl = templates.get_template("solder.axi_atomic_adapter.sv.tpl" if not filter else
+                                     "solder.axi_atop_filter.sv.tpl")
         context.write(
             tpl.render_unicode(
                 bus_in=self,


### PR DESCRIPTION
* Remove ID serializer in front of SPM
* Move narrow-to-wide ID width conversion behind atomics adapter
* Add ATOP filters in front of all atomics-incapable narrow slaves