### PR TITLE
dma: Properly handle 2D request with single repetition

### DIFF
--- a/hw/ip/snitch_dma/src/axi_dma_twod_ext.sv
+++ b/hw/ip/snitch_dma/src/axi_dma_twod_ext.sv
@@ -85,7 +85,7 @@ module axi_dma_twod_ext #(
         // 1D Case
         //--------------------------------------
         // in the case that we have a 1D transfer, hand the transfer out
-        if (!twod_req_current.is_twod) begin
+        if (!twod_req_current.is_twod || twod_req_current.num_repetitions == 'h1) begin
             // bypass the 1D parameters
             burst_req_o.id           = twod_req_current.id;
             burst_req_o.src          = twod_req_current.src;


### PR DESCRIPTION
Currently 2D requests with num_repetitions=1 will cause an error in the
DMA, being improperly handled. This will handle 2D requests with
num_reps=1 as 1D requests.