### PR TITLE
occamy: Add missing routes to HBM config crossbar

### DIFF
--- a/hw/system/occamy/src/occamy_pkg.sv
+++ b/hw/system/occamy/src/occamy_pkg.sv
@@ -218,7 +218,7 @@ package occamy_pkg;
   } soc_regbus_periph_xbar_outputs_e;
 
   /// Address map of the `soc_regbus_periph_xbar` crossbar.
-  localparam xbar_rule_48_t [13:0] SocRegbusPeriphXbarAddrmap = '{
+  localparam xbar_rule_48_t [14:0] SocRegbusPeriphXbarAddrmap = '{
   '{ idx: 0, start_addr: 48'h02000000, end_addr: 48'h02001000 },
   '{ idx: 1, start_addr: 48'h02001000, end_addr: 48'h02002000 },
   '{ idx: 2, start_addr: 48'h02002000, end_addr: 48'h02003000 },
@@ -232,7 +232,8 @@ package occamy_pkg;
   '{ idx: 10, start_addr: 48'h07000000, end_addr: 48'h07010000 },
   '{ idx: 11, start_addr: 48'h0c000000, end_addr: 48'h10000000 },
   '{ idx: 12, start_addr: 48'h01000000, end_addr: 48'h01020000 },
-  '{ idx: 13, start_addr: 48'h04000000, end_addr: 48'h04100000 }
+  '{ idx: 13, start_addr: 48'h04000000, end_addr: 48'h04100000 },
+  '{ idx: 14, start_addr: 48'h08000000, end_addr: 48'h0a810000 }
 };
 
   /// Inputs of the `quadrant_pre_xbar_0` crossbar.

--- a/hw/system/occamy/src/occamy_soc.sv
+++ b/hw/system/occamy/src/occamy_soc.sv
@@ -515,7 +515,7 @@ module occamy_soc
   '{ idx: 6, start_addr: 48'h80000000, end_addr: 48'h20000000000 },
   '{ idx: 8, start_addr: 48'h00000000, end_addr: 48'h00001000 },
   '{ idx: 9, start_addr: 48'h70000000, end_addr: 48'h70080000 },
-  '{ idx: 10, start_addr: 48'h01000000, end_addr: 48'h07010000 },
+  '{ idx: 10, start_addr: 48'h01000000, end_addr: 48'h0a810000 },
   '{ idx: 10, start_addr: 48'h0c000000, end_addr: 48'h10000000 },
   '{ idx: 11, start_addr: 48'h20000000, end_addr: 48'h70000000 },
   '{ idx: 0, start_addr: s1_quadrant_base_addr[0], end_addr: s1_quadrant_base_addr[0] + S1QuadrantAddressSpace },

--- a/hw/system/occamy/src/occamy_top.sv
+++ b/hw/system/occamy/src/occamy_top.sv
@@ -202,7 +202,7 @@ SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS
 
   addr_decode #(
       .NoIndices(SOC_REGBUS_PERIPH_XBAR_NUM_OUTPUTS),
-      .NoRules(14),
+      .NoRules(15),
       .addr_t(logic [47:0]),
       .rule_t(xbar_rule_48_t)
   ) i_addr_decode_soc_regbus_periph_xbar (

--- a/util/occamygen.py
+++ b/util/occamygen.py
@@ -480,6 +480,8 @@ def main():
 
     hbm_cfg_xbar.add_input("cfg")
 
+    am_soc_regbus_periph_xbar.attach(am_hbm_cfg_xbar)
+
     ##########
     # RegBus #
     ##########

--- a/util/occamygen.py
+++ b/util/occamygen.py
@@ -432,7 +432,8 @@ def main():
     # Connect wide xbar
     am_soc_wide_xbar.attach(am_soc_narrow_xbar)
 
-    # Generate crossbars.
+    # Connect HBM config xbar to regbus xbar
+    am_soc_regbus_periph_xbar.attach(am_hbm_cfg_xbar)
 
     #######################
     # SoC Peripheral Xbar #
@@ -479,8 +480,6 @@ def main():
         hbm_cfg_xbar.add_output_entry(name, leaf)
 
     hbm_cfg_xbar.add_input("cfg")
-
-    am_soc_regbus_periph_xbar.attach(am_hbm_cfg_xbar)
 
     ##########
     # RegBus #


### PR DESCRIPTION
Adds a missing attachment in `occamygen` of HBM config xbar to Occamy's config xbar, making the latter accessible.