### PR TITLE
vendor: Update `fpnew` to fix FMA bug

### DIFF
--- a/hw/vendor/pulp_platform_fpnew.lock.hjson
+++ b/hw/vendor/pulp_platform_fpnew.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/fpnew.git
-    rev: edf287f7aa9fff197ec3ed9af584af93f1754884
+    rev: d4bd9cc844f7d86e24b9ae432919b28f747687e0
   }
 }

--- a/hw/vendor/pulp_platform_fpnew/src/fpnew_fma.sv
+++ b/hw/vendor/pulp_platform_fpnew/src/fpnew_fma.sv
@@ -66,8 +66,8 @@ module fpnew_fma #(
   // datapath leakage. This is either given by the exponent bits or the width of the LZC result.
   // In most reasonable FP formats the internal exponent will be wider than the LZC result.
   localparam int unsigned EXP_WIDTH = unsigned'(fpnew_pkg::maximum(EXP_BITS + 2, LZC_RESULT_WIDTH));
-  // Shift amount width: maximum internal mantissa size is 3p+3 bits
-  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(3 * PRECISION_BITS + 3);
+  // Shift amount width: maximum internal mantissa size is 3p+4 bits
+  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(3 * PRECISION_BITS + 5);
   // Pipelines
   localparam NUM_INP_REGS = PipeConfig == fpnew_pkg::BEFORE
                             ? NumPipeRegs

--- a/hw/vendor/pulp_platform_fpnew/src/fpnew_fma_multi.sv
+++ b/hw/vendor/pulp_platform_fpnew/src/fpnew_fma_multi.sv
@@ -72,8 +72,8 @@ module fpnew_fma_multi #(
   // datapath leakage. This is either given by the exponent bits or the width of the LZC result.
   // In most reasonable FP formats the internal exponent will be wider than the LZC result.
   localparam int unsigned EXP_WIDTH = fpnew_pkg::maximum(SUPER_EXP_BITS + 2, LZC_RESULT_WIDTH);
-  // Shift amount width: maximum internal mantissa size is 3p+3 bits
-  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(3 * PRECISION_BITS + 3);
+  // Shift amount width: maximum internal mantissa size is 3p+4 bits
+  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(3 * PRECISION_BITS + 5);
   // Pipelines
   localparam NUM_INP_REGS = PipeConfig == fpnew_pkg::BEFORE
                             ? NumPipeRegs


### PR DESCRIPTION
vendor: Update FPnew
Fix bug in `fpnew_fma` and `fpnew_fma_multi` triggered by the fp8alt format. The `SHIFT_AMOUNT_WIDTH` parameter was not large enough to represent the maximum shift