### PR TITLE
solder: Parametrize ATOP template instance name

### DIFF
--- a/hw/system/occamy/src/occamy_soc.sv
+++ b/hw/system/occamy/src/occamy_soc.sv
@@ -998,7 +998,7 @@ module occamy_soc
       .AxiMaxWriteTxns(32),
       .req_t(axi_a48_d64_i8_u0_req_t),
       .resp_t(axi_a48_d64_i8_u0_resp_t)
-  ) i_axi_atop_filter (
+  ) pcie_out_atop_filter (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_PCIE]),
@@ -2626,7 +2626,7 @@ module occamy_soc
       .AxiMaxWriteTxns(32),
       .req_t(axi_a48_d512_i6_u0_req_t),
       .resp_t(axi_a48_d512_i6_u0_resp_t)
-  ) i_axi_atop_filter (
+  ) wide_to_hbi_atop_filter (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .slv_req_i (wide_to_hbi_trunc_req),
@@ -2718,7 +2718,7 @@ module occamy_soc
       .AxiMaxWriteTxns(4),
       .req_t(axi_a48_d64_i8_u0_req_t),
       .resp_t(axi_a48_d64_i8_u0_resp_t)
-  ) i_axi_atop_filter (
+  ) periph_regbus_out_atop_filter (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_REGBUS_PERIPH]),
@@ -2755,7 +2755,7 @@ module occamy_soc
       .AxiMaxWriteTxns(4),
       .req_t(axi_a48_d64_i8_u0_req_t),
       .resp_t(axi_a48_d64_i8_u0_resp_t)
-  ) i_axi_atop_filter (
+  ) periph_axi_lite_out_atop_filter (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_PERIPH]),

--- a/util/solder/solder.axi_atop_filter.sv.tpl
+++ b/util/solder/solder.axi_atop_filter.sv.tpl
@@ -3,7 +3,7 @@
     .AxiMaxWriteTxns (${max_trans}),
     .req_t (${bus_in.req_type()}),
     .resp_t (${bus_in.rsp_type()})
-  ) i_axi_atop_filter (
+  ) ${name} (
     .clk_i     (${bus_in.clk}),
     .rst_ni    (${bus_in.rst}),
     .slv_req_i (${bus_in.req_name()}),


### PR DESCRIPTION
The name of the ATOP filter instance is hardcoded which results in multiple instances that are called `i_axi_atop_filter ` which does not compile.

See for example `occamy_soc.sv`