### PR TITLE
occamy: Fix `axi_atop_filter` instantiation names

### DIFF
--- a/hw/system/occamy/src/occamy_soc.sv
+++ b/hw/system/occamy/src/occamy_soc.sv
@@ -900,7 +900,7 @@ module occamy_soc
       .AxiMaxWriteTxns(32),
       .req_t(axi_a48_d64_i8_u0_req_t),
       .resp_t(axi_a48_d64_i8_u0_resp_t)
-  ) pcie_out_atop_filter (
+  ) i_pcie_out_atop_filter (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_PCIE]),
@@ -2252,7 +2252,7 @@ module occamy_soc
       .AxiMaxWriteTxns(32),
       .req_t(axi_a48_d512_i6_u0_req_t),
       .resp_t(axi_a48_d512_i6_u0_resp_t)
-  ) wide_to_hbi_atop_filter (
+  ) i_wide_to_hbi_atop_filter (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .slv_req_i (wide_to_hbi_trunc_req),
@@ -2344,7 +2344,7 @@ module occamy_soc
       .AxiMaxWriteTxns(4),
       .req_t(axi_a48_d64_i8_u0_req_t),
       .resp_t(axi_a48_d64_i8_u0_resp_t)
-  ) periph_regbus_out_atop_filter (
+  ) i_periph_regbus_out_atop_filter (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_REGBUS_PERIPH]),
@@ -2381,7 +2381,7 @@ module occamy_soc
       .AxiMaxWriteTxns(4),
       .req_t(axi_a48_d64_i8_u0_req_t),
       .resp_t(axi_a48_d64_i8_u0_resp_t)
-  ) periph_axi_lite_out_atop_filter (
+  ) i_periph_axi_lite_out_atop_filter (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .slv_req_i (soc_narrow_xbar_out_req[SOC_NARROW_XBAR_OUT_PERIPH]),

--- a/hw/system/occamy/src/occamy_soc.sv.tpl
+++ b/hw/system/occamy/src/occamy_soc.sv.tpl
@@ -152,7 +152,7 @@ module ${name}_soc
   //////////
   <%
     pcie_out = soc_narrow_xbar.__dict__["out_pcie"] \
-      .atomic_adapter(context, filter=True, max_trans=max_trans_atop_filter_ser, name="pcie_out_noatop", inst_name="pcie_out_atop_filter") \
+      .atomic_adapter(context, filter=True, max_trans=max_trans_atop_filter_ser, name="pcie_out_noatop", inst_name="i_pcie_out_atop_filter") \
       .cut(context, cuts_narrow_and_pcie, name="pcie_out", inst_name="i_pcie_out_cut")
     pcie_in = soc_narrow_xbar.__dict__["in_pcie"].copy(name="pcie_in").declare(context)
     pcie_in.cut(context, cuts_narrow_and_pcie, to=soc_narrow_xbar.__dict__["in_pcie"])
@@ -318,7 +318,7 @@ module ${name}_soc
     hbi_in_wide_soc.cut(context, cuts_wide_and_hbi, name="hbi_to_wide_cut", to=soc_wide_xbar.in_hbi)
     hbi_out_wide_soc = soc_wide_xbar.out_hbi \
       .trunc_addr(context, hbi_trunc_addr_width, name="wide_to_hbi_trunc") \
-      .atomic_adapter(context, filter=True, max_trans=max_trans_atop_filter_ser, name="wide_to_hbi_noatop", inst_name="wide_to_hbi_atop_filter") \
+      .atomic_adapter(context, filter=True, max_trans=max_trans_atop_filter_ser, name="wide_to_hbi_noatop", inst_name="i_wide_to_hbi_atop_filter") \
       .cut(context, cuts_wide_and_hbi, name="wide_to_hbi_cut")
     #// hbi <-> narrow xbar
     hbi_in_narrow_soc = soc_narrow_xbar.in_hbi.copy(name="hbi_in_narrow_soc").declare(context)
@@ -363,10 +363,10 @@ module ${name}_soc
   /////////////////
   <%
     periph_regbus_out = soc_narrow_xbar.__dict__["out_regbus_periph"] \
-      .atomic_adapter(context, filter=True, max_trans=max_trans_atop_filter_per, name="periph_regbus_out_noatop", inst_name="periph_regbus_out_atop_filter") \
+      .atomic_adapter(context, filter=True, max_trans=max_trans_atop_filter_per, name="periph_regbus_out_noatop", inst_name="i_periph_regbus_out_atop_filter") \
       .cut(context, cuts_periph_regbus, name="periph_regbus_out", inst_name="i_periph_regbus_out_cut")
     periph_axi_lite_out = soc_narrow_xbar.__dict__["out_periph"] \
-      .atomic_adapter(context, filter=True, max_trans=max_trans_atop_filter_per, name="periph_axi_lite_out_noatop", inst_name="periph_axi_lite_out_atop_filter") \
+      .atomic_adapter(context, filter=True, max_trans=max_trans_atop_filter_per, name="periph_axi_lite_out_noatop", inst_name="i_periph_axi_lite_out_atop_filter") \
       .cut(context, cuts_periph_axi_lite, name="periph_axi_lite_out", inst_name="i_periph_axi_lite_out_cut") \
 
     periph_axi_lite_in = soc_narrow_xbar.__dict__["in_periph"].copy(name="periph_axi_lite_in").declare(context)


### PR DESCRIPTION
Add missing `i_` prefix on instance names of `axi_atop_filter`.

**Dependency:** first PR #351 should be merged.

Proposal: should we add the compilation of the occamy system to CI to prevent further mistakes like this?