### PR TITLE
snRuntime: Replace AMOSWAP with SW in lock release

### DIFF
--- a/sw/snRuntime/include/snrt.h
+++ b/sw/snRuntime/include/snrt.h
@@ -298,8 +298,7 @@ static inline void snrt_mutex_ttas_lock(volatile uint32_t *pmtx) {
  * @brief Release the mutex
  */
 static inline void snrt_mutex_release(volatile uint32_t *pmtx) {
-    asm volatile("amoswap.w.rl  x0,x0,(%0)   # Release lock by storing 0\n"
-                 : "+r"(pmtx));
+    *pmtx = 0;
 }
 
 //================================================================================


### PR DESCRIPTION
Atomic operation not needed on release. Replacing it with a normal store should improve performance minorly.