### PR TITLE
axi-riscv-atomics: Update to latest version

### DIFF
--- a/hw/ip/test/src/tb_memory_axi.sv
+++ b/hw/ip/test/src/tb_memory_axi.sv
@@ -60,6 +60,7 @@ module tb_memory_axi #(
       .AXI_DATA_WIDTH (AxiDataWidth),
       .AXI_ID_WIDTH (AxiIdWidth),
       .AXI_USER_WIDTH (AxiUserWidth),
+      .AXI_MAX_READ_TXNS (2),
       .AXI_MAX_WRITE_TXNS (2),
       .RISCV_WORD_WIDTH (32)
     ) i_axi_riscv_atomics_wrap (

--- a/hw/system/occamy/src/occamy_soc.sv
+++ b/hw/system/occamy/src/occamy_soc.sv
@@ -720,7 +720,11 @@ module occamy_soc
       .AXI_DATA_WIDTH(64),
       .AXI_ID_WIDTH(8),
       .AXI_USER_WIDTH(1),
+      .AXI_MAX_READ_TXNS(16),
       .AXI_MAX_WRITE_TXNS(16),
+      .AXI_USER_AS_ID(0),
+      .AXI_USER_ID_MSB(0),
+      .AXI_USER_ID_LSB(0),
       .RISCV_WORD_WIDTH(64)
   ) i_soc_narrow_wide_amo_adapter (
       .clk_i(clk_i),
@@ -1851,7 +1855,11 @@ module occamy_soc
       .AXI_DATA_WIDTH(64),
       .AXI_ID_WIDTH(8),
       .AXI_USER_WIDTH(1),
+      .AXI_MAX_READ_TXNS(16),
       .AXI_MAX_WRITE_TXNS(16),
+      .AXI_USER_AS_ID(0),
+      .AXI_USER_ID_MSB(0),
+      .AXI_USER_ID_LSB(0),
       .RISCV_WORD_WIDTH(64)
   ) i_spm_narrow_amo_adapter (
       .clk_i(clk_i),

--- a/hw/system/occamy/src/occamy_soc.sv.tpl
+++ b/hw/system/occamy/src/occamy_soc.sv.tpl
@@ -149,7 +149,7 @@ module ${name}_soc
     #// narrow xbar -> wide xbar & wide xbar -> narrow xbar
     soc_narrow_xbar.out_soc_wide \
       .cut(context, cuts_narrow_and_wide) \
-      .atomic_adapter(context, max_atomics_narrow, "soc_narrow_wide_amo_adapter") \
+      .atomic_adapter(context, max_trans=max_atomics_narrow, user_as_id=0, user_id_msb=0 , user_id_lsb=0, name="soc_narrow_wide_amo_adapter") \
       .change_iw(context, soc_wide_xbar.in_soc_narrow.iw, "soc_narrow_wide_iwc", max_txns_per_id=txns_narrow_and_wide) \
       .change_dw(context, soc_wide_xbar.in_soc_narrow.dw, "soc_narrow_wide_dw", to=soc_wide_xbar.in_soc_narrow)
     soc_wide_xbar.out_soc_narrow \
@@ -243,7 +243,7 @@ module ${name}_soc
   // SPM NARROW //
   ////////////////
   <% narrow_spm_mst = soc_narrow_xbar.out_spm_narrow \
-                      .atomic_adapter(context, max_atomics_narrow, "spm_narrow_amo_adapter") \
+                      .atomic_adapter(context, max_trans=max_atomics_narrow, user_as_id=0, user_id_msb=0, user_id_lsb=0, name="spm_narrow_amo_adapter") \
                       .cut(context, cuts_narrow_conv_to_spm_narrow)
   %>\
 

--- a/hw/vendor/patches/pulp_platform_axi_riscv_atomics/0001-axi_riscv_atomics-Remove-timeunit-in-testbench.patch
+++ b/hw/vendor/patches/pulp_platform_axi_riscv_atomics/0001-axi_riscv_atomics-Remove-timeunit-in-testbench.patch
@@ -1,0 +1,26 @@
+From 71457e7936957e345780a1c28af835c62ad98fdd Mon Sep 17 00:00:00 2001
+From: Samuel Riedel <sriedel@iis.ee.ethz.ch>
+Date: Tue, 3 May 2022 18:45:27 +0200
+Subject: [PATCH] axi_riscv_atomics: Remove timeunit in testbench
+
+---
+ test/axi_riscv_lrsc_tb.sv | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/test/axi_riscv_lrsc_tb.sv b/test/axi_riscv_lrsc_tb.sv
+index 9abbea54..937ef171 100644
+--- a/test/axi_riscv_lrsc_tb.sv
++++ b/test/axi_riscv_lrsc_tb.sv
+@@ -31,9 +31,6 @@ module axi_riscv_lrsc_tb #(
+     parameter bit VERBOSE = 1'b0
+ );
+ 
+-    timeunit 1ns;
+-    timeprecision 10ps;
+-
+     localparam time TCLK = 10ns;
+     localparam time TA = TCLK * 1/4;
+     localparam time TT = TCLK * 3/4;
+-- 
+2.16.5
+

--- a/hw/vendor/patches/pulp_platform_common_cells/0006-common_cells-Patch-ID-queue-for-VCS.patch
+++ b/hw/vendor/patches/pulp_platform_common_cells/0006-common_cells-Patch-ID-queue-for-VCS.patch
@@ -1,0 +1,44 @@
+From c85700cdf32cf7fdf290bee97c8928b97144469c Mon Sep 17 00:00:00 2001
+From: Samuel Riedel <sriedel@iis.ee.ethz.ch>
+Date: Thu, 28 Apr 2022 18:10:47 +0200
+Subject: [PATCH] common_cells: Patch ID queue for VCS
+
+---
+ src/id_queue.sv | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/id_queue.sv b/src/id_queue.sv
+index 2ba347e3..65373f6d 100644
+--- a/src/id_queue.sv
++++ b/src/id_queue.sv
+@@ -51,8 +51,7 @@ module id_queue #(
+     parameter bit FULL_BW   = 0,
+     parameter type data_t   = logic,
+     // Dependent parameters, DO NOT OVERRIDE!
+-    localparam type id_t    = logic[ID_WIDTH-1:0],
+-    localparam type mask_t  = logic[$bits(data_t)-1:0]
++    localparam type id_t    = logic[ID_WIDTH-1:0]
+ ) (
+     input  logic    clk_i,
+     input  logic    rst_ni,
+@@ -63,7 +62,7 @@ module id_queue #(
+     output logic    inp_gnt_o,
+ 
+     input  data_t   exists_data_i,
+-    input  mask_t   exists_mask_i,
++    input  data_t   exists_mask_i,
+     input  logic    exists_req_i,
+     output logic    exists_o,
+     output logic    exists_gnt_o,
+@@ -357,7 +356,7 @@ module id_queue #(
+ 
+     // Exists Lookup
+     for (genvar i = 0; i < CAPACITY; i++) begin: gen_lookup
+-        mask_t exists_match_bits;
++        data_t exists_match_bits;
+         for (genvar j = 0; j < $bits(data_t); j++) begin: gen_mask
+             always_comb begin
+                 if (linked_data_q[i].free) begin
+-- 
+2.16.5
+

--- a/hw/vendor/pulp_platform_axi_riscv_atomics.lock.hjson
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/axi_riscv_atomics.git
-    rev: 4e5b837797d3ecd768ff423ef964a0bd2cec6418
+    rev: 0c049715abc91a74e2292057fb16333af628d3fc
   }
 }

--- a/hw/vendor/pulp_platform_axi_riscv_atomics.vendor.hjson
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics.vendor.hjson
@@ -10,7 +10,7 @@
     rev: "v0.5.0",
   },
 
-//   patch_dir: "patches/pulp_platform_axi_riscv_atomics",
+  patch_dir: "patches/pulp_platform_axi_riscv_atomics",
 
 //   exclude_from_upstream: [
 //     ".ci",

--- a/hw/vendor/pulp_platform_axi_riscv_atomics.vendor.hjson
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics.vendor.hjson
@@ -7,7 +7,7 @@
 
   upstream: {
     url: "https://github.com/pulp-platform/axi_riscv_atomics.git",
-    rev: "master",
+    rev: "v0.5.0",
   },
 
 //   patch_dir: "patches/pulp_platform_axi_riscv_atomics",

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/.gitignore
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/.gitignore
@@ -1,0 +1,13 @@
+# Bender
+.bender/
+*.lock
+Bender.local
+# Build
+build/
+# Override dependencies
+deps/
+# Backup
+*.bk
+*.tmp
+# OS
+*.DS_Store

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/Bender.yml
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/Bender.yml
@@ -3,8 +3,9 @@ package:
   authors: ["Andreas Kurth <akurth@iis.ee.ethz.ch>", "Samuel Riedel <sriedel@student.ethz.ch>"]
 
 dependencies:
-  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.6.0 }
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.10.0 }
+  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.35.1 }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.11.0 }
+  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.1 }
 
 sources:
   # Source files grouped in levels.  Files in level 0 have no dependencies on files in this package.
@@ -20,4 +21,16 @@ sources:
   - src/axi_riscv_atomics.sv
   - src/axi_riscv_lrsc_wrap.sv
   # Level 3
+  - src/axi_riscv_amos_wrap.sv
   - src/axi_riscv_atomics_wrap.sv
+
+  - target: test
+    files:
+      - test/tb_axi_pkg.sv
+      - test/golden_memory.sv
+      - test/axi_riscv_atomics_tb.sv
+      - test/axi_riscv_lrsc_tb.sv
+
+  - target: synth_test
+    files:
+      - test/axi_riscv_lrsc_synth.v

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/CHANGELOG.md
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/CHANGELOG.md
@@ -5,17 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](http://semver.org).
 
-## Unreleased
+
+## 0.5.0 - 2022-05-03
+
+### Changed
+- `axi_riscv_lrsc`: Always apply tool workaround, as VCS also has trouble with the syntax and
+  it is likely that other Synopsys tools suffer from the same problem.
+
+
+## 0.4.0 - 2022-04-13
+
+### Added
+- `axi_riscv_atomics`: Add capability to use the AXI User signal as reservation ID.
+
+### Fixed
+- `axi_riscv_amos`: Use `axi_pkg::ATOP_R_RESP` to determine the need for an R response.
+- `axi_riscv_amos`: Only treat requests as ATOPs if the two MSBs are nonzero.
+
+
+## 0.3.0 - 2022-03-11
+
+### Added
+- Add testbench for `axi_riscv_atomics`
+
+### Changed
+- `axi_riscv_lrsc` now supports a configurable number of in-flight read and write transfers
+  downstream.
+
+### Fixed
+- `axi_riscv_lrsc` is now able to sustain the nominal write bandwidth.
+- `axi_riscv_lrsc` now orders SWs and SCs in accordance with RVWMO (#4).
+- `axi_riscv_amos` use LR/SC to guarantee atomicity despite in-flight writes downstream.
+
 
 ## v0.2.2 - 2019-02-28
 
 ### Changed
 - Update `axi` dependency to v0.6.0 (from an intermediary commit).
 
+
 ## v0.2.1 - 2019-02-25
 
 ### Fixed
 - `axi_riscv_amos`: Fixed timing of R response (#10).
+
 
 ## v0.2.0 - 2019-02-21
 
@@ -24,8 +57,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
   an optional wrapper provides SystemVerilog interfaces.  This improves compatibility with tools
   that have poor support for SystemVerilog interfaces.
 
+
 ## Fixed
 - `axi_riscv_amos`: Fixed burst, cache, lock, prot, qos, region, size, and user of ARs.
+
 
 ## v0.1.1 - 2019-02-20
 
@@ -43,6 +78,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 ### Added
 - Added simple standalone synthesis bench for `axi_riscv_atomics`.
 - Added simple standalone synthesis bench for `axi_riscv_lrsc`.
+
 
 ## v0.1.0 - 2019-02-19
 

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/scripts/compile_vsim.sh
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/scripts/compile_vsim.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+if [ "$#" -ne 1 ]; then
+    echo "Please specify whether to use the user signal (1) or the id signal (0) for the reservation ID."
+    echo 'Use: `'`basename "$0"`' 0` to use the `aw_id` signal as the reservation ID'
+    echo 'Use: `'`basename "$0"`' 1` to use the `aw_user` signal as the reservation ID'
+    exit 1
+fi
+
+bender script vsim -t test \
+    -DDEF_USER_AS_ID=$1 \
+    --vlog-arg="-svinputport=compat" \
+    --vlog-arg="-override_timescale 1ns/1ps" \
+    --vlog-arg="-suppress 2583" \
+    > compile.tcl
+echo "exit" >> compile.tcl
+
+vsim -c -do compile.tcl

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/scripts/run_vsim.sh
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/scripts/run_vsim.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+vsim -voptargs=+acc work.axi_riscv_atomics_tb -do "do ../test/axi_riscv_atomics_tb_wave.do; log -r /*; run -a"

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_amos.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_amos.sv
@@ -185,12 +185,17 @@ module axi_riscv_amos #(
     logic                               w_d_valid_d,    w_d_valid_q,    // AMO operand valid
                                         r_d_valid_d,    r_d_valid_q;    // Data from memory valid
     // Counters
+    logic [OUTSTND_BURSTS_WIDTH-1:0]    aw_trans_d,     aw_trans_q;     // AW transaction in flight downstream
     logic [OUTSTND_BURSTS_WIDTH-1:0]    w_cnt_d,        w_cnt_q;        // Outstanding W beats
     logic [OUTSTND_BURSTS_WIDTH-1:0]    w_cnt_req_d,    w_cnt_req_q;    // W beats until AMO can read W
     logic [OUTSTND_BURSTS_WIDTH-1:0]    w_cnt_inj_d,    w_cnt_inj_q;    // W beats until AMO can insert its W
     // States
     logic                               adapter_ready;
     logic                               transaction_collision;
+    logic                               atop_r_resp_d,  atop_r_resp_q;
+    logic                               force_wf_d,     force_wf_q;
+    logic                               start_wf_d,     start_wf_q;
+    logic                               b_resp_valid;
     logic                               aw_valid,       aw_ready,       aw_free,
                                         w_valid,        w_ready,        w_free,
                                         b_valid,        b_ready,        b_free,
@@ -262,9 +267,11 @@ module axi_riscv_amos #(
 
     always_comb begin : calc_atop_valid
         atop_valid_d = atop_valid_q;
+        atop_r_resp_d = atop_r_resp_q;
         if (adapter_ready) begin
             atop_valid_d = NONE;
-            if (slv_aw_valid_i && slv_aw_atop_i) begin
+            atop_r_resp_d = 1'b0;
+            if (slv_aw_valid_i && (slv_aw_atop_i[5:4] != axi_pkg::ATOP_NONE)) begin
                 // Default is invalid request
                 atop_valid_d = INVALID;
                 // Valid load operation
@@ -285,6 +292,10 @@ module axi_riscv_amos #(
                 if (slv_aw_size_i > $clog2(RISCV_WORD_WIDTH/8)) begin
                     atop_valid_d = INVALID;
                 end
+                // Do we have to issue a r_resp?
+                if (slv_aw_atop_i[axi_pkg::ATOP_R_RESP]) begin
+                    atop_r_resp_d = 1'b1;
+                end
             end
         end
     end
@@ -292,8 +303,10 @@ module axi_riscv_amos #(
     always_ff @(posedge clk_i or negedge rst_ni) begin : proc_atop_valid
         if(~rst_ni) begin
             atop_valid_q <= NONE;
+            atop_r_resp_q <= 1'b0;
         end else begin
             atop_valid_q <= atop_valid_d;
+            atop_r_resp_q <= atop_r_resp_d;
         end
     end
 
@@ -333,12 +346,16 @@ module axi_riscv_amos #(
         aw_state_d      = aw_state_q;
 
         // Default control: Block AW channel if...
-        if (slv_aw_valid_i && slv_aw_atop_i) begin
+        if (slv_aw_valid_i && (slv_aw_atop_i[5:4] != axi_pkg::ATOP_NONE)) begin
             // Block if atomic request
             mst_aw_valid_o = 1'b0;
             slv_aw_ready_o = 1'b0;
-        end else if (w_cnt_q == AXI_MAX_WRITE_TXNS) begin
+        end else if (w_cnt_q == AXI_MAX_WRITE_TXNS || aw_trans_q == AXI_MAX_WRITE_TXNS) begin
             // Block if counter is overflowing
+            mst_aw_valid_o = 1'b0;
+            slv_aw_ready_o = 1'b0;
+        end else if (force_wf_q && aw_free) begin
+            // Block if the adapter is in force wait-free mode and the AW is free
             mst_aw_valid_o = 1'b0;
             slv_aw_ready_o = 1'b0;
         end else if (slv_aw_valid_i && transaction_collision && !adapter_ready) begin
@@ -347,8 +364,8 @@ module axi_riscv_amos #(
             slv_aw_ready_o = 1'b0;
         end else begin
             // Forward
-            mst_aw_valid_o  = slv_aw_valid_i;
-            slv_aw_ready_o  = mst_aw_ready_i;
+            mst_aw_valid_o = slv_aw_valid_i;
+            slv_aw_ready_o = mst_aw_ready_i;
         end
 
         // Count W burst to know when to inject the W data
@@ -360,7 +377,7 @@ module axi_riscv_amos #(
 
             FEEDTHROUGH_AW: begin
                 // Feedthrough slave to master until atomic operation is detected
-                if (slv_aw_valid_i && slv_aw_atop_i && adapter_ready) begin
+                if (slv_aw_valid_i && (slv_aw_atop_i[5:4] != axi_pkg::ATOP_NONE) && adapter_ready) begin
                     // Acknowledge atomic transaction
                     slv_aw_ready_o = 1'b1;
                     // Remember request
@@ -379,6 +396,12 @@ module axi_riscv_amos #(
                     end
                 end
 
+                if (start_wf_q) begin
+                    // Forced wait-free state --> wait for ALU once more
+                    aw_state_d = WAIT_RESULT_AW;
+                end
+
+
             end // FEEDTHROUGH_AW
 
             WAIT_RESULT_AW, SEND_AW: begin
@@ -393,7 +416,7 @@ module axi_riscv_amos #(
                     mst_aw_id_o     = id_q;
                     mst_aw_size_o   = size_q;
                     mst_aw_burst_o  = axi_pkg::BURST_INCR;
-                    mst_aw_lock_o   = 1'b0;
+                    mst_aw_lock_o   = ~force_wf_q;
                     mst_aw_cache_o  = cache_q;
                     mst_aw_prot_o   = prot_q;
                     mst_aw_qos_o    = qos_q;
@@ -489,6 +512,12 @@ module axi_riscv_amos #(
                         end
                     end
                 end
+
+                if (start_wf_q) begin
+                    // Forced wait-free state --> wait for ALU once more
+                    w_state_d = WAIT_RESULT_W;
+                end
+
             end // FEEDTHROUGH_W
 
             WAIT_DATA_W: begin
@@ -574,6 +603,10 @@ module axi_riscv_amos #(
         slv_b_resp_o  = mst_b_resp_i;
         slv_b_user_o  = mst_b_user_i;
         slv_b_valid_o = mst_b_valid_i;
+        // Defaults FF
+        force_wf_d    = force_wf_q;
+        start_wf_d    = 1'b0;
+        b_resp_valid  = 1'b0;
         // State Machine
         b_state_d     = b_state_q;
 
@@ -593,7 +626,7 @@ module axi_riscv_amos #(
                             slv_b_valid_o = 1'b1;
                             slv_b_id_o    = slv_aw_id_i;
                             slv_b_resp_o  = axi_pkg::RESP_SLVERR;
-                            slv_b_user_o  = '0;
+                            slv_b_user_o  = slv_aw_user_i;
                             if (!slv_b_ready_i) begin
                                 b_state_d = SEND_B;
                             end
@@ -612,7 +645,7 @@ module axi_riscv_amos #(
                     slv_b_valid_o = 1'b1;
                     slv_b_id_o    = id_q;
                     slv_b_resp_o  = axi_pkg::RESP_SLVERR;
-                    slv_b_user_o  = '0;
+                    slv_b_user_o  = aw_user_q;
                     if (slv_b_ready_i) begin
                         b_state_d = FEEDTHROUGH_B;
                     end else begin
@@ -623,7 +656,32 @@ module axi_riscv_amos #(
 
             WAIT_COMPLETE_B: begin
                 if (mst_b_valid_i && (mst_b_id_i == id_q)) begin
-                    b_state_d = FEEDTHROUGH_B;
+                    // Check if store-conditional was successful
+                    if (mst_b_resp_i == axi_pkg::RESP_OKAY) begin
+                        if (force_wf_q) begin
+                            // We were in wf mode so now we are done
+                            force_wf_d    = 1'b0;
+                            b_resp_valid  = 1'b1;
+                            b_state_d     = FEEDTHROUGH_B;
+                        end else begin
+                            // We were not in wf mode --> catch response
+                            mst_b_ready_o = 1'b1;
+                            slv_b_valid_o = 1'b0;
+                            // Go into wf mode
+                            start_wf_d    = 1'b1;
+                            force_wf_d    = 1'b1;
+                        end
+                    end else if (mst_b_resp_i == axi_pkg::RESP_EXOKAY) begin
+                        // Modify the B response to regular OK.
+                        b_resp_valid = 1'b1;
+                        slv_b_resp_o = axi_pkg::RESP_OKAY;
+                        if (slv_b_ready_i) begin
+                            b_state_d = FEEDTHROUGH_B;
+                        end
+                    end else begin
+                        b_resp_valid = 1'b1;
+                        b_state_d    = FEEDTHROUGH_B;
+                    end
                 end
             end // WAIT_COMPLETE_B
 
@@ -632,14 +690,19 @@ module axi_riscv_amos #(
         endcase
     end // axi_b_channel
 
-    // Keep track of outstanding downstream write bursts and responses.
+    // Keep track of AW requests missing a W and of downstream transactions
     always_comb begin
-        w_cnt_d = w_cnt_q;
+        w_cnt_d    = w_cnt_q;
+        aw_trans_d = aw_trans_q;
         if (mst_aw_valid_o && mst_aw_ready_i) begin
-            w_cnt_d += 1;
+            w_cnt_d    += 1;
+            aw_trans_d += 1;
         end
         if (mst_w_valid_o && mst_w_ready_i && mst_w_last_o) begin
-            w_cnt_d -= 1;
+            w_cnt_d    -= 1;
+        end
+        if (mst_b_valid_i && mst_b_ready_o) begin
+            aw_trans_d -= 1;
         end
     end
 
@@ -648,9 +711,12 @@ module axi_riscv_amos #(
             aw_state_q  <= FEEDTHROUGH_AW;
             w_state_q   <= FEEDTHROUGH_W;
             b_state_q   <= FEEDTHROUGH_B;
+            aw_trans_q  <= '0;
             w_cnt_q     <= '0;
             w_cnt_req_q <= '0;
             w_cnt_inj_q <= '0;
+            force_wf_q  <= 1'b0;
+            start_wf_q  <= 1'b0;
             addr_q      <= '0;
             id_q        <= '0;
             size_q      <= '0;
@@ -669,9 +735,12 @@ module axi_riscv_amos #(
             aw_state_q  <= aw_state_d;
             w_state_q   <= w_state_d;
             b_state_q   <= b_state_d;
+            aw_trans_q  <= aw_trans_d;
             w_cnt_q     <= w_cnt_d;
             w_cnt_req_q <= w_cnt_req_d;
             w_cnt_inj_q <= w_cnt_inj_d;
+            force_wf_q  <= force_wf_d;
+            start_wf_q  <= start_wf_d;
             addr_q      <= addr_d;
             id_q        <= id_d;
             size_q      <= size_d;
@@ -721,39 +790,41 @@ module axi_riscv_amos #(
                 mst_ar_valid_o = slv_ar_valid_i;
                 slv_ar_ready_o = mst_ar_ready_i;
 
-                if (adapter_ready) begin
-                    if (atop_valid_d == LOAD | atop_valid_d == STORE) begin
-                        if (ar_free) begin
-                            // Acquire channel
-                            slv_ar_ready_o  = 1'b0;
-                            // Immediately start read request
-                            mst_ar_valid_o  = 1'b1;
-                            mst_ar_addr_o   = slv_aw_addr_i;
-                            mst_ar_id_o     = slv_aw_id_i;
-                            mst_ar_len_o    = 8'h00;
-                            mst_ar_size_o   = slv_aw_size_i;
-                            mst_ar_burst_o  = axi_pkg::BURST_INCR;
-                            mst_ar_lock_o   = 1'h0;
-                            mst_ar_cache_o  = slv_aw_cache_i;
-                            mst_ar_prot_o   = slv_aw_prot_i;
-                            mst_ar_qos_o    = slv_aw_qos_i;
-                            mst_ar_region_o = slv_aw_region_i;
-                            mst_ar_user_o   = slv_aw_user_i;
-                            if (!mst_ar_ready_i) begin
-                                // Hold read request but do not depend on AW
-                                ar_state_d = SEND_AR;
-                            end
-                        end else begin
-                            // Wait until AR is free
-                            ar_state_d   = WAIT_CHANNEL_AR;
+                if (adapter_ready && (atop_valid_d == LOAD || atop_valid_d == STORE)) begin
+                    if (ar_free) begin
+                        // Acquire channel
+                        slv_ar_ready_o  = 1'b0;
+                        // Immediately start read request
+                        mst_ar_valid_o  = 1'b1;
+                        mst_ar_addr_o   = slv_aw_addr_i;
+                        mst_ar_id_o     = slv_aw_id_i;
+                        mst_ar_len_o    = 8'h00;
+                        mst_ar_size_o   = slv_aw_size_i;
+                        mst_ar_burst_o  = axi_pkg::BURST_INCR;
+                        mst_ar_lock_o   = ~force_wf_q;
+                        mst_ar_cache_o  = slv_aw_cache_i;
+                        mst_ar_prot_o   = slv_aw_prot_i;
+                        mst_ar_qos_o    = slv_aw_qos_i;
+                        mst_ar_region_o = slv_aw_region_i;
+                        mst_ar_user_o   = slv_aw_user_i;
+                        if (!mst_ar_ready_i) begin
+                            // Hold read request but do not depend on AW
+                            ar_state_d = SEND_AR;
                         end
+                    end else begin
+                        // Wait until AR is free
+                        ar_state_d   = WAIT_CHANNEL_AR;
                     end
+                end
+
+                if (start_wf_q) begin
+                    ar_state_d = WAIT_CHANNEL_AR;
                 end
             end // FEEDTHROUGH_AR
 
             WAIT_CHANNEL_AR, SEND_AR: begin
                 // Issue read request
-                if (ar_free || (ar_state_q == SEND_AR)) begin
+                if ((ar_free  && (aw_trans_q == 0 || force_wf_q == 0)) || (ar_state_q == SEND_AR)) begin
                     // Inject read request
                     mst_ar_valid_o  = 1'b1;
                     mst_ar_addr_o   = addr_q;
@@ -761,7 +832,7 @@ module axi_riscv_amos #(
                     mst_ar_len_o    = 8'h00;
                     mst_ar_size_o   = size_q;
                     mst_ar_burst_o  = axi_pkg::BURST_INCR;
-                    mst_ar_lock_o   = 1'h0;
+                    mst_ar_lock_o   = ~force_wf_q;
                     mst_ar_cache_o  = cache_q;
                     mst_ar_prot_o   = prot_q;
                     mst_ar_qos_o    = qos_q;
@@ -816,7 +887,7 @@ module axi_riscv_amos #(
                     if (atop_valid_d == LOAD || atop_valid_d == STORE) begin
                         // Wait for R response to read data
                         r_state_d = WAIT_DATA_R;
-                    end else if (atop_valid_d == INVALID) begin
+                    end else if (atop_valid_d == INVALID && atop_r_resp_d) begin
                         // Send R response once channel is free
                         if (r_free) begin
                             // Acquire the R channel
@@ -828,7 +899,7 @@ module axi_riscv_amos #(
                             slv_r_id_o    = slv_aw_id_i;
                             slv_r_last_o  = 1'b1;
                             slv_r_resp_o  = axi_pkg::RESP_SLVERR;
-                            slv_r_user_o  = '0;
+                            slv_r_user_o  = slv_aw_user_i;
                             if (!slv_r_ready_i) begin
                                 // Hold R response
                                 r_state_d = SEND_R;
@@ -837,6 +908,11 @@ module axi_riscv_amos #(
                             r_state_d = WAIT_CHANNEL_R;
                         end
                     end
+                end
+
+                if (start_wf_q) begin
+                    r_d_valid_d = 1'b0;
+                    r_state_d   = WAIT_DATA_R;
                 end
             end // FEEDTHROUGH_R
 
@@ -862,8 +938,7 @@ module axi_riscv_amos #(
 
             WAIT_CHANNEL_R, SEND_R: begin
                 // Wait for the R channel to become free and B response to be valid
-                // TODO: Use b_state_d to be one cycle quicker
-                if ((r_free && (b_state_q != WAIT_COMPLETE_B)) || (r_state_q == SEND_R)) begin
+                if ((r_free && (b_resp_valid || b_state_q != WAIT_COMPLETE_B)) || (r_state_q == SEND_R)) begin
                     // Block downstream
                     mst_r_ready_o = 1'b0;
                     // Send R response
@@ -873,16 +948,21 @@ module axi_riscv_amos #(
                     slv_r_last_o  = 1'b1;
                     slv_r_resp_o  = r_resp_q;
                     slv_r_user_o  = r_user_q;
-                    if (atop_valid_q == INVALID) begin
+                    if (atop_valid_q == INVALID && atop_r_resp_q) begin
                         slv_r_data_o = '0;
                         slv_r_resp_o = axi_pkg::RESP_SLVERR;
-                        slv_r_user_o = '0;
+                        slv_r_user_o = aw_user_q;
                     end
                     if (slv_r_ready_i) begin
                         r_state_d = FEEDTHROUGH_R;
                     end else begin
                         r_state_d = SEND_R;
                     end
+                end
+
+                if (start_wf_q) begin
+                    r_d_valid_d = 1'b0;
+                    r_state_d   = WAIT_DATA_R;
                 end
             end // WAIT_CHANNEL_R, SEND_R
 

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_amos_wrap.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_amos_wrap.sv
@@ -9,30 +9,26 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-// Wrapper for the AXI RISC-V LR/SC Adapter that exposes AXI SystemVerilog interfaces.
+// Wrapper for the AXI RISC-V AMO Adapter that exposes AXI SystemVerilog interfaces.
 //
-// See the header of `axi_riscv_lrsc` for a description.
+// See the header of `axi_riscv_amos` for a description.
 //
 // Maintainer: Andreas Kurth <akurth@iis.ee.ethz.ch>
 
-module axi_riscv_lrsc_wrap #(
-    /// Exclusively-accessible address range (closed interval from ADDR_BEGIN to ADDR_END)
-    parameter longint unsigned ADDR_BEGIN = 0,
-    parameter longint unsigned ADDR_END = 0,
+module axi_riscv_amos_wrap #(
     /// AXI Parameters
-    parameter int unsigned AXI_ADDR_WIDTH = 0,
-    parameter int unsigned AXI_DATA_WIDTH = 0,
-    parameter int unsigned AXI_ID_WIDTH = 0,
-    parameter int unsigned AXI_USER_WIDTH = 0,
-    parameter int unsigned AXI_MAX_READ_TXNS = 0,  // Maximum number of in-flight read transactions
-    parameter int unsigned AXI_MAX_WRITE_TXNS = 0, // Maximum number of in-flight write transactions
-    parameter bit AXI_USER_AS_ID = 1'b0,           // Use the AXI User signal instead of the AXI ID to track reservations
-    parameter int unsigned AXI_USER_ID_MSB = 0,    // MSB of the ID in the user signal
-    parameter int unsigned AXI_USER_ID_LSB = 0,    // LSB of the ID in the user signal
-    /// Enable debug prints (not synthesizable).
-    parameter bit DEBUG = 1'b0,
+    parameter int unsigned AXI_ADDR_WIDTH       = 0,
+    parameter int unsigned AXI_DATA_WIDTH       = 0,
+    parameter int unsigned AXI_ID_WIDTH         = 0,
+    parameter int unsigned AXI_USER_WIDTH       = 0,
+    // Maximum number of AXI write transactions outstanding at the same time
+    parameter int unsigned AXI_MAX_WRITE_TXNS   = 0,
+    // Word width of the widest RISC-V processor that can issue requests to this module.
+    // 32 for RV32; 64 for RV64, where both 32-bit (.W suffix) and 64-bit (.D suffix) AMOs are
+    // supported if `aw_strb` is set correctly.
+    parameter int unsigned RISCV_WORD_WIDTH     = 0,
     /// Derived Parameters (do NOT change manually!)
-    localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
+    localparam int unsigned AXI_STRB_WIDTH      = AXI_DATA_WIDTH / 8
 ) (
     input  logic    clk_i,
     input  logic    rst_ni,
@@ -40,20 +36,14 @@ module axi_riscv_lrsc_wrap #(
     AXI_BUS.Slave   slv
 );
 
-    axi_riscv_lrsc #(
-        .ADDR_BEGIN             (ADDR_BEGIN),
-        .ADDR_END               (ADDR_END),
-        .AXI_ADDR_WIDTH         (AXI_ADDR_WIDTH),
-        .AXI_DATA_WIDTH         (AXI_DATA_WIDTH),
-        .AXI_ID_WIDTH           (AXI_ID_WIDTH),
-        .AXI_USER_WIDTH         (AXI_USER_WIDTH),
-        .AXI_MAX_READ_TXNS      (AXI_MAX_READ_TXNS),
-        .AXI_MAX_WRITE_TXNS     (AXI_MAX_WRITE_TXNS),
-        .AXI_USER_AS_ID         (AXI_USER_AS_ID),
-        .AXI_USER_ID_MSB        (AXI_USER_ID_MSB),
-        .AXI_USER_ID_LSB        (AXI_USER_ID_LSB),
-        .DEBUG                  (DEBUG)
-    ) i_lrsc (
+    axi_riscv_amos #(
+        .AXI_ADDR_WIDTH     ( AXI_ADDR_WIDTH     ),
+        .AXI_DATA_WIDTH     ( AXI_DATA_WIDTH     ),
+        .AXI_ID_WIDTH       ( AXI_ID_WIDTH       ),
+        .AXI_USER_WIDTH     ( AXI_USER_WIDTH     ),
+        .AXI_MAX_WRITE_TXNS ( AXI_MAX_WRITE_TXNS ),
+        .RISCV_WORD_WIDTH   ( RISCV_WORD_WIDTH   )
+    ) i_amos (
         .clk_i           ( clk_i         ),
         .rst_ni          ( rst_ni        ),
         .slv_aw_addr_i   ( slv.aw_addr   ),

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_atomics.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_atomics.sv
@@ -22,8 +22,16 @@ module axi_riscv_atomics #(
     parameter int unsigned AXI_DATA_WIDTH = 0,
     parameter int unsigned AXI_ID_WIDTH = 0,
     parameter int unsigned AXI_USER_WIDTH = 0,
+    // Maximum number of AXI read bursts outstanding at the same time
+    parameter int unsigned AXI_MAX_READ_TXNS = 0,
     // Maximum number of AXI write bursts outstanding at the same time
     parameter int unsigned AXI_MAX_WRITE_TXNS = 0,
+    // Use the AXI User signal instead of the AXI ID to track reservations
+    parameter bit AXI_USER_AS_ID = 1'b0,
+    // MSB of the ID in the user signal
+    parameter int unsigned AXI_USER_ID_MSB = 0,
+    // LSB of the ID in the user signal
+    parameter int unsigned AXI_USER_ID_LSB = 0,
     // Word width of the widest RISC-V processor that can issue requests to this module.
     // 32 for RV32; 64 for RV64, where both 32-bit (.W suffix) and 64-bit (.D suffix) AMOs are
     // supported if `aw_strb` is set correctly.
@@ -296,12 +304,17 @@ module axi_riscv_atomics #(
     );
 
     axi_riscv_lrsc #(
-        .ADDR_BEGIN     (ADDR_BEGIN),
-        .ADDR_END       (ADDR_END),
-        .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
-        .AXI_DATA_WIDTH (AXI_DATA_WIDTH),
-        .AXI_ID_WIDTH   (AXI_ID_WIDTH),
-        .AXI_USER_WIDTH (AXI_USER_WIDTH)
+        .ADDR_BEGIN         (ADDR_BEGIN),
+        .ADDR_END           (ADDR_END),
+        .AXI_ADDR_WIDTH     (AXI_ADDR_WIDTH),
+        .AXI_DATA_WIDTH     (AXI_DATA_WIDTH),
+        .AXI_ID_WIDTH       (AXI_ID_WIDTH),
+        .AXI_USER_WIDTH     (AXI_USER_WIDTH),
+        .AXI_MAX_READ_TXNS  (AXI_MAX_READ_TXNS),
+        .AXI_MAX_WRITE_TXNS (AXI_MAX_WRITE_TXNS),
+        .AXI_USER_AS_ID     (AXI_USER_AS_ID),
+        .AXI_USER_ID_MSB    (AXI_USER_ID_MSB),
+        .AXI_USER_ID_LSB    (AXI_USER_ID_LSB)
     ) i_lrsc (
         .clk_i              ( clk_i             ),
         .rst_ni             ( rst_ni            ),

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_atomics_wrap.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_atomics_wrap.sv
@@ -21,8 +21,16 @@ module axi_riscv_atomics_wrap #(
     parameter int unsigned AXI_DATA_WIDTH = 0,
     parameter int unsigned AXI_ID_WIDTH = 0,
     parameter int unsigned AXI_USER_WIDTH = 0,
-    /// Maximum number of AXI bursts outstanding at the same time
+    // Maximum number of AXI read bursts outstanding at the same time
+    parameter int unsigned AXI_MAX_READ_TXNS = 0,
+    // Maximum number of AXI write bursts outstanding at the same time
     parameter int unsigned AXI_MAX_WRITE_TXNS = 0,
+    // Use the AXI User signal instead of the AXI ID to track reservations
+    parameter bit AXI_USER_AS_ID = 1'b0,
+    // MSB of the ID in the user signal
+    parameter int unsigned AXI_USER_ID_MSB = 0,
+    // LSB of the ID in the user signal
+    parameter int unsigned AXI_USER_ID_LSB = 0,
     // Word width of the widest RISC-V processor that can issue requests to this module.
     // 32 for RV32; 64 for RV64, where both 32-bit (.W suffix) and 64-bit (.D suffix) AMOs are
     // supported if `aw_strb` is set correctly.
@@ -41,7 +49,11 @@ module axi_riscv_atomics_wrap #(
         .AXI_DATA_WIDTH     (AXI_DATA_WIDTH),
         .AXI_ID_WIDTH       (AXI_ID_WIDTH),
         .AXI_USER_WIDTH     (AXI_USER_WIDTH),
+        .AXI_MAX_READ_TXNS  (AXI_MAX_READ_TXNS),
         .AXI_MAX_WRITE_TXNS (AXI_MAX_WRITE_TXNS),
+        .AXI_USER_AS_ID     (AXI_USER_AS_ID),
+        .AXI_USER_ID_MSB    (AXI_USER_ID_MSB),
+        .AXI_USER_ID_LSB    (AXI_USER_ID_LSB),
         .RISCV_WORD_WIDTH   (RISCV_WORD_WIDTH)
     ) i_atomics (
         .clk_i           ( clk_i         ),

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_lrsc.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/src/axi_riscv_lrsc.sv
@@ -22,8 +22,6 @@
 // behave like a slave that does not support exclusive memory accesses (see AXI4, A7.2.5).
 //
 // Limitations:
-//  -   The adapter allows at most one read and one write access to be outstanding at any given
-//      time.
 //  -   The adapter does not support bursts in exclusive accessing.  Only single words can be
 //      reserved.
 //
@@ -38,6 +36,13 @@ module axi_riscv_lrsc #(
     parameter int unsigned AXI_DATA_WIDTH = 0,
     parameter int unsigned AXI_ID_WIDTH = 0,
     parameter int unsigned AXI_USER_WIDTH = 0,
+    parameter int unsigned AXI_MAX_READ_TXNS = 0,  // Maximum number of in-flight read transactions
+    parameter int unsigned AXI_MAX_WRITE_TXNS = 0, // Maximum number of in-flight write transactions
+    parameter bit AXI_USER_AS_ID = 1'b0,           // Use the AXI User signal instead of the AXI ID to track reservations
+    parameter int unsigned AXI_USER_ID_MSB = 0,    // MSB of the ID in the user signal
+    parameter int unsigned AXI_USER_ID_LSB = 0,    // LSB of the ID in the user signal
+    /// Enable debug prints (not synthesizable).
+    parameter bit DEBUG = 1'b0,
     /// Derived Parameters (do NOT change manually!)
     localparam int unsigned AXI_STRB_WIDTH = AXI_DATA_WIDTH / 8
 ) (
@@ -148,345 +153,834 @@ module axi_riscv_lrsc #(
 );
 
     // Declarations of Signals and Types
+    localparam int unsigned RES_ID_WIDTH = AXI_USER_AS_ID ?
+            AXI_USER_ID_MSB - AXI_USER_ID_LSB + 1
+            : AXI_ID_WIDTH;
 
-    logic [AXI_ID_WIDTH-1:0]        art_check_id,
-                                    art_set_id,
-                                    w_id_d,                     w_id_q;
+    typedef logic [AXI_ADDR_WIDTH-1:0]  axi_addr_t;
+    typedef logic [AXI_DATA_WIDTH-1:0]  axi_data_t;
+    typedef logic [AXI_ID_WIDTH-1:0]    axi_id_t;
+    typedef logic [1:0]                 axi_resp_t;
+    typedef logic [AXI_USER_WIDTH-1:0]  axi_user_t;
+    typedef logic [AXI_ADDR_WIDTH-3:0]  res_addr_t; // Track reservations word wise.
+    typedef logic [RES_ID_WIDTH-1:0]    res_id_t;
 
-    logic [AXI_ADDR_WIDTH-1:0]      art_check_addr,
-                                    art_clr_addr,
-                                    art_set_addr,
-                                    rd_clr_addr,
-                                    wr_clr_addr,
-                                    w_addr_d,                   w_addr_q;
+    typedef enum logic [1:0] {
+        B_REGULAR='0, B_EXCLUSIVE, B_INJECT
+    } b_cmd_t;
 
-    logic                           art_check_req,              art_check_gnt,
-                                    art_clr_req,                art_clr_gnt,
-                                    art_set_req,                art_set_gnt,
-                                    rd_clr_req,                 rd_clr_gnt,
-                                    wr_clr_req,                 wr_clr_gnt;
+    typedef struct packed {
+        axi_id_t    id;
+        axi_user_t  user;
+    } b_inj_t;
 
-    logic                           art_check_res;
+    typedef struct packed {
+        axi_id_t    id;
+        axi_user_t  user;
+        axi_resp_t  resp;
+    } b_chan_t;
 
-    logic                           b_excl_d,                   b_excl_q,
-                                    r_excl_d,                   r_excl_q;
+    typedef struct packed {
+        axi_id_t    id;
+        axi_data_t  data;
+        axi_resp_t  resp;
+        axi_user_t  user;
+        logic       last;
+    } r_chan_t;
 
-    typedef enum logic [1:0]    {R_IDLE, R_WAIT_AR, R_WAIT_R} r_state_t;
-    r_state_t                       r_state_d,                  r_state_q;
+    typedef struct packed {
+        logic   excl;
+    } r_flight_t;
 
-    typedef enum logic [2:0]    {AW_IDLE, W_FORWARD, W_BYPASS, W_WAIT_ART_CLR, W_DROP, B_FORWARD,
-                                B_INJECT} w_state_t;
-    w_state_t                       w_state_d,                  w_state_q;
+    typedef struct packed {
+        logic       forward;
+        axi_id_t    id;
+        axi_user_t  user;
+    } w_cmd_t;
+
+    typedef struct packed {
+        res_addr_t  addr;
+        logic       excl;
+    } w_flight_t;
+
+    typedef struct packed {
+        w_flight_t                      data;
+        logic [$bits(w_flight_t)-1:0]   mask;
+    } wifq_exists_t;
+
+    typedef enum logic {
+        AR_IDLE, AR_WAIT
+    } ar_state_t;
+
+    typedef enum logic {
+        AW_IDLE, AW_WAIT
+    } aw_state_t;
+
+    typedef struct packed {
+        axi_addr_t  addr;
+        logic [2:0] prot;
+        logic [3:0] region;
+        logic [5:0] atop;
+        logic [7:0] len;
+        logic [2:0] size;
+        logic [1:0] burst;
+        logic [3:0] cache;
+        logic [3:0] qos;
+        axi_id_t    id;
+        axi_user_t  user;
+    } aw_chan_t;
+
+    typedef enum logic {
+        B_NORMAL, B_FORWARD
+    } b_state_t;
+
+    axi_id_t        b_status_inp_id,
+                    b_status_oup_id,
+                    rifq_oup_id;
+
+    res_addr_t      ar_push_addr,
+                    art_check_clr_addr;
+
+    res_id_t        art_set_id,
+                    art_check_id;
+
+    logic           ar_push_excl,
+                    ar_push_res;
+
+    logic           art_check_clr_excl;
+
+    logic           ar_push_valid,              ar_push_ready,
+                    art_check_clr_req,          art_check_clr_gnt,
+                    art_filter_valid,           art_filter_ready,
+                    art_set_req,                art_set_gnt;
+
+    logic           rifq_inp_req,               rifq_inp_gnt,
+                    rifq_oup_req,               rifq_oup_gnt,
+                    rifq_oup_pop,
+                    rifq_oup_data_valid;
+
+    r_flight_t      rifq_inp_data,
+                    rifq_oup_data;
+
+    logic           wifq_exists,
+                    ar_wifq_exists_req,         ar_wifq_exists_gnt,
+                    aw_wifq_exists_req,         aw_wifq_exists_gnt,
+                    wifq_exists_req,            wifq_exists_gnt,
+                                                wifq_inp_gnt,
+                    wifq_oup_req,               wifq_oup_gnt,
+                    wifq_oup_data_valid;
+
+    wifq_exists_t   ar_wifq_exists_inp,
+                    aw_wifq_exists_inp,
+                    wifq_exists_inp;
+
+    b_chan_t        slv_b;
+
+    logic           slv_b_valid,                slv_b_ready;
+
+    r_chan_t        slv_r;
+
+    logic           slv_r_valid,                slv_r_ready;
+
+    logic           mst_b_valid,                mst_b_ready;
+
+    w_cmd_t         w_cmd_inp,                  w_cmd_oup;
+
+    logic           w_cmd_push,                 w_cmd_pop,
+                    w_cmd_full,                 w_cmd_empty;
+
+    b_inj_t         b_inj_inp,                  b_inj_oup;
+
+    logic           b_inj_push,                 b_inj_pop,
+                    b_inj_full,                 b_inj_empty;
+
+    b_cmd_t         b_status_inp_cmd,           b_status_oup_cmd;
+
+    logic           b_status_inp_req,           b_status_oup_req,
+                    b_status_inp_gnt,           b_status_oup_gnt,
+                    b_status_oup_pop,
+                    b_status_oup_valid;
+
+    logic           art_check_res;
+
+    ar_state_t      ar_state_d,                 ar_state_q;
+
+    aw_state_t      aw_state_d,                 aw_state_q;
+
+    b_state_t       b_state_d,                  b_state_q;
+
+    aw_chan_t       slv_aw,                     mst_aw;
+
+    logic           mst_aw_valid,               mst_aw_ready;
 
     // AR and R Channel
 
+    // IQ Queue to track in-flight reads
+    id_queue #(
+        .ID_WIDTH   (AXI_ID_WIDTH),
+        .CAPACITY   (AXI_MAX_READ_TXNS),
+        .data_t     (r_flight_t)
+    ) i_read_in_flight_queue (
+        .clk_i              (clk_i),
+        .rst_ni             (rst_ni),
+        .inp_id_i           (slv_ar_id_i),
+        .inp_data_i         (rifq_inp_data),
+        .inp_req_i          (rifq_inp_req),
+        .inp_gnt_o          (rifq_inp_gnt),
+        .exists_data_i      (),
+        .exists_mask_i      (),
+        .exists_req_i       (1'b0),
+        .exists_o           (),
+        .exists_gnt_o       (),
+        .oup_id_i           (rifq_oup_id),
+        .oup_pop_i          (rifq_oup_pop),
+        .oup_req_i          (rifq_oup_req),
+        .oup_data_o         (rifq_oup_data),
+        .oup_data_valid_o   (rifq_oup_data_valid),
+        .oup_gnt_o          (rifq_oup_gnt)
+    );
+    assign rifq_inp_data.excl = ar_push_excl;
+
+    // Fork requests from AR into reservation table and queue of in-flight reads.
+    stream_fork #(
+        .N_OUP  (2)
+    ) i_ar_push_fork (
+        .clk_i      (clk_i),
+        .rst_ni     (rst_ni),
+        .valid_i    (ar_push_valid),
+        .ready_o    (ar_push_ready),
+        .valid_o    ({art_filter_valid, rifq_inp_req}),
+        .ready_i    ({art_filter_ready, rifq_inp_gnt})
+    );
+
+    stream_filter i_art_filter (
+        .valid_i    (art_filter_valid),
+        .ready_o    (art_filter_ready),
+        .drop_i     (!ar_push_res),
+        .valid_o    (art_set_req),
+        .ready_i    (art_set_gnt)
+    );
+
     // Time-Invariant Signal Assignments
-    assign mst_ar_addr_o      = slv_ar_addr_i;
-    assign mst_ar_prot_o      = slv_ar_prot_i;
-    assign mst_ar_region_o    = slv_ar_region_i;
-    assign mst_ar_len_o       = slv_ar_len_i;
-    assign mst_ar_size_o      = slv_ar_size_i;
-    assign mst_ar_burst_o     = slv_ar_burst_i;
-    assign mst_ar_lock_o      = 1'b0;
-    assign mst_ar_cache_o     = slv_ar_cache_i;
-    assign mst_ar_qos_o       = slv_ar_qos_i;
-    assign mst_ar_id_o        = slv_ar_id_i;
-    assign mst_ar_user_o      = slv_ar_user_i;
-    assign slv_r_data_o       = mst_r_data_i;
-    assign slv_r_last_o       = mst_r_last_i;
-    assign slv_r_id_o         = mst_r_id_i;
-    assign slv_r_user_o       = mst_r_user_i;
+    assign mst_ar_addr_o    = slv_ar_addr_i;
+    assign mst_ar_prot_o    = slv_ar_prot_i;
+    assign mst_ar_region_o  = slv_ar_region_i;
+    assign mst_ar_len_o     = slv_ar_len_i;
+    assign mst_ar_size_o    = slv_ar_size_i;
+    assign mst_ar_burst_o   = slv_ar_burst_i;
+    assign mst_ar_lock_o    = 1'b0;
+    assign mst_ar_cache_o   = slv_ar_cache_i;
+    assign mst_ar_qos_o     = slv_ar_qos_i;
+    assign mst_ar_id_o      = slv_ar_id_i;
+    assign mst_ar_user_o    = slv_ar_user_i;
+    assign slv_r.data       = mst_r_data_i;
+    assign slv_r.last       = mst_r_last_i;
+    assign slv_r.id         = mst_r_id_i;
+    assign slv_r.user       = mst_r_user_i;
 
-    // FSM for Time-Variant Signal Assignments
+    // Control R Channel
     always_comb begin
-        mst_ar_valid_o  = 1'b0;
-        slv_ar_ready_o  = 1'b0;
         mst_r_ready_o   = 1'b0;
-        slv_r_valid_o   = 1'b0;
-        slv_r_resp_o    = '0;
-        art_set_addr    = '0;
-        art_set_id      = '0;
-        art_set_req     = 1'b0;
-        rd_clr_addr     = '0;
-        rd_clr_req      = 1'b0;
-        r_excl_d        = r_excl_q;
-        r_state_d       = r_state_q;
+        slv_r.resp      = '0;
+        slv_r_valid     = 1'b0;
+        rifq_oup_id     = '0;
+        rifq_oup_pop    = 1'b0;
+        rifq_oup_req    = 1'b0;
+        if (mst_r_valid_i && slv_r_ready) begin
+            rifq_oup_id     = mst_r_id_i;
+            rifq_oup_pop    = mst_r_last_i;
+            rifq_oup_req    = 1'b1;
+            if (rifq_oup_gnt) begin
+                mst_r_ready_o = 1'b1;
+                if (mst_r_resp_i[1] == 1'b0) begin
+                    slv_r.resp = {1'b0, rifq_oup_data.excl};
+                end else begin
+                    slv_r.resp = mst_r_resp_i;
+                end
+                slv_r_valid = 1'b1;
+            end
+        end
+    end
 
-        case (r_state_q)
+// pragma translate_off
+    always @(posedge clk_i) begin
+        if (~rst_ni) begin
+            if (rifq_oup_req && rifq_oup_gnt) begin
+                assert (rifq_oup_data_valid) else $error("Unexpected R with ID %0x!", mst_r_id_i);
+            end
+        end
+    end
+// pragma translate_on
 
-            R_IDLE: begin
+    // Control AR Channel
+    always_comb begin
+        mst_ar_valid_o                  = 1'b0;
+        slv_ar_ready_o                  = 1'b0;
+        ar_push_addr                    = '0;
+        ar_push_excl                    = '0;
+        ar_push_res                     = '0;
+        ar_push_valid                   = 1'b0;
+        ar_wifq_exists_inp.data.addr    = '0;
+        ar_wifq_exists_inp.data.excl    = 1'b0;
+        ar_wifq_exists_inp.mask         = '1;
+        ar_wifq_exists_inp.mask[0]      = 1'b0; // Don't care on `excl` bit.
+        ar_wifq_exists_req              = 1'b0;
+        ar_state_d                      = ar_state_q;
+
+        case (ar_state_q)
+
+            AR_IDLE: begin
                 if (slv_ar_valid_i) begin
-                    if (slv_ar_addr_i >= ADDR_BEGIN && slv_ar_addr_i <= ADDR_END && slv_ar_lock_i &&
-                            slv_ar_len_i == 8'h00) begin
-                        // Inside exclusively-accessible address range and exclusive access and no
-                        // burst
-                        art_set_addr    = slv_ar_addr_i;
-                        art_set_id      = slv_ar_id_i;
-                        art_set_req     = 1'b1;
-                        r_excl_d        = 1'b1;
-                        if (art_set_gnt) begin
-                            mst_ar_valid_o = 1'b1;
-                            if (mst_ar_ready_i) begin
-                                slv_ar_ready_o = 1'b1;
-                                r_state_d = R_WAIT_R;
-                            end else begin
-                                r_state_d = R_WAIT_AR;
-                            end
+                    ar_push_addr = slv_ar_addr_i[AXI_ADDR_WIDTH-1:2];
+                    ar_push_excl = (slv_ar_addr_i >= ADDR_BEGIN && slv_ar_addr_i <= ADDR_END &&
+                            slv_ar_lock_i && slv_ar_len_i == 8'h00);
+                    if (ar_push_excl) begin
+                        ar_wifq_exists_inp.data.addr = slv_ar_addr_i[AXI_ADDR_WIDTH-1:2];
+                        ar_wifq_exists_req = 1'b1;
+                        if (ar_wifq_exists_gnt) begin
+                            ar_push_res = !wifq_exists;
+                            ar_push_valid = 1'b1;
                         end
                     end else begin
-                        // Outside exclusively-accessible address range or regular access or burst
-                        r_excl_d = 1'b0;
+                        ar_push_res = 1'b0;
+                        ar_push_valid = 1'b1;
+                    end
+                    if (ar_push_ready) begin
                         mst_ar_valid_o = 1'b1;
                         if (mst_ar_ready_i) begin
                             slv_ar_ready_o = 1'b1;
-                            r_state_d = R_WAIT_R;
                         end else begin
-                            r_state_d = R_WAIT_AR;
+                            ar_state_d = AR_WAIT;
                         end
                     end
                 end
             end
 
-            R_WAIT_AR: begin
+            AR_WAIT: begin
                 mst_ar_valid_o = slv_ar_valid_i;
                 slv_ar_ready_o = mst_ar_ready_i;
                 if (mst_ar_ready_i && mst_ar_valid_o) begin
-                    r_state_d = R_WAIT_R;
-                end
-            end
-
-            R_WAIT_R: begin
-                mst_r_ready_o = slv_r_ready_i;
-                slv_r_valid_o = mst_r_valid_i;
-                if (mst_r_resp_i[1] == 1'b0) begin
-                    slv_r_resp_o = {1'b0, r_excl_q};
-                end else begin
-                    slv_r_resp_o = mst_r_resp_i;
-                end
-                if (mst_r_valid_i && mst_r_ready_o && mst_r_last_i) begin
-                    r_excl_d    = 1'b0;
-                    r_state_d   = R_IDLE;
+                    ar_state_d = AR_IDLE;
                 end
             end
 
             default: begin
-                r_state_d = R_IDLE;
+                ar_state_d = AR_IDLE;
             end
         endcase
     end
 
     // AW, W and B Channel
 
+    // FIFO to track commands for W bursts.
+    fifo_v3 #(
+        .FALL_THROUGH   (1'b0), // There would be a combinatorial loop if this were a fall-through
+                                // register.  Optimizing this can reduce the latency of this module.
+        .dtype          (w_cmd_t),
+        .DEPTH          (AXI_MAX_WRITE_TXNS)
+    ) i_w_cmd_fifo (
+        .clk_i      (clk_i),
+        .rst_ni     (rst_ni),
+        .flush_i    (1'b0),
+        .testmode_i (1'b0),
+        .full_o     (w_cmd_full),
+        .empty_o    (w_cmd_empty),
+        .usage_o    (),
+        .data_i     (w_cmd_inp),
+        .push_i     (w_cmd_push),
+        .data_o     (w_cmd_oup),
+        .pop_i      (w_cmd_pop)
+    );
+
+    // ID Queue to track downstream W bursts and their pending B responses.
+    // Workaround for bug in Questa (at least 2018.07 is affected) and VCS (at least 2020.12 is
+    // affected):
+    // Flatten the enum into a logic vector before using that type when instantiating `id_queue`.
+    typedef logic [$bits(b_cmd_t)-1:0] b_cmd_flat_t;
+    b_cmd_flat_t b_status_inp_cmd_flat, b_status_oup_cmd_flat;
+    assign b_status_inp_cmd_flat = b_cmd_flat_t'(b_status_inp_cmd);
+    id_queue #(
+        .ID_WIDTH   (AXI_ID_WIDTH),
+        .CAPACITY   (AXI_MAX_WRITE_TXNS),
+        .data_t     (b_cmd_flat_t)
+    ) i_b_status_queue (
+        .clk_i              (clk_i),
+        .rst_ni             (rst_ni),
+        .inp_id_i           (b_status_inp_id),
+        .inp_data_i         (b_status_inp_cmd_flat),
+        .inp_req_i          (b_status_inp_req),
+        .inp_gnt_o          (b_status_inp_gnt),
+        .exists_data_i      (),
+        .exists_mask_i      (),
+        .exists_req_i       (1'b0),
+        .exists_o           (),
+        .exists_gnt_o       (),
+        .oup_id_i           (b_status_oup_id),
+        .oup_pop_i          (b_status_oup_pop),
+        .oup_req_i          (b_status_oup_req),
+        .oup_data_o         (b_status_oup_cmd_flat),
+        .oup_data_valid_o   (b_status_oup_valid),
+        .oup_gnt_o          (b_status_oup_gnt)
+    );
+    assign b_status_oup_cmd = b_cmd_t'(b_status_oup_cmd_flat);
+
+    // ID Queue to track in-flight writes.
+    id_queue #(
+        .ID_WIDTH   (AXI_ID_WIDTH),
+        .CAPACITY   (AXI_MAX_WRITE_TXNS),
+        .data_t     (w_flight_t)
+    ) i_write_in_flight_queue (
+        .clk_i              (clk_i),
+        .rst_ni             (rst_ni),
+        .inp_id_i           (mst_aw_id_o),
+        .inp_data_i         ({mst_aw_addr_o[AXI_ADDR_WIDTH-1:2], slv_aw_lock_i}),
+        .inp_req_i          (mst_aw_valid && mst_aw_ready),
+        .inp_gnt_o          (wifq_inp_gnt),
+        .exists_data_i      (wifq_exists_inp.data),
+        .exists_mask_i      (wifq_exists_inp.mask),
+        .exists_req_i       (wifq_exists_req),
+        .exists_o           (wifq_exists),
+        .exists_gnt_o       (wifq_exists_gnt),
+        .oup_id_i           (mst_b_id_i),
+        .oup_pop_i          (1'b1),
+        .oup_req_i          (wifq_oup_req),
+        .oup_data_o         (),
+        .oup_data_valid_o   (wifq_oup_data_valid),
+        .oup_gnt_o          (wifq_oup_gnt)
+    );
+
+// pragma translate_off
+    always @(posedge clk_i) begin
+        if (~rst_ni) begin
+            if (mst_aw_valid && mst_aw_ready) begin
+                assert (wifq_inp_gnt) else $error("Missed enqueuing of in-flight write!");
+            end
+            if (wifq_oup_req && wifq_oup_gnt) begin
+                assert (wifq_oup_data_valid) else $error("Unexpected B!");
+            end
+        end
+    end
+// pragma translate_on
+
+    stream_arbiter #(
+        .DATA_T (wifq_exists_t),
+        .N_INP  (2)
+    ) i_wifq_exists_arb (
+        .clk_i          (clk_i),
+        .rst_ni         (rst_ni),
+        .inp_data_i     ({ar_wifq_exists_inp,   aw_wifq_exists_inp}),
+        .inp_valid_i    ({ar_wifq_exists_req,   aw_wifq_exists_req}),
+        .inp_ready_o    ({ar_wifq_exists_gnt,   aw_wifq_exists_gnt}),
+        .oup_data_o     (wifq_exists_inp),
+        .oup_valid_o    (wifq_exists_req),
+        .oup_ready_i    (wifq_exists_gnt)
+    );
+
+    stream_fork #(
+        .N_OUP  (2)
+    ) i_mst_b_fork (
+        .clk_i      (clk_i),
+        .rst_ni     (rst_ni),
+        .valid_i    (mst_b_valid_i),
+        .ready_o    (mst_b_ready_o),
+        .valid_o    ({mst_b_valid, wifq_oup_req}),
+        .ready_i    ({mst_b_ready, wifq_oup_gnt})
+    );
+
+    // FIFO to track B responses that are to be injected.
+    fifo_v3 #(
+        .FALL_THROUGH   (1'b0),
+        .dtype          (b_inj_t),
+        .DEPTH          (AXI_MAX_WRITE_TXNS)
+    ) i_b_inj_fifo (
+        .clk_i      (clk_i),
+        .rst_ni     (rst_ni),
+        .flush_i    (1'b0),
+        .testmode_i (1'b0),
+        .full_o     (b_inj_full),
+        .empty_o    (b_inj_empty),
+        .usage_o    (),
+        .data_i     (b_inj_inp),
+        .push_i     (b_inj_push),
+        .data_o     (b_inj_oup),
+        .pop_i      (b_inj_pop)
+    );
+
+    // Fall-through register to hold AW transactin that passed
+    assign slv_aw = {slv_aw_addr_i,
+                     slv_aw_prot_i,
+                     slv_aw_region_i,
+                     slv_aw_atop_i,
+                     slv_aw_len_i,
+                     slv_aw_size_i,
+                     slv_aw_burst_i,
+                     slv_aw_cache_i,
+                     slv_aw_qos_i,
+                     slv_aw_id_i,
+                     slv_aw_user_i};
+    assign {mst_aw_addr_o,
+            mst_aw_prot_o,
+            mst_aw_region_o,
+            mst_aw_atop_o,
+            mst_aw_len_o,
+            mst_aw_size_o,
+            mst_aw_burst_o,
+            mst_aw_cache_o,
+            mst_aw_qos_o,
+            mst_aw_id_o,
+            mst_aw_user_o} = mst_aw;
+
+
+    fall_through_register #(
+        .T (aw_chan_t)
+    ) i_aw_trans_reg (
+        .clk_i       (clk_i),
+        .rst_ni      (rst_ni),
+        .clr_i       (1'b0),
+        .testmode_i  (1'b0),
+        // Input
+        .valid_i     (mst_aw_valid),
+        .ready_o     (mst_aw_ready),
+        .data_i      (slv_aw),
+        // Output
+        .valid_o     (mst_aw_valid_o),
+        .ready_i     (mst_aw_ready_i),
+        .data_o      (mst_aw)
+    );
+
     // Time-Invariant Signal Assignments
-    assign mst_aw_addr_o    = slv_aw_addr_i;
-    assign mst_aw_prot_o    = slv_aw_prot_i;
-    assign mst_aw_region_o  = slv_aw_region_i;
-    assign mst_aw_atop_o    = slv_aw_atop_i;
-    assign mst_aw_len_o     = slv_aw_len_i;
-    assign mst_aw_size_o    = slv_aw_size_i;
-    assign mst_aw_burst_o   = slv_aw_burst_i;
     assign mst_aw_lock_o    = 1'b0;
-    assign mst_aw_cache_o   = slv_aw_cache_i;
-    assign mst_aw_qos_o     = slv_aw_qos_i;
-    assign mst_aw_id_o      = slv_aw_id_i;
-    assign mst_aw_user_o    = slv_aw_user_i;
     assign mst_w_data_o     = slv_w_data_i;
     assign mst_w_strb_o     = slv_w_strb_i;
     assign mst_w_user_o     = slv_w_user_i;
     assign mst_w_last_o     = slv_w_last_i;
 
+    // Control AW Channel
     always_comb begin
-        w_addr_d    = w_addr_q;
-        w_id_d      = w_id_q;
-        if (slv_aw_valid_i && slv_aw_ready_o) begin
-            w_addr_d    = slv_aw_addr_i;
-            w_id_d      = slv_aw_id_i;
-        end
-    end
+        mst_aw_valid            = 1'b0;
+        slv_aw_ready_o          = 1'b0;
+        art_check_clr_addr      = '0;
+        art_check_clr_excl      = '0;
+        art_check_clr_req       = 1'b0;
+        aw_wifq_exists_inp.data = '0;
+        aw_wifq_exists_inp.mask = '1;
+        aw_wifq_exists_req      = 1'b0;
+        b_status_inp_id         = '0;
+        b_status_inp_cmd        = B_REGULAR;
+        b_status_inp_req        = 1'b0;
+        w_cmd_inp               = '0;
+        w_cmd_push              = 1'b0;
+        aw_state_d              = aw_state_q;
 
-    // FSM for Time-Variant Signal Assignments
-    always_comb begin
-        mst_aw_valid_o  = 1'b0;
-        slv_aw_ready_o  = 1'b0;
-        mst_w_valid_o   = 1'b0;
-        slv_w_ready_o   = 1'b0;
-        slv_b_valid_o   = 1'b0;
-        mst_b_ready_o   = 1'b0;
-        slv_b_resp_o    = '0;
-        slv_b_id_o      = '0;
-        slv_b_user_o    = '0;
-        art_check_addr  = '0;
-        art_check_id    = '0;
-        art_check_req   = 1'b0;
-        wr_clr_addr     = '0;
-        wr_clr_req      = 1'b0;
-        b_excl_d        = b_excl_q;
-        w_state_d       = w_state_q;
-
-        case (w_state_q)
-
+        case (aw_state_q)
             AW_IDLE: begin
-                if (slv_aw_valid_i) begin
-                    // New AW, and W channel is idle
+                if (slv_aw_valid_i && !w_cmd_full && b_status_inp_gnt && wifq_inp_gnt) begin
+                    // New AW and we are ready to handle it.
                     if (slv_aw_addr_i >= ADDR_BEGIN && slv_aw_addr_i <= ADDR_END) begin
-                        // Inside exclusively-accessible address range
-                        if (slv_aw_lock_i && slv_aw_len_i == 8'h00) begin
-                            // Exclusive access and no burst, so check if reservation exists
-                            art_check_addr  = slv_aw_addr_i;
-                            art_check_id    = slv_aw_id_i;
-                            art_check_req   = 1'b1;
-                            if (art_check_gnt) begin
-                                if (art_check_res) begin
-                                    // Yes, so forward downstream
-                                    mst_aw_valid_o = 1'b1;
-                                    if (mst_aw_ready_i) begin
-                                        slv_aw_ready_o    = 1'b1;
-                                        b_excl_d        = 1'b1;
-                                        w_state_d       = W_FORWARD;
-                                    end
-                                end else begin
-                                    // No, drop in W channel.
-                                    slv_aw_ready_o    = 1'b1;
-                                    w_state_d       = W_DROP;
+                        // Inside exclusively-accessible range.
+                        // Make sure no exclusive AR to the same address is currently waiting.
+                        if (!(slv_ar_valid_i && slv_ar_lock_i &&
+                                slv_ar_addr_i[AXI_ADDR_WIDTH-1:2] == slv_aw_addr_i[AXI_ADDR_WIDTH-1:2])) begin
+                            // Make sure no exclusive write to the same address is currently in
+                            // flight.
+                            aw_wifq_exists_inp.data.addr = slv_aw_addr_i[AXI_ADDR_WIDTH-1:2];
+                            aw_wifq_exists_inp.data.excl = 1'b1;
+                            aw_wifq_exists_req = 1'b1;
+                            if (aw_wifq_exists_gnt && !wifq_exists) begin
+                                // Check reservation and clear identical addresses.
+                                art_check_clr_addr  = slv_aw_addr_i[AXI_ADDR_WIDTH-1:2];
+                                art_check_clr_excl  = slv_aw_lock_i;
+                                if (mst_aw_ready) begin
+                                    art_check_clr_req = 1'b1;
                                 end
-                            end
-                        end else begin
-                            // Non-exclusive access or burst, so forward downstream
-                            mst_aw_valid_o = 1'b1;
-                            if (mst_aw_ready_i) begin
-                                slv_aw_ready_o    = 1'b1;
-                                w_state_d       = W_FORWARD;
+                                if (art_check_clr_gnt) begin
+                                    if (slv_aw_lock_i && slv_aw_len_i == 8'h00) begin
+                                        // Exclusive access and no burst, so check reservation.
+                                        if (art_check_res) begin
+                                            // Reservation exists, so forward downstream.
+                                            mst_aw_valid   = 1'b1;
+                                            slv_aw_ready_o = mst_aw_ready;
+                                            if (!mst_aw_ready) begin
+                                                aw_state_d = AW_WAIT;
+                                            end
+                                        end else begin
+                                            // No reservation exists, so drop AW.
+                                            slv_aw_ready_o = 1'b1;
+                                        end
+                                        // Store command to forward or drop W burst.
+                                        w_cmd_inp = '{forward: art_check_res, id: slv_aw_id_i,
+                                                user: slv_aw_user_i};
+                                        w_cmd_push = 1'b1;
+                                        // Add B status for this ID (exclusive if there is a
+                                        // reservation, inject otherwise).
+                                        b_status_inp_cmd = art_check_res ? B_EXCLUSIVE : B_INJECT;
+                                    end else begin
+                                        // Non-exclusive access or burst, so forward downstream.
+                                        mst_aw_valid   = 1'b1;
+                                        slv_aw_ready_o = mst_aw_ready;
+                                        // Store command to forward W burst.
+                                        w_cmd_inp  = '{forward: 1'b1, id: '0, user: '0};
+                                        w_cmd_push = 1'b1;
+                                        // Track B response as regular-okay.
+                                        b_status_inp_cmd = B_REGULAR;
+                                        if (!mst_aw_ready) begin
+                                            aw_state_d = AW_WAIT;
+                                        end
+                                    end
+                                    b_status_inp_id = slv_aw_id_i;
+                                    b_status_inp_req = 1'b1;
+                                end
                             end
                         end
                     end else begin
                         // Outside exclusively-accessible address range, so bypass any
                         // modifications.
-                        mst_aw_valid_o = 1'b1;
-                        slv_aw_ready_o = mst_aw_ready_i;
-                        if (slv_aw_ready_o) begin
-                            w_state_d = W_BYPASS;
+                        mst_aw_valid   = 1'b1;
+                        slv_aw_ready_o = mst_aw_ready;
+                        if (mst_aw_ready) begin
+                            // Store command to forward W burst.
+                            w_cmd_inp = '{forward: 1'b1, id: '0, user: '0};
+                            w_cmd_push = 1'b1;
+                            // Track B response as regular-okay.
+                            b_status_inp_id  = slv_aw_id_i;
+                            b_status_inp_cmd = B_REGULAR;
+                            b_status_inp_req = 1'b1;
                         end
                     end
                 end
             end
 
-            W_FORWARD: begin
-                mst_w_valid_o = slv_w_valid_i;
+            AW_WAIT: begin
+                mst_aw_valid   = 1'b1;
+                slv_aw_ready_o = mst_aw_ready;
+                if (mst_aw_ready) begin
+                    aw_state_d = AW_IDLE;
+                end
+            end
+
+            default:
+                aw_state_d = AW_IDLE;
+        endcase
+    end
+
+// pragma translate_off
+    if (DEBUG) begin
+        always @(posedge clk_i) begin
+            if (b_status_inp_req && b_status_inp_gnt) begin
+                $display("%0t: AW added %0x as %0d", $time, b_status_inp_id, b_status_inp_cmd);
+            end
+        end
+    end
+// pragma translate_on
+
+    // Control W Channel
+    always_comb begin
+        mst_w_valid_o   = 1'b0;
+        slv_w_ready_o   = 1'b0;
+        b_inj_inp       = '0;
+        b_inj_push      = 1'b0;
+        w_cmd_pop       = 1'b0;
+        if (slv_w_valid_i && !w_cmd_empty && !b_inj_full) begin
+            if (w_cmd_oup.forward) begin
+                // Forward
+                mst_w_valid_o = 1'b1;
                 slv_w_ready_o = mst_w_ready_i;
-                if (slv_w_valid_i && slv_w_ready_o && slv_w_last_i) begin
-                    wr_clr_addr = w_addr_q;
-                    wr_clr_req  = 1'b1;
-                    if (wr_clr_gnt) begin
-                        w_state_d = B_FORWARD;
-                    end else begin
-                        w_state_d = W_WAIT_ART_CLR;
+            end else begin
+                // Drop
+                slv_w_ready_o = 1'b1;
+            end
+            if (slv_w_ready_o && slv_w_last_i) begin
+                w_cmd_pop = 1'b1;
+                if (!w_cmd_oup.forward) begin
+                    // Add command to inject B response.
+                    b_inj_inp = '{id: w_cmd_oup.id, user: w_cmd_oup.user};
+                    b_inj_push = 1'b1;
+                end
+            end
+        end
+    end
+
+// pragma translate_off
+    if (DEBUG) begin
+        always @(posedge clk_i) begin
+            if (b_inj_push) begin
+                $display("%0t: W added inject for %0x", $time, b_inj_inp.id);
+            end
+        end
+    end
+// pragma translate_on
+
+    // Control B Channel
+    always_comb begin
+        slv_b.id            = mst_b_id_i;
+        slv_b.resp          = mst_b_resp_i;
+        slv_b.user          = mst_b_user_i;
+        slv_b_valid         = 1'b0;
+        mst_b_ready         = 1'b0;
+        b_inj_pop           = 1'b0;
+        b_status_oup_id     = '0;
+        b_status_oup_req    = 1'b0;
+        b_state_d           = b_state_q;
+
+        case (b_state_q)
+            B_NORMAL: begin
+                if (!b_inj_empty) begin
+                    // There is a response to be injected ..
+                    b_status_oup_id = b_inj_oup.id;
+                    b_status_oup_req = 1'b1;
+                    if (b_status_oup_gnt && b_status_oup_valid) begin
+                        if (b_status_oup_cmd == B_INJECT) begin
+                            // .. and the next B for that ID is indeed an injection, so go ahead and
+                            // inject it.
+                            slv_b.id    = b_inj_oup.id;
+                            slv_b.resp  = axi_pkg::RESP_OKAY;
+                            slv_b.user  = b_inj_oup.user;
+                            slv_b_valid = 1'b1;
+                            b_inj_pop   = slv_b_ready;
+                        end else begin
+                            // .. but the next B for that ID is *not* an injection, so try to
+                            // forward a B.
+                            b_state_d = B_FORWARD;
+                        end
+                    end
+                end else if (mst_b_valid) begin
+                    // There is currently no response to be injected, so try to forward a B.
+                    b_status_oup_id = mst_b_id_i;
+                    b_status_oup_req = 1'b1;
+                    if (b_status_oup_gnt && b_status_oup_valid) begin
+                        if (mst_b_resp_i[1] == 1'b0) begin
+                            slv_b.resp = {1'b0, (b_status_oup_cmd == B_EXCLUSIVE)};
+                        end else begin
+                            slv_b.resp = mst_b_resp_i;
+                        end
+                        slv_b_valid = 1'b1;
+                        mst_b_ready = slv_b_ready;
                     end
                 end
             end
 
-            W_BYPASS: begin
-                mst_w_valid_o = slv_w_valid_i;
-                slv_w_ready_o = mst_w_ready_i;
-                if (slv_w_valid_i && slv_w_ready_o && slv_w_last_i) begin
-                    w_state_d = B_FORWARD;
-                end
-            end
-
-            W_WAIT_ART_CLR: begin
-                wr_clr_addr = w_addr_q;
-                wr_clr_req  = 1'b1;
-                if (wr_clr_gnt) begin
-                    w_state_d = B_FORWARD;
-                end
-            end
-
-            W_DROP: begin
-                slv_w_ready_o = 1'b1;
-                if (slv_w_valid_i && slv_w_last_i) begin
-                    w_state_d = B_INJECT;
-                end
-            end
-
             B_FORWARD: begin
-                mst_b_ready_o   = slv_b_ready_i;
-                slv_b_valid_o   = mst_b_valid_i;
-                slv_b_resp_o[1] = mst_b_resp_i[1];
-                slv_b_resp_o[0] = (mst_b_resp_i[1] == 1'b0) ? b_excl_q : mst_b_resp_i[0];
-                slv_b_user_o    = mst_b_user_i;
-                slv_b_id_o      = mst_b_id_i;
-                if (slv_b_valid_o && slv_b_ready_i) begin
-                    b_excl_d    = 1'b0;
-                    w_state_d   = AW_IDLE;
+                if (mst_b_valid) begin
+                    b_status_oup_id = mst_b_id_i;
+                    b_status_oup_req = 1'b1;
+                    if (b_status_oup_gnt && b_status_oup_valid) begin
+                        if (mst_b_resp_i[1] == 1'b0) begin
+                            slv_b.resp = {1'b0, (b_status_oup_cmd == B_EXCLUSIVE)};
+                        end else begin
+                            slv_b.resp = mst_b_resp_i;
+                        end
+                        slv_b_valid = 1'b1;
+                        mst_b_ready = slv_b_ready;
+                        if (slv_b_ready) begin
+                            b_state_d = B_NORMAL;
+                        end
+                    end
                 end
             end
 
-            B_INJECT: begin
-                slv_b_id_o = w_id_q;
-                slv_b_resp_o = 2'b00;
-                slv_b_valid_o = 1'b1;
-                if (slv_b_ready_i) begin
-                    w_state_d = AW_IDLE;
-                end
-            end
-
-            default: begin
-                w_state_d = AW_IDLE;
-            end
+            default:
+                b_state_d = B_NORMAL;
         endcase
     end
 
+// pragma translate_off
+    always @(posedge clk_i) begin
+        if (b_status_oup_req && b_status_oup_gnt) begin
+            assert (b_status_oup_valid);
+            if ((b_state_q == B_NORMAL && b_inj_empty) || b_state_q == B_FORWARD) begin
+                assert (b_status_oup_cmd != B_INJECT);
+            end
+        end
+    end
+// pragma translate_on
+
+// pragma translate_off
+    if (DEBUG) begin
+        always @(posedge clk_i) begin
+            if (slv_b_valid && slv_b_ready) begin
+                if (mst_b_ready) begin
+                    $display("%0t: B forwarded %0x", $time, slv_b.id);
+                end else begin
+                    $display("%0t: B injected  %0x", $time, slv_b.id);
+                end
+            end
+        end
+    end
+// pragma translate_on
+
+    assign b_status_oup_pop = slv_b_valid && slv_b_ready;
+
+    // Register in front of slv_b to prevent changes by FSM while valid and not yet ready.
+    stream_register #(
+        .T  (b_chan_t)
+    ) slv_b_reg (
+        .clk_i      (clk_i),
+        .rst_ni     (rst_ni),
+        .clr_i      (1'b0),
+        .testmode_i (1'b0),
+
+        .valid_i    (slv_b_valid),
+        .ready_o    (slv_b_ready),
+        .data_i     (slv_b),
+
+        .valid_o    (slv_b_valid_o),
+        .ready_i    (slv_b_ready_i),
+        .data_o     ({slv_b_id_o, slv_b_user_o, slv_b_resp_o})
+    );
+
+    // Fall-through register in front of slv_r to remove mutual dependency.
+    spill_register #( // There would be a combinatorial loop if this were a fall-through register.
+                      // Optimizing this can reduce the latency of this module.
+        .T  (r_chan_t)
+    ) slv_r_reg (
+        .clk_i      (clk_i),
+        .rst_ni     (rst_ni),
+
+        .valid_i    (slv_r_valid),
+        .ready_o    (slv_r_ready),
+        .data_i     (slv_r),
+
+        .valid_o    (slv_r_valid_o),
+        .ready_i    (slv_r_ready_i),
+        .data_o     ({slv_r_id_o, slv_r_data_o, slv_r_resp_o, slv_r_user_o, slv_r_last_o})
+    );
+
     // AXI Reservation Table
+
+    assign art_check_id = AXI_USER_AS_ID ?
+            slv_aw_user_i[AXI_USER_ID_MSB:AXI_USER_ID_LSB]
+            : slv_aw_id_i;
+    assign art_set_id = AXI_USER_AS_ID ?
+            slv_ar_user_i[AXI_USER_ID_MSB:AXI_USER_ID_LSB]
+            : slv_ar_id_i;
     axi_res_tbl #(
-        .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
-        .AXI_ID_WIDTH   (AXI_ID_WIDTH)
+        .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH-2), // Track reservations word-wise.
+        .AXI_ID_WIDTH   (RES_ID_WIDTH)
     ) i_art (
         .clk_i                  (clk_i),
         .rst_ni                 (rst_ni),
-        .clr_addr_i             (art_clr_addr),
-        .clr_req_i              (art_clr_req),
-        .clr_gnt_o              (art_clr_gnt),
-        .set_addr_i             (art_set_addr),
+        .check_clr_addr_i       (art_check_clr_addr),
+        .check_id_i             (art_check_id),
+        .check_clr_excl_i       (art_check_clr_excl),
+        .check_res_o            (art_check_res),
+        .check_clr_req_i        (art_check_clr_req),
+        .check_clr_gnt_o        (art_check_clr_gnt),
+        .set_addr_i             (ar_push_addr),
         .set_id_i               (art_set_id),
         .set_req_i              (art_set_req),
-        .set_gnt_o              (art_set_gnt),
-        .check_addr_i           (art_check_addr),
-        .check_id_i             (art_check_id),
-        .check_res_o            (art_check_res),
-        .check_req_i            (art_check_req),
-        .check_gnt_o            (art_check_gnt)
-    );
-
-    // ART Clear Arbiter
-    stream_arbiter #(
-        .DATA_T     (logic[AXI_ADDR_WIDTH-1:0]),
-        .N_INP      (2)
-    ) i_non_excl_acc_arb (
-        .clk_i          (clk_i),
-        .rst_ni         (rst_ni),
-        .inp_data_i     ({rd_clr_addr,  wr_clr_addr}),
-        .inp_valid_i    ({rd_clr_req,   wr_clr_req}),
-        .inp_ready_o    ({rd_clr_gnt,   wr_clr_gnt}),
-        .oup_data_o     (art_clr_addr),
-        .oup_valid_o    (art_clr_req),
-        .oup_ready_i    (art_clr_gnt)
+        .set_gnt_o              (art_set_gnt)
     );
 
     // Registers
     always_ff @(posedge clk_i, negedge rst_ni) begin
         if (~rst_ni) begin
-            b_excl_q    <= 1'b0;
-            r_excl_q    <= 1'b0;
-            r_state_q   <= R_IDLE;
-            w_addr_q    <= '0;
-            w_id_q      <= '0;
-            w_state_q   <= AW_IDLE;
+            ar_state_q = AR_IDLE;
+            aw_state_q = AW_IDLE;
+            b_state_q  = B_NORMAL;
         end else begin
-            b_excl_q    <= b_excl_d;
-            r_excl_q    <= r_excl_d;
-            r_state_q   <= r_state_d;
-            w_addr_q    <= w_addr_d;
-            w_id_q      <= w_id_d;
-            w_state_q   <= w_state_d;
+            ar_state_q = ar_state_d;
+            aw_state_q = aw_state_d;
+            b_state_q  = b_state_d;
         end
     end
 
@@ -502,6 +996,16 @@ module axi_riscv_lrsc #(
             else $fatal(1, "AXI_DATA_WIDTH must be greater than 0!");
         assert (AXI_ID_WIDTH > 0)
             else $fatal(1, "AXI_ID_WIDTH must be greater than 0!");
+        assert (AXI_MAX_READ_TXNS > 0)
+            else $fatal(1, "AXI_MAX_READ_TXNS must be greater than 0!");
+        assert (AXI_MAX_WRITE_TXNS > 0)
+            else $fatal(1, "AXI_MAX_WRITE_TXNS must be greater than 0!");
+        if (AXI_USER_AS_ID) begin
+            assert (AXI_USER_ID_MSB >= AXI_USER_ID_LSB)
+                else $fatal(1, "AXI_USER_ID_MSB must be greater equal to AXI_USER_ID_LSB!");
+            assert (AXI_USER_WIDTH > AXI_USER_ID_MSB)
+                else $fatal(1, "AXI_USER_WIDTH must be greater than AXI_USER_ID_MSB!");
+        end
     end
 `endif
 // pragma translate_on

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/src_files.yml
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/src_files.yml
@@ -1,0 +1,11 @@
+axi_riscv_atomics:
+  files: [
+    src/axi_res_tbl.sv,
+    src/axi_riscv_amos_alu.sv,
+    src/axi_riscv_amos.sv,
+    src/axi_riscv_amos_wrap.sv,
+    src/axi_riscv_lrsc.sv,
+    src/axi_riscv_lrsc_wrap.sv,
+    src/axi_riscv_atomics.sv,
+    src/axi_riscv_atomics_wrap.sv,
+  ]

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_atomics_synth.v
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_atomics_synth.v
@@ -16,8 +16,10 @@ module axi_riscv_atomics_synth #(
     parameter integer AXI_DATA_WIDTH = 64,
     parameter integer AXI_ID_WIDTH = 4,
     parameter integer AXI_USER_WIDTH = 0,
-    /// Maximum number of AXI bursts outstanding at the same time
+    /// Maximum number of AXI write bursts outstanding at the same time
     parameter integer AXI_MAX_WRITE_TXNS = 4,
+    /// Maximum number of AXI read bursts outstanding at the same time
+    parameter integer AXI_MAX_READ_TXNS = 4,
     // Word width of the widest RISC-V processor that can issue requests to this module.
     // 32 for RV32; 64 for RV64, where both 32-bit (.W suffix) and 64-bit (.D suffix) AMOs are
     // supported if `aw_strb` is set correctly.
@@ -136,6 +138,7 @@ module axi_riscv_atomics_synth #(
         .AXI_DATA_WIDTH     (AXI_DATA_WIDTH),
         .AXI_ID_WIDTH       (AXI_ID_WIDTH),
         .AXI_USER_WIDTH     (AXI_USER_WIDTH),
+        .AXI_MAX_READ_TXNS  (AXI_MAX_READ_TXNS),
         .AXI_MAX_WRITE_TXNS (AXI_MAX_WRITE_TXNS),
         .RISCV_WORD_WIDTH   (RISCV_WORD_WIDTH)
     ) i_axi_riscv_atomics (

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_atomics_tb.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_atomics_tb.sv
@@ -1,0 +1,808 @@
+// Copyright (c) 2019 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+`include "axi/assign.svh"
+
+module automatic axi_riscv_atomics_tb;
+
+    // Constants
+    parameter NUM_MASTERS    = 32;
+    parameter OFFSET         = 16;
+    parameter MAX_TIMEOUT    = 1000; // Cycles
+    parameter USER_AS_ID     = `ifdef DEF_USER_AS_ID `DEF_USER_AS_ID `else 0 `endif; // Use the aw_user signal as the reservation ID instead of the aw_id
+
+    parameter AXI_ADDR_WIDTH = 64;
+    parameter AXI_DATA_WIDTH = 64;
+    parameter AXI_ID_WIDTH_M = 8;
+    parameter AXI_ID_WIDTH_S = AXI_ID_WIDTH_M + $clog2(NUM_MASTERS);
+    parameter AXI_ID_WIDTH_N = USER_AS_ID ? AXI_ID_WIDTH_M : AXI_ID_WIDTH_S;
+    parameter AXI_USER_WIDTH = $clog2(NUM_MASTERS);
+
+    parameter SYS_DATA_WIDTH = 64;
+    parameter SYS_OFFSET_BIT = $clog2(SYS_DATA_WIDTH/8);
+
+    parameter MEM_ADDR_WIDTH = 18;
+    parameter MEM_START_ADDR = 128'h0000_0000_0000_0000_0000_0000_0000_0000; //32'h1C00_0000;
+    parameter MEM_END_ADDR   = 128'hFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF; //MEM_START_ADDR + (2**MEM_ADDR_WIDTH);
+
+    // Signal declarations
+    logic clk   = 0;
+    logic rst_n = 0;
+
+    // Generate clock
+    localparam tCK = 10ns;
+
+    initial begin : clk_gen
+        #tCK;
+        while (1) begin
+            clk <= 1;
+            #(tCK/2);
+            clk <= 0;
+            #(tCK/2);
+        end
+    end
+
+    initial begin : rst_gen
+        rst_n <= 0;
+        @(posedge clk);
+        #(tCK/2);
+        rst_n <= 1;
+    end
+
+    initial $timeformat(-9, 2, " ns", 10);
+
+    // Testbench status
+    logic finished = 0;
+    int unsigned num_errors = 0;
+
+    // AXI bus declarations
+    AXI_BUS #(
+        .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH ),
+        .AXI_DATA_WIDTH ( AXI_DATA_WIDTH ),
+        .AXI_ID_WIDTH   ( AXI_ID_WIDTH_N ),
+        .AXI_USER_WIDTH ( AXI_USER_WIDTH )
+    ) axi_mem();
+
+    AXI_BUS #(
+        .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH ),
+        .AXI_DATA_WIDTH ( AXI_DATA_WIDTH ),
+        .AXI_ID_WIDTH   ( AXI_ID_WIDTH_S ),
+        .AXI_USER_WIDTH ( AXI_USER_WIDTH )
+    ) axi_iwc();
+
+    AXI_BUS #(
+        .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH ),
+        .AXI_DATA_WIDTH ( AXI_DATA_WIDTH ),
+        .AXI_ID_WIDTH   ( AXI_ID_WIDTH_N ),
+        .AXI_USER_WIDTH ( AXI_USER_WIDTH )
+    ) axi_dut();
+
+    // Simulated clusters
+    AXI_BUS #(
+        .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH ),
+        .AXI_DATA_WIDTH ( AXI_DATA_WIDTH ),
+        .AXI_ID_WIDTH   ( AXI_ID_WIDTH_M ),
+        .AXI_USER_WIDTH ( AXI_USER_WIDTH )
+    ) axi_cl[NUM_MASTERS]();
+
+    AXI_BUS_DV #(
+        .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH ),
+        .AXI_DATA_WIDTH ( AXI_DATA_WIDTH ),
+        .AXI_ID_WIDTH   ( AXI_ID_WIDTH_M ),
+        .AXI_USER_WIDTH ( AXI_USER_WIDTH )
+    ) axi_cl_dv[NUM_MASTERS](
+        .clk_i          ( clk            )
+    );
+
+    // Monitor bus for golden model
+    MONITOR_BUS_DV #(
+        .ADDR_WIDTH ( AXI_ADDR_WIDTH ),
+        .DATA_WIDTH ( AXI_DATA_WIDTH ),
+        .ID_WIDTH   ( AXI_ID_WIDTH_N ),
+        .USER_WIDTH ( AXI_USER_WIDTH )
+    ) mem_monitor_dv (
+        .clk_i  ( clk )
+    );
+
+    generate
+        for (genvar i = 0; i < NUM_MASTERS; i++) begin
+            `AXI_ASSIGN(axi_cl[i], axi_cl_dv[i]);
+        end
+    endgenerate
+
+    // Multiplexer between simulated clusters and atomics adapter
+    axi_mux_intf #(
+        .SLV_AXI_ID_WIDTH   ( AXI_ID_WIDTH_M ),
+        .MST_AXI_ID_WIDTH   ( AXI_ID_WIDTH_S ),
+        .AXI_ADDR_WIDTH     ( AXI_ADDR_WIDTH ),
+        .AXI_DATA_WIDTH     ( AXI_DATA_WIDTH ),
+        .AXI_USER_WIDTH     ( AXI_USER_WIDTH ),
+        .NO_SLV_PORTS       ( NUM_MASTERS    ),
+        .MAX_W_TRANS        ( 8              ),
+        .FALL_THROUGH       ( 1'b1           ),
+        .SPILL_AW           ( 1'b0           ),
+        .SPILL_W            ( 1'b0           ),
+        .SPILL_B            ( 1'b0           ),
+        .SPILL_AR           ( 1'b0           ),
+        .SPILL_R            ( 1'b0           )
+    ) i_axi_mux (
+        .clk_i  ( clk     ),
+        .rst_ni ( rst_n   ),
+        .test_i ( 1'b0    ),
+        .slv    ( axi_cl  ),
+        .mst    ( axi_iwc )
+    );
+
+    axi_iw_converter_intf #(
+      .AXI_SLV_PORT_ID_WIDTH        ( AXI_ID_WIDTH_S    ),
+      .AXI_MST_PORT_ID_WIDTH        ( AXI_ID_WIDTH_N    ),
+      .AXI_SLV_PORT_MAX_UNIQ_IDS    ( 2**AXI_ID_WIDTH_S ),
+      .AXI_SLV_PORT_MAX_TXNS_PER_ID ( 8                 ),
+      .AXI_SLV_PORT_MAX_TXNS        ( NUM_MASTERS*8     ),
+      .AXI_MST_PORT_MAX_UNIQ_IDS    ( 2**AXI_ID_WIDTH_N ),
+      .AXI_MST_PORT_MAX_TXNS_PER_ID ( 8                 ),
+      .AXI_ADDR_WIDTH               ( AXI_ADDR_WIDTH    ),
+      .AXI_DATA_WIDTH               ( AXI_DATA_WIDTH    ),
+      .AXI_USER_WIDTH               ( AXI_USER_WIDTH    )
+    ) i_axi_iw_converter_intf (
+      .clk_i  ( clk     ),
+      .rst_ni ( rst_n   ),
+      .slv    ( axi_iwc ),
+      .mst    ( axi_dut )
+    );
+
+    // axi_riscv_amos_wrap #(
+    axi_riscv_atomics_wrap #(
+        .AXI_ADDR_WIDTH     ( AXI_ADDR_WIDTH   ),
+        .AXI_DATA_WIDTH     ( AXI_DATA_WIDTH   ),
+        .AXI_ID_WIDTH       ( AXI_ID_WIDTH_N   ),
+        .AXI_USER_WIDTH     ( AXI_USER_WIDTH   ),
+        .AXI_MAX_READ_TXNS  ( 31               ),
+        .AXI_MAX_WRITE_TXNS ( 31               ),
+        .AXI_USER_AS_ID     ( USER_AS_ID       ),
+        .AXI_USER_ID_MSB    ( AXI_USER_WIDTH-1 ),
+        .AXI_USER_ID_LSB    ( 0                ),
+        .RISCV_WORD_WIDTH   ( SYS_DATA_WIDTH   )
+    ) i_axi_atomic_adapter (
+        .clk_i    ( clk     ),
+        .rst_ni   ( rst_n   ),
+        .mst      ( axi_mem ),
+        .slv      ( axi_dut )
+    );
+
+    // Memory accessible over AXI bus
+    axi_sim_mem_intf #(
+        .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH ),
+        .AXI_DATA_WIDTH ( AXI_DATA_WIDTH ),
+        .AXI_ID_WIDTH   ( AXI_ID_WIDTH_N ),
+        .AXI_USER_WIDTH ( AXI_USER_WIDTH ),
+        .APPL_DELAY     ( tCK * 1 / 4    ),
+        .ACQ_DELAY      ( tCK * 3 / 4    )
+    ) i_axi_sim_mem (
+        .clk_i              ( clk                         ),
+        .rst_ni             ( rst_n                       ),
+        .axi_slv            ( axi_mem                     ),
+        .mon_w_valid_o      ( mem_monitor_dv.w_valid      ),
+        .mon_w_addr_o       ( mem_monitor_dv.w_addr       ),
+        .mon_w_data_o       ( mem_monitor_dv.w_data       ),
+        .mon_w_id_o         ( mem_monitor_dv.w_id         ),
+        .mon_w_user_o       ( mem_monitor_dv.w_user       ),
+        .mon_w_beat_count_o ( mem_monitor_dv.w_beat_count ),
+        .mon_w_last_o       ( mem_monitor_dv.w_last       ),
+        .mon_r_valid_o      ( mem_monitor_dv.r_valid      ),
+        .mon_r_addr_o       ( mem_monitor_dv.r_addr       ),
+        .mon_r_data_o       ( mem_monitor_dv.r_data       ),
+        .mon_r_id_o         ( mem_monitor_dv.r_id         ),
+        .mon_r_user_o       ( mem_monitor_dv.r_user       ),
+        .mon_r_beat_count_o ( mem_monitor_dv.r_beat_count ),
+        .mon_r_last_o       ( mem_monitor_dv.r_last       )
+    );
+
+    // AXI Testbench
+    // AXI driver
+    tb_axi_pkg::axi_access #(
+        .AW( AXI_ADDR_WIDTH ),
+        .DW( AXI_DATA_WIDTH ),
+        .IW( AXI_ID_WIDTH_M ),
+        .UW( AXI_USER_WIDTH ),
+        .SW( SYS_DATA_WIDTH ),
+        .TA( tCK * 1 / 4    ),
+        .TT( tCK * 3 / 4    )
+    ) axi_dut_master[NUM_MASTERS];
+
+    generate
+        for (genvar i = 0; i < NUM_MASTERS; i++) begin : gen_axi_access
+            initial begin
+                axi_dut_master[i] = new(i, axi_cl_dv[i]);
+            end
+        end
+    endgenerate
+
+    // Golden model
+    // The `axi_sim_mem` can hold the full addressable range of memory, so let's do the same
+    golden_model_pkg::golden_memory #(
+        .MEM_ADDR_WIDTH( AXI_ADDR_WIDTH ),
+        .MEM_DATA_WIDTH( SYS_DATA_WIDTH ),
+        .AXI_ADDR_WIDTH( AXI_ADDR_WIDTH ),
+        .AXI_DATA_WIDTH( AXI_DATA_WIDTH ),
+        .AXI_ID_WIDTH_M( AXI_ID_WIDTH_M ),
+        .AXI_ID_WIDTH_S( AXI_ID_WIDTH_N ),
+        .AXI_USER_WIDTH( AXI_USER_WIDTH ),
+        .USER_AS_ID    ( USER_AS_ID     ),
+        .APPL_DELAY    ( tCK * 1 / 4    ),
+        .ACQ_DELAY     ( tCK * 3 / 4    )
+    ) gold_memory = new(mem_monitor_dv);
+
+    /*====================================================================
+    =                                Main                                =
+    ====================================================================*/
+    initial begin : main
+        // Initialize the AXI drivers
+        for (int i = 0; i < NUM_MASTERS; i++) begin
+            axi_dut_master[i].reset_master();
+        end
+        // Wait for reset
+        @(posedge clk);
+        wait (rst_n);
+        @(posedge clk);
+        // Run tests!
+        test_all_amos();
+        test_same_address();
+        test_amo_write_consistency();
+        // test_interleaving(); // Only works on old memory controller
+        test_atomic_counter();
+        random_amo();
+
+        overtake_r();
+
+        finished = 1;
+    end
+
+    /*====================================================================
+    =                               Timeout                              =
+    ====================================================================*/
+    initial begin : timeout_block
+        // Signals to check
+        automatic int unsigned timeout = 0;
+        automatic logic [3:0] handshake = 0;
+        // Check for timeout
+        @(posedge clk);
+        wait (rst_n);
+
+        fork
+            while (timeout < MAX_TIMEOUT) begin
+                handshake = {axi_dut.aw_valid, axi_dut.aw_ready, axi_dut.ar_valid, axi_dut.ar_ready};
+                #100ns;
+                @(posedge clk);
+                if (handshake != {axi_dut.aw_valid, axi_dut.aw_ready, axi_dut.ar_valid, axi_dut.ar_ready}) begin
+                    timeout = 0;
+                end else begin
+                    timeout += 1;
+                end
+            end
+            while (!finished) begin
+                #100ns;
+                @(posedge clk);
+            end
+        join_any
+
+        if (finished && num_errors == 0) begin
+            $display("\nSUCCESS\n");
+        end else if (finished) begin
+            $display("\nFINISHED\n");
+            if (num_errors > 0) begin
+                $fatal(1, "Encountered %d errors.", num_errors);
+            end else begin
+                $display("All tests passed.");
+            end
+        end else begin
+            $fatal(1, "TIMEOUT");
+        end
+
+        $stop;
+    end
+
+    /*====================================================================
+    =                            Random tests                            =
+    ====================================================================*/
+    task automatic random_amo();
+
+        $display("Test random atomic accesses...\n");
+
+        // Create multiple drivers
+        for (int i = 0; i < NUM_MASTERS; i++) begin
+            fork
+                automatic int m = i;
+                begin
+                    automatic logic [AXI_ADDR_WIDTH-1:0] address;
+                    automatic logic [AXI_ID_WIDTH_M-1:0] id;
+                    automatic logic [AXI_USER_WIDTH-1:0] user;
+                    automatic logic [SYS_DATA_WIDTH-1:0] data_init;
+                    automatic logic [SYS_DATA_WIDTH-1:0] data_amo;
+                    automatic logic [2:0]                size;
+                    automatic logic [5:0]                atop;
+
+                    automatic logic [SYS_DATA_WIDTH-1:0] r_data;
+                    automatic logic [SYS_DATA_WIDTH-1:0] exp_data;
+                    automatic logic [SYS_DATA_WIDTH-1:0] act_data;
+                    automatic logic [1:0]                b_resp;
+                    automatic logic [1:0]                exp_b_resp;
+
+                    // Make some non-atomic transactions
+                    repeat (100) begin
+                        void'(randomize(address));
+                        void'(randomize(data_init));
+                        void'(randomize(id));
+                        void'(randomize(user));
+                        size = $urandom_range(0,SYS_OFFSET_BIT);
+                        create_consistent_transaction(address, size, 0);
+                        // Write
+                        fork
+                            axi_dut_master[m].axi_write(address, data_init, size, id, user, r_data, b_resp);
+                            gold_memory.write(address, data_init, size, id, user, m, exp_data, exp_b_resp);
+                        join
+                        assert(b_resp == exp_b_resp) else begin
+                            $warning("B (0x%1x) did not match expected (0x%1x)", b_resp, exp_b_resp);
+                            num_errors += 1;
+                        end
+                        // Read
+                        fork
+                            axi_dut_master[m].axi_read(address, act_data, size, id, user);
+                            gold_memory.read(address, exp_data, size, id, user, m);
+                        join
+                        assert(act_data == exp_data) else begin
+                            $warning("R (0x%x) did not match expected data (0x%x) at address 0x%x, size 0x%x", act_data, exp_data, address, size);
+                            num_errors += 1;
+                        end
+                    end
+
+                    repeat (500) @(posedge clk);
+                    repeat (2000) begin
+                        void'(randomize(address));
+                        void'(randomize(data_init));
+                        void'(randomize(data_amo));
+                        void'(randomize(id));
+                        void'(randomize(atop));
+                        size = $urandom_range(0,SYS_OFFSET_BIT);
+
+                        // Mix in some non-atomic accesses
+                        if (atop[3] == 1'b1) begin
+                            atop = 6'b0;
+                        end
+                        // Make transaction valid
+                        create_consistent_transaction(address, size, atop);
+                        // Execute a write with data init, a AMO with data_amo and read result
+                        write_amo_read_cycle(m, address, data_init, data_amo, size, id, m, atop);
+                        // Wait a random amount of cycles
+                        repeat ($urandom_range(100,MAX_TIMEOUT/2)) @(posedge clk);
+                    end
+                end
+            join_none
+        end
+
+        // Wait for all cores to finish
+        wait fork;
+
+    endtask : random_amo
+
+    task automatic overtake_r();
+
+        $display("Try to overtake R...\n");
+        fork
+            begin
+                // Create writes to slow down other thread
+                automatic logic [AXI_ADDR_WIDTH-1:0] address;
+                automatic logic [AXI_ID_WIDTH_M-1:0] id;
+                automatic logic [SYS_DATA_WIDTH-1:0] data_init;
+                automatic logic [2:0]                size;
+                automatic logic [SYS_DATA_WIDTH-1:0] r_data;
+                automatic logic [1:0]                b_resp;
+
+                void'(randomize(address));
+                void'(randomize(data_init));
+                void'(randomize(id));
+                size = $urandom_range(0,SYS_OFFSET_BIT);
+                create_consistent_transaction(address, size, 0);
+
+                repeat (20000) begin
+                    axi_dut_master[0].axi_write(address, data_init, size, id, 0, r_data, b_resp);
+                end
+            end
+            begin
+                // Create AMOs
+                automatic logic [AXI_ADDR_WIDTH-1:0] address;
+                automatic logic [AXI_ID_WIDTH_M-1:0] id;
+                automatic logic [SYS_DATA_WIDTH-1:0] data_init;
+                automatic logic [SYS_DATA_WIDTH-1:0] data_amo;
+                automatic logic [2:0]                size;
+                automatic logic [5:0]                atop = 6'b100000;
+
+                repeat (2000) begin
+                    void'(randomize(address));
+                    void'(randomize(data_init));
+                    void'(randomize(data_amo));
+                    void'(randomize(id));
+                    size = $urandom_range(0,SYS_OFFSET_BIT);
+
+                    // Make transaction valid
+                    create_consistent_transaction(address, size, atop);
+                    // Execute a write with data init, a AMO with data_amo and read result
+                    write_amo_read_cycle(1, address, data_init, data_amo, size, id, 1, atop);
+                    // Wait a random amount of cycles
+                    // repeat ($urandom_range(100,1000)) @(posedge clk);
+                end
+            end
+        join
+
+    endtask : overtake_r
+
+    /*====================================================================
+    =                         Hand crafted tests                         =
+    ====================================================================*/
+    task automatic test_all_amos();
+
+        localparam AXI_OFFSET_BIT = $clog2(AXI_DATA_WIDTH/8);
+
+        automatic logic [AXI_ADDR_WIDTH-1:0] address;
+        automatic logic [SYS_DATA_WIDTH-1:0] data_init;
+        automatic logic [SYS_DATA_WIDTH-1:0] data_amo;
+        automatic logic [2:0]                size;
+        automatic logic [1:0]                atomic_transaction;
+        automatic logic [2:0]                atomic_operation;
+        automatic logic [5:0]                atop;
+
+        $display("Test all possible amos with a single thread...\n");
+
+        // There are 17 AMO instructions + regular write
+        for (int i = 0; i < 18; i++) begin
+            // Go through all atomic operations
+            atomic_operation   = i % 8;
+            if (i < 8) begin
+                // Atomic load
+                atomic_transaction = 2'b10;
+            end else if (i < 16) begin
+                // Atomic store
+                atomic_transaction = 2'b01;
+            end else if (i == 16) begin
+                // Atomic swap
+                atomic_transaction = 2'b11;
+                atomic_operation   = 0;
+            end else if (i == 17) begin
+                // Atomic swap
+                atomic_transaction = 2'b0;
+                atomic_operation   = 0;
+            end
+            atop = {atomic_transaction, 1'b0, atomic_operation};
+
+            // Check all possible sizes
+            for (int j = 2; j <= SYS_OFFSET_BIT; j++) begin
+                // AMOs need to have at least 4 bytes --> start with size = 2
+                size = j;
+
+                // Test all possible alignments
+                for (int k = 0; k < AXI_DATA_WIDTH/8; k = k+(2**size)) begin
+
+                    // Test instructions with all possible signed/unsigned combinations
+                    for (int l = 0; l < 4; l++) begin
+                        // Find MSB (size is log2(num_bytes))
+                        int unsigned msb = 2**size * 8;
+                        void'(randomize(address));
+                        void'(randomize(data_init));
+                        void'(randomize(data_amo));
+                        address[AXI_OFFSET_BIT-1:0] = k;
+
+                        case (l)
+                            0 : begin
+                                // unsigned/unsigned
+                                data_init[msb-1] = 1'b0;
+                                data_amo[msb-1]  = 1'b0;
+                            end
+                            1 : begin
+                                // unsigned/signed
+                                data_init[msb-1] = 1'b0;
+                                data_amo[msb-1]  = 1'b1;
+                            end
+                            2 : begin
+                                // signed/unsigned
+                                data_init[msb-1] = 1'b1;
+                                data_amo[msb-1]  = 1'b0;
+                            end
+                            3 : begin
+                                // signed/signed
+                                data_init[msb-1] = 1'b1;
+                                data_amo[msb-1]  = 1'b1;
+                            end
+                        endcase
+
+                        create_consistent_transaction(address, size, atop);
+                        // $display("Test: AMO=%x, Size=%x, Offset=%x, Sign=%x: %x # %x @(%x)", i, j, k, l, data_init, data_amo, address);
+                        write_amo_read_cycle(0, address, data_init, data_amo, size, 0, 0, atop);
+
+                    end
+                end
+            end
+        end
+
+    endtask : test_all_amos
+
+    // Test multiple atomic accesses to the same address
+    task automatic test_atomic_counter();
+        // Parameters
+        parameter NUM_ITERATION = 100;
+        parameter COUNTER_ADDR  = 'h01002000;
+        // Variables
+        automatic logic [SYS_DATA_WIDTH-1:0] r_data;
+        automatic logic [2:0] size = SYS_OFFSET_BIT;
+        automatic logic [1:0] b_resp;
+
+        $display("Run atomic counter...\n");
+
+        // Initialize to zero
+        axi_dut_master[0].axi_write(COUNTER_ADDR, 0, size, 0, 0, r_data, b_resp, 6'b000000);
+
+        // Create multiple drivers
+        for (int i = 0; i < NUM_MASTERS; i++) begin
+            fork
+                automatic int m = i;
+                for (int i = 0; i < NUM_ITERATION; i++) begin
+                    axi_dut_master[m].axi_write(COUNTER_ADDR, 1, size, m, m, r_data, b_resp, 6'b100000);
+                end
+            join_none
+        end
+
+        // Wait for all cores to finish
+        wait fork;
+
+        // Check result
+        axi_dut_master[0].axi_read(COUNTER_ADDR, r_data, size, 0, 0);
+
+        if (r_data == NUM_ITERATION*NUM_MASTERS) begin
+            $display("Adder result correct: %d", r_data);
+        end else begin
+            $display("Adder result wrong: %d (Expected: %d)", r_data, NUM_ITERATION*NUM_MASTERS);
+        end
+
+    endtask : test_atomic_counter
+
+    // Test if the adapter protects the atomic region correctly
+    task automatic test_same_address();
+        // Parameters
+        parameter NUM_ITERATION = 10;
+        parameter ADDRESS = 'h01004000;
+        // Variables
+        automatic logic [AXI_ADDR_WIDTH-1:0] address = ADDRESS; // shared by all threads
+        automatic logic [SYS_DATA_WIDTH-1:0] r_data_init;
+        automatic logic [1:0] b_resp_init;
+        automatic logic [SYS_DATA_WIDTH-1:0] exp_data_init;
+        automatic logic [1:0] exp_b_resp_init;
+
+        $display("Test random accesses to the same memory location...\n");
+
+        // Initialize memory with 0
+        fork
+            axi_dut_master[0].axi_write(address, 0, SYS_OFFSET_BIT, 1, 1, r_data_init, b_resp_init);
+            gold_memory.write(address, 0, SYS_OFFSET_BIT, 1, 1, 0, exp_data_init, exp_b_resp_init);
+        join
+
+        // Spawn multiple processes accessing this address
+        for (int i = 0; i < NUM_MASTERS; i++) begin
+            fork
+                automatic int m = i;
+                automatic logic [SYS_OFFSET_BIT-1:0] addr_range;
+                automatic logic [AXI_ID_WIDTH_M-1:0] id;
+                automatic logic [AXI_USER_WIDTH-1:0] user;
+                automatic logic [AXI_ID_WIDTH_S-1:0] s_id;
+                automatic logic [SYS_DATA_WIDTH-1:0] w_data;
+                automatic logic [2:0]                size = 3'b011;
+                automatic logic [SYS_DATA_WIDTH-1:0] r_data;
+                automatic logic [SYS_DATA_WIDTH-1:0] exp_data;
+                automatic logic [1:0] b_resp;
+                automatic logic [1:0] exp_b_resp;
+                automatic logic [5:0] atop;
+                for (int j = 0; j < NUM_ITERATION; j++) begin
+                    // Randomize address but keep it in same word
+                    void'(randomize(addr_range));
+                    address = ADDRESS + addr_range;
+                    user = m;
+                    void'(randomize(id));
+                    void'(randomize(w_data));
+                    void'(randomize(atop));
+                    void'(randomize(size));
+                    size = 3'b011;
+                    if (atop[3] | (&atop[5:4] & |atop[2:0])) begin
+                        atop = 6'b000000;
+                    end
+                    create_consistent_transaction(address, size, atop);
+                    fork
+                        axi_dut_master[m].axi_write(address, w_data, size, id, user, r_data, b_resp, atop);
+                        gold_memory.write(address, w_data, size, id, user, m, exp_data, exp_b_resp, atop);
+                    join
+                    assert(b_resp == exp_b_resp) else begin
+                        $warning("B (0x%1x) did not match expected (0x%1x)", b_resp, exp_b_resp);
+                        num_errors += 1;
+                    end
+                    if ((atop[5:3] == {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END}) |
+                        (atop[5:3] == {axi_pkg::ATOP_ATOMICSWAP, axi_pkg::ATOP_LITTLE_END})) begin
+                        assert(r_data == exp_data) else begin
+                            $warning("ATOP (0x%x) did not match expected data (0x%x) at address 0x%x at operation: 0x%2x", r_data, exp_data, address, atop);
+                            num_errors += 1;
+                        end
+                    end
+                end
+            join_none
+        end
+
+        // Wait for all cores to finish
+        wait fork;
+
+        #1000ns;
+
+    endtask : test_same_address
+
+    // Test if the adapter protects the atomic region correctly
+    task automatic test_amo_write_consistency();
+        // Parameters
+        parameter NUM_ITERATION = 200;
+        parameter ADDRESS_START = 'h01004000;
+        parameter ADDRESS_END   = 'h01004040;
+        // Variables
+        automatic logic [AXI_ADDR_WIDTH-1:0] address = ADDRESS_START; // shared by all threads
+        automatic logic [SYS_DATA_WIDTH-1:0] r_data_init;
+        automatic logic [1:0] b_resp_init;
+        automatic logic [SYS_DATA_WIDTH-1:0] exp_data_init;
+        automatic logic [1:0] exp_b_resp_init;
+
+        $display("Test AMO and write consistency...\n");
+
+        // Initialize memory with 0
+        for (int i = 0; i < (ADDRESS_END-ADDRESS_START)/(SYS_DATA_WIDTH/8); i+=(SYS_DATA_WIDTH/8)) begin
+            write_amo_read_cycle(0, ADDRESS_START+i, 0, 0, SYS_OFFSET_BIT, 0, 0, 0);
+        end
+
+        // Spawn multiple processes accessing this address
+        for (int i = 0; i < NUM_MASTERS; i++) begin
+            fork
+                automatic int m = i;
+                automatic logic [AXI_ADDR_WIDTH-1:0] address;
+                automatic logic [AXI_ID_WIDTH_M-1:0] id;
+                automatic logic [AXI_USER_WIDTH-1:0] user = m;
+                automatic logic [SYS_DATA_WIDTH-1:0] data_init;
+                automatic logic [SYS_DATA_WIDTH-1:0] data_amo;
+                automatic logic [2:0]                size;
+                automatic logic [5:0]                atop;
+                for (int j = 0; j < NUM_ITERATION; j++) begin
+                    // Randomize address but keep it in same word
+                    address = $urandom_range(ADDRESS_START,ADDRESS_END);
+                    void'(randomize(id));
+                    void'(randomize(data_init));
+                    void'(randomize(data_amo));
+                    void'(randomize(atop));
+                    atop = create_valid_atop();
+                    // void'(randomize(size)); // Half-word not supported by LRSC yet
+                    size = SYS_OFFSET_BIT;
+                    create_consistent_transaction(address, size, atop);
+                    write_amo_read_cycle(m, address, data_init, data_amo, size, id, user, atop);
+                end
+            join_none
+        end
+
+        // Wait for all cores to finish
+        wait fork;
+
+        #1000ns;
+
+    endtask : test_amo_write_consistency
+
+    /*====================================================================
+    =                          Helper Functions                          =
+    ====================================================================*/
+    task automatic create_consistent_transaction(
+        inout logic [AXI_ADDR_WIDTH-1:0] address,
+        inout logic [2:0]                size,
+        input logic [5:0]                amo
+    );
+        // Transaction must be single burst --> max size is system size
+        if (size > SYS_OFFSET_BIT) begin
+            size = SYS_OFFSET_BIT;
+        end
+
+        // AMO transactions need to be 4 bytes at least
+        if ((size < 3'b010) && amo) begin
+            size = 3'b010;
+        end
+
+        // Address needs to by size aligned
+        if (size) begin
+            // At least two bytes --> alignment necessary
+            for (int i = 0; i < size; i++) begin
+                address[i] = 1'b0;
+            end
+        end
+    endtask : create_consistent_transaction
+
+    function automatic logic [5:0] create_valid_atop();
+        int random_atop = $urandom_range(0, 16);
+        void'(randomize(create_valid_atop));
+
+        if (random_atop < 8) begin
+            // Store
+            create_valid_atop[5:3] = 3'b010;
+        end else if (random_atop < 16) begin
+            // Load
+            create_valid_atop[5:3] = 3'b100;
+        end else begin
+            create_valid_atop = 6'b110000;
+        end
+    endfunction : create_valid_atop
+
+    task automatic write_amo_read_cycle(
+        input int unsigned               driver,
+        input logic [AXI_ADDR_WIDTH-1:0] address,
+        input logic [SYS_DATA_WIDTH-1:0] data_init,
+        input logic [SYS_DATA_WIDTH-1:0] data_amo,
+        input logic [2:0]                size,
+        input logic [AXI_ID_WIDTH_M-1:0] id,
+        input logic [AXI_USER_WIDTH-1:0] user,
+        input logic [5:0]                atop
+    );
+        automatic logic [AXI_ID_WIDTH_M-1:0] trans_id = id;
+        automatic logic [SYS_DATA_WIDTH-1:0] r_data;
+        automatic logic [SYS_DATA_WIDTH-1:0] exp_data;
+        automatic logic [SYS_DATA_WIDTH-1:0] act_data;
+        automatic logic [1:0]  b_resp;
+        automatic logic [1:0]  exp_b_resp;
+
+        // Write (Need valid memory for atop)
+        if (!id) begin
+            void'(randomize(trans_id));
+        end
+        fork
+            axi_dut_master[driver].axi_write(address, data_init, size, trans_id, user, r_data, b_resp);
+            gold_memory.write(address, data_init, size, trans_id, user, driver, exp_data, exp_b_resp);
+        join
+        // AMO
+        if (!id) begin
+            void'(randomize(trans_id));
+        end
+        fork
+            // Atomic operation
+            axi_dut_master[driver].axi_write(address, data_amo, size, trans_id, user, r_data, b_resp, atop);
+            // Golden model
+            gold_memory.write(address, data_amo, size, trans_id, user, driver, exp_data, exp_b_resp, atop);
+        join
+        assert(b_resp == exp_b_resp) else begin
+            $warning("B (0x%1x) did not match expected (0x%1x)", b_resp, exp_b_resp);
+            num_errors += 1;
+        end
+        if ((atop[5:3] == {axi_pkg::ATOP_ATOMICLOAD, axi_pkg::ATOP_LITTLE_END}) |
+            (atop[5:3] == {axi_pkg::ATOP_ATOMICSWAP, axi_pkg::ATOP_LITTLE_END})) begin
+            assert(r_data == exp_data) else begin
+                $warning("ATOP (0x%x) did not match expected data (0x%x) at address 0x%x at operation: 0x%2x", r_data, exp_data, address, atop);
+                num_errors += 1;
+            end
+        end
+        // Read result
+        if (!id) begin
+            void'(randomize(trans_id));
+        end
+        fork
+            begin
+                @(posedge clk);
+                axi_dut_master[driver].axi_read(address, act_data, size, trans_id, user);
+            end
+            gold_memory.read(address, exp_data, size, trans_id, user, driver);
+        join
+        assert(act_data == exp_data) else begin
+            $warning("R (0x%x) did not match expected data (0x%x) at address 0x%x, size %x, after operation: 0x%2x (0x%x)", act_data, exp_data, address, size, atop, data_init);
+            num_errors += 1;
+        end
+    endtask : write_amo_read_cycle
+endmodule

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_atomics_tb_wave.do
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_atomics_tb_wave.do
@@ -1,0 +1,726 @@
+onerror {resume}
+quietly WaveActivateNextPane {} 0
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_id
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_addr
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_len
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_size
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_burst
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_lock
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_cache
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_prot
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_qos
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_region
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_atop
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_user
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_valid
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/aw_ready
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/w_data
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/w_strb
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/w_last
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/w_user
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/w_valid
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/w_ready
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/b_id
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/b_resp
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/b_user
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/b_valid
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/b_ready
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_id
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_addr
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_len
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_size
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_burst
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_lock
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_cache
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_prot
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_qos
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_region
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_user
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_valid
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/ar_ready
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/r_id
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/r_data
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/r_resp
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/r_last
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/r_user
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/r_valid
+add wave -noupdate -group {AXIBUS dut} /axi_riscv_atomics_tb/axi_dut/r_ready
+add wave -noupdate -group {AXIBUS lrsc} -label aw_addr /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_addr
+add wave -noupdate -group {AXIBUS lrsc} -label aw_prot /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_prot
+add wave -noupdate -group {AXIBUS lrsc} -label aw_region /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_region
+add wave -noupdate -group {AXIBUS lrsc} -label aw_atop /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_atop
+add wave -noupdate -group {AXIBUS lrsc} -label aw_len /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_len
+add wave -noupdate -group {AXIBUS lrsc} -label aw_size /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_size
+add wave -noupdate -group {AXIBUS lrsc} -label aw_burst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_burst
+add wave -noupdate -group {AXIBUS lrsc} -label aw_lock /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_lock
+add wave -noupdate -group {AXIBUS lrsc} -label aw_cache /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_cache
+add wave -noupdate -group {AXIBUS lrsc} -label aw_qos /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_qos
+add wave -noupdate -group {AXIBUS lrsc} -label aw_id /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_id
+add wave -noupdate -group {AXIBUS lrsc} -label aw_user /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_user
+add wave -noupdate -group {AXIBUS lrsc} -color {Cornflower Blue} -label aw_valid /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_valid
+add wave -noupdate -group {AXIBUS lrsc} -label aw_ready /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_aw_ready
+add wave -noupdate -group {AXIBUS lrsc} -label w_data /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_w_data
+add wave -noupdate -group {AXIBUS lrsc} -label w_strb /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_w_strb
+add wave -noupdate -group {AXIBUS lrsc} -label w_user /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_w_user
+add wave -noupdate -group {AXIBUS lrsc} -label w_last /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_w_last
+add wave -noupdate -group {AXIBUS lrsc} -color {Cornflower Blue} -label w_valid /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_w_valid
+add wave -noupdate -group {AXIBUS lrsc} -label w_ready /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_w_ready
+add wave -noupdate -group {AXIBUS lrsc} -label b_resp /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_b_resp
+add wave -noupdate -group {AXIBUS lrsc} -label b_id /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_b_id
+add wave -noupdate -group {AXIBUS lrsc} -label b_user /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_b_user
+add wave -noupdate -group {AXIBUS lrsc} -color {Cornflower Blue} -label b_valid /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_b_valid
+add wave -noupdate -group {AXIBUS lrsc} -label b_ready /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_b_ready
+add wave -noupdate -group {AXIBUS lrsc} -label ar_addr /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_addr
+add wave -noupdate -group {AXIBUS lrsc} -label ar_prot /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_prot
+add wave -noupdate -group {AXIBUS lrsc} -label ar_region /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_region
+add wave -noupdate -group {AXIBUS lrsc} -label ar_len /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_len
+add wave -noupdate -group {AXIBUS lrsc} -label ar_size /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_size
+add wave -noupdate -group {AXIBUS lrsc} -label ar_burst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_burst
+add wave -noupdate -group {AXIBUS lrsc} -label ar_lock /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_lock
+add wave -noupdate -group {AXIBUS lrsc} -label ar_cache /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_cache
+add wave -noupdate -group {AXIBUS lrsc} -label ar_qos /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_qos
+add wave -noupdate -group {AXIBUS lrsc} -label ar_id /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_id
+add wave -noupdate -group {AXIBUS lrsc} -label ar_user /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_user
+add wave -noupdate -group {AXIBUS lrsc} -color {Cornflower Blue} -label ar_valid /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_valid
+add wave -noupdate -group {AXIBUS lrsc} -label ar_ready /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_ar_ready
+add wave -noupdate -group {AXIBUS lrsc} -label r_data /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_r_data
+add wave -noupdate -group {AXIBUS lrsc} -label r_resp /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_r_resp
+add wave -noupdate -group {AXIBUS lrsc} -label r_last /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_r_last
+add wave -noupdate -group {AXIBUS lrsc} -label r_id /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_r_id
+add wave -noupdate -group {AXIBUS lrsc} -label r_user /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_r_user
+add wave -noupdate -group {AXIBUS lrsc} -color {Cornflower Blue} -label r_valid /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_r_valid
+add wave -noupdate -group {AXIBUS lrsc} -label r_ready /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/int_axi_r_ready
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_id
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_addr
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_len
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_size
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_burst
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_lock
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_cache
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_prot
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_qos
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_region
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_atop
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_user
+add wave -noupdate -group {AXIBUS mem} -color {Steel Blue} /axi_riscv_atomics_tb/axi_mem/aw_valid
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/aw_ready
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/w_data
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/w_strb
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/w_last
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/w_user
+add wave -noupdate -group {AXIBUS mem} -color {Steel Blue} /axi_riscv_atomics_tb/axi_mem/w_valid
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/w_ready
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/b_id
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/b_resp
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/b_user
+add wave -noupdate -group {AXIBUS mem} -color {Steel Blue} /axi_riscv_atomics_tb/axi_mem/b_valid
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/b_ready
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_id
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_addr
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_len
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_size
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_burst
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_lock
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_cache
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_prot
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_qos
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_region
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_user
+add wave -noupdate -group {AXIBUS mem} -color {Steel Blue} /axi_riscv_atomics_tb/axi_mem/ar_valid
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/ar_ready
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/r_id
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/r_data
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/r_resp
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/r_last
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/r_user
+add wave -noupdate -group {AXIBUS mem} -color {Steel Blue} /axi_riscv_atomics_tb/axi_mem/r_valid
+add wave -noupdate -group {AXIBUS mem} /axi_riscv_atomics_tb/axi_mem/r_ready
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_id}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_addr}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_len}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_size}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_burst}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_lock}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_cache}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_prot}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_qos}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_region}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_atop}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_user}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_valid}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/aw_ready}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/w_data}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/w_strb}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/w_last}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/w_user}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/w_valid}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/w_ready}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/b_id}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/b_resp}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/b_user}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/b_valid}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/b_ready}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_id}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_addr}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_len}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_size}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_burst}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_lock}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_cache}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_prot}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_qos}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_region}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_user}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_valid}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/ar_ready}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/r_id}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/r_data}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/r_resp}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/r_last}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/r_user}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/r_valid}
+add wave -noupdate -group {AXIBUS_cl_[0]} {/axi_riscv_atomics_tb/axi_cl[0]/r_ready}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_id}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_addr}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_len}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_size}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_burst}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_lock}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_cache}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_prot}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_qos}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_region}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_atop}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_user}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_valid}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/aw_ready}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/w_data}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/w_strb}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/w_last}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/w_user}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/w_valid}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/w_ready}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/b_id}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/b_resp}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/b_user}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/b_valid}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/b_ready}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_id}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_addr}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_len}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_size}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_burst}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_lock}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_cache}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_prot}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_qos}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_region}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_user}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_valid}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/ar_ready}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/r_id}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/r_data}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/r_resp}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/r_last}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/r_user}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/r_valid}
+add wave -noupdate -group {AXIBUS_cl_[1]} {/axi_riscv_atomics_tb/axi_cl[1]/r_ready}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_id}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_addr}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_len}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_size}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_burst}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_lock}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_cache}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_prot}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_qos}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_region}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_atop}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_user}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_valid}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/aw_ready}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/w_data}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/w_strb}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/w_last}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/w_user}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/w_valid}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/w_ready}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/b_id}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/b_resp}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/b_user}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/b_valid}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/b_ready}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_id}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_addr}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_len}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_size}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_burst}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_lock}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_cache}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_prot}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_qos}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_region}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_user}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_valid}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/ar_ready}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/r_id}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/r_data}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/r_resp}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/r_last}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/r_user}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/r_valid}
+add wave -noupdate -group {AXI_cl[7]} {/axi_riscv_atomics_tb/axi_cl[7]/r_ready}
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/clk_i
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/rst_ni
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_addr_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_prot_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_region_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_atop_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_len_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_size_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_burst_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_lock_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_cache_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_qos_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_id_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_user_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_ready_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_aw_valid_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_addr_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_prot_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_region_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_len_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_size_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_burst_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_lock_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_cache_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_qos_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_id_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_user_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_ready_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_ar_valid_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_w_data_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_w_strb_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_w_user_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_w_last_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_w_ready_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_w_valid_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_r_data_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_r_resp_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_r_last_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_r_id_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_r_user_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_r_ready_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_r_valid_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_b_resp_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_b_id_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_b_user_o
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_b_ready_i
+add wave -noupdate -group {AMO Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/slv_b_valid_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_addr_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_prot_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_region_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_atop_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_len_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_size_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_burst_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_lock_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_cache_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_qos_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_id_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_user_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_ready_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_aw_valid_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_addr_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_prot_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_region_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_len_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_size_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_burst_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_lock_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_cache_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_qos_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_id_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_user_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_ready_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_ar_valid_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_w_data_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_w_strb_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_w_user_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_w_last_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_w_ready_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_w_valid_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_r_data_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_r_resp_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_r_last_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_r_id_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_r_user_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_r_ready_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_r_valid_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_b_resp_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_b_id_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_b_user_i
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_b_ready_o
+add wave -noupdate -group {AMO Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/mst_b_valid_i
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/aw_state_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/aw_state_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_state_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_state_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/b_state_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/b_state_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/ar_state_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/ar_state_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_state_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_state_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/adapter_ready
+add wave -noupdate -group {AMO Adapter} -color Orange /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/atop_valid_d
+add wave -noupdate -group {AMO Adapter} -color Orange /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/atop_valid_q
+add wave -noupdate -group {AMO Adapter} -color Yellow /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/force_wf_d
+add wave -noupdate -group {AMO Adapter} -color Yellow /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/force_wf_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/start_wf_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/start_wf_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/b_resp_valid
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/aw_free
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_free
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/b_free
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/ar_free
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_free
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/aw_trans_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/aw_trans_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_cnt_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_cnt_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_cnt_req_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_cnt_req_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_cnt_inj_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_cnt_inj_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/addr_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/addr_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/size_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/size_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/strb_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/strb_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/id_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/id_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/cache_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/cache_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/prot_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/prot_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/qos_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/qos_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/region_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/region_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/aw_user_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/aw_user_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_user_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_user_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_user_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_user_q
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_resp_d
+add wave -noupdate -group {AMO Adapter} -expand -group Transaction /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_resp_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/atop_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/atop_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_data_d
+add wave -noupdate -group {AMO Adapter} -color {Cornflower Blue} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_data_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_data_d
+add wave -noupdate -group {AMO Adapter} -color {Cornflower Blue} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_data_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/result_d
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/result_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_d_valid_d
+add wave -noupdate -group {AMO Adapter} -color {Cornflower Blue} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/w_d_valid_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_d_valid_d
+add wave -noupdate -group {AMO Adapter} -color {Cornflower Blue} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/r_d_valid_q
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/alu_operand_a
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/alu_operand_b
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/alu_result
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/alu_result_ext
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/transaction_collision
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/op_a
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/op_b
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/op_a_sign_ext
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/op_b_sign_ext
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/res
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/strb_ext
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/sign_a
+add wave -noupdate -group {AMO Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/sign_b
+add wave -noupdate -group {AMO Adapter} -expand -group ALU /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/i_amo_alu/amo_op_i
+add wave -noupdate -group {AMO Adapter} -expand -group ALU /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/i_amo_alu/amo_operand_a_i
+add wave -noupdate -group {AMO Adapter} -expand -group ALU /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/i_amo_alu/amo_operand_b_i
+add wave -noupdate -group {AMO Adapter} -expand -group ALU /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/i_amo_alu/amo_result_o
+add wave -noupdate -group {AMO Adapter} -expand -group ALU /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/i_amo_alu/adder_sum
+add wave -noupdate -group {AMO Adapter} -expand -group ALU /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/i_amo_alu/adder_operand_a
+add wave -noupdate -group {AMO Adapter} -expand -group ALU /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_amos/i_amo_alu/adder_operand_b
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/clk_i
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rst_ni
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_addr_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_prot_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_region_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_atop_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_len_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_size_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_burst_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_lock_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_cache_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_qos_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_id_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_user_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_ready_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_aw_valid_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_addr_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_prot_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_region_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_len_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_size_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_burst_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_lock_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_cache_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_qos_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_id_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_user_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_ready_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_ar_valid_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_w_data_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_w_strb_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_w_user_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_w_last_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_w_ready_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_w_valid_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_data_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_resp_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_last_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_id_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_user_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_ready_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_valid_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_b_resp_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_b_id_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_b_user_o
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_b_ready_i
+add wave -noupdate -group {LRSC Adapter} -group slv /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_b_valid_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_addr_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_prot_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_region_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_atop_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_len_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_size_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_burst_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_lock_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_cache_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_qos_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_id_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_user_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_ready_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_valid_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_ready
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_aw_valid
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/clk_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/rst_ni
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/clr_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/testmode_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/valid_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/ready_o
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/data_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/valid_o
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/ready_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/data_o
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/fifo_empty
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/fifo_full
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/clk_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/rst_ni
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/flush_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/testmode_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/full_o
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/empty_o
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/usage_o
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO -color {Cornflower Blue} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/push_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/data_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO -color {Cornflower Blue} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/pop_i
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/data_o
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/gate_clock
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/read_pointer_n
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/read_pointer_q
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/write_pointer_n
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/write_pointer_q
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/status_cnt_n
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/status_cnt_q
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/mem_n
+add wave -noupdate -group {LRSC Adapter} -group mst -group aw_trans_fifo -expand -group FIFO /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_aw_trans_reg/i_fifo/i_fifo_v3/mem_q
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_addr_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_prot_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_region_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_len_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_size_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_burst_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_lock_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_cache_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_qos_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_id_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_user_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_ready_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_ar_valid_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_w_data_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_w_strb_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_w_user_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_w_last_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_w_ready_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_w_valid_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_r_data_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_r_resp_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_r_last_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_r_id_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_r_user_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_r_ready_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_r_valid_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_b_resp_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_b_id_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_b_user_i
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_b_ready_o
+add wave -noupdate -group {LRSC Adapter} -group mst /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_b_valid_i
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_push_id
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_check_id
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_check_res
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_check_clr_addr
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_check_clr_excl
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_check_clr_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_check_clr_gnt
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/clk_i
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/rst_ni
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/check_clr_addr_i
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/check_id_i
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/check_clr_excl_i
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/check_res_o
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/check_clr_req_i
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/check_clr_gnt_o
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/set_addr_i
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/set_id_i
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/set_req_i
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/set_gnt_o
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/clr
+add wave -noupdate -group {LRSC Adapter} -group art /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/gen_res_tbl/i_art/set
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/w_cmd_inp
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/w_cmd_oup
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/w_cmd_push
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/w_cmd_pop
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/w_cmd_full
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/w_cmd_empty
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_inp_id
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_inp_cmd
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_inp_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_inp_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_inj_inp
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_inj_push
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_inj_oup
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_inj_pop
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_oup_id
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_inj_full
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_inj_empty
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_oup_cmd
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_oup_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_oup_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_oup_pop
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_status_oup_valid
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_state_d
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/b_state_q
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_oup_id
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_push_addr
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_push_excl
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_push_res
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_push_valid
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_push_ready
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_filter_valid
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_filter_ready
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_set_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/art_set_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_inp_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_inp_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_oup_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_oup_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_oup_pop
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_oup_data_valid
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_inp_data
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/rifq_oup_data
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/wifq_exists
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_wifq_exists_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_wifq_exists_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/aw_wifq_exists_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/aw_wifq_exists_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/wifq_exists_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/wifq_exists_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/wifq_inp_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/wifq_oup_req
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/wifq_oup_gnt
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/wifq_oup_data_valid
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_wifq_exists_inp
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/aw_wifq_exists_inp
+add wave -noupdate -group {LRSC Adapter} -expand /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/wifq_exists_inp
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_b
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_b_valid
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_b_ready
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_valid
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/slv_r_ready
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_b_valid
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/mst_b_ready
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_state_d
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/ar_state_q
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/aw_state_d
+add wave -noupdate -group {LRSC Adapter} /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/aw_state_q
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/clk_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/rst_ni
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/inp_id_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/inp_data_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/inp_req_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/inp_gnt_o
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/exists_data_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/exists_mask_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/exists_req_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/exists_o
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/exists_gnt_o
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/oup_id_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/oup_pop_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/oup_req_i
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/oup_data_o
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/oup_data_valid_o
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/oup_gnt_o
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/head_tail_d
+add wave -noupdate -group Write_in_flight_Q -expand /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/head_tail_q
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/linked_data_d
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/linked_data_q
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/full
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/head_tail_free
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/exists_match
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/linked_data_free
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/head_tail_free_idx
+add wave -noupdate -group Write_in_flight_Q /axi_riscv_atomics_tb/i_axi_atomic_adapter/i_atomics/i_lrsc/i_write_in_flight_queue/linked_data_free_idx
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/clk_i
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/w_valid
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/w_addr
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/w_data
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/w_id
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/w_user
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/w_beat_count
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/w_last
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/r_valid
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/r_addr
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/r_data
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/r_id
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/r_user
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/r_beat_count
+add wave -noupdate -group {Memory Monitor} /axi_riscv_atomics_tb/mem_monitor_dv/r_last
+TreeUpdate [SetDefaultTree]
+WaveRestoreCursors {{Cursor 5} {0 ps} 0}
+quietly wave cursor active 1
+configure wave -namecolwidth 192
+configure wave -valuecolwidth 193
+configure wave -justifyvalue left
+configure wave -signalnamewidth 1
+configure wave -snapdistance 10
+configure wave -datasetprefix 0
+configure wave -rowmargin 4
+configure wave -childrowmargin 2
+configure wave -gridoffset 0
+configure wave -gridperiod 1
+configure wave -griddelta 40
+configure wave -timeline 0
+configure wave -timelineunits ns
+update
+WaveRestoreZoom {0 ps} {186396 ns}

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_lrsc_synth.v
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_lrsc_synth.v
@@ -12,15 +12,17 @@
 // Simple standalone synthesis bench for axi_riscv_lrsc
 module axi_riscv_lrsc_synth #(
     /// Exclusively-accessible address range (closed interval from ADDR_BEGIN to ADDR_END)
-    parameter integer ADDR_BEGIN        = 64'h0000_0000_0000_0000,
-    parameter integer ADDR_END          = 64'h0000_7fff_ffff_ffff,
+    parameter [63:0] ADDR_BEGIN             = 64'h0000_0000_0000_0000,
+    parameter [63:0] ADDR_END               = 64'h0000_7fff_ffff_ffff,
     /// AXI Parameters
-    parameter integer AXI_ADDR_WIDTH    = 64,
-    parameter integer AXI_DATA_WIDTH    = 64,
-    parameter integer AXI_ID_WIDTH      = 4,
-    parameter integer AXI_USER_WIDTH    = 0,
+    parameter integer AXI_ADDR_WIDTH        = 64,
+    parameter integer AXI_DATA_WIDTH        = 64,
+    parameter integer AXI_ID_WIDTH          = 4,
+    parameter integer AXI_USER_WIDTH        = 0,
+    parameter integer AXI_MAX_READ_TXNS     = 8,
+    parameter integer AXI_MAX_WRITE_TXNS    = 8,
     /// Derived Parameters (do NOT change manually!)
-    localparam integer AXI_STRB_WIDTH   = AXI_DATA_WIDTH / 8
+    localparam integer AXI_STRB_WIDTH       = AXI_DATA_WIDTH / 8
 ) (
     input                          clk_i,
     input                          rst_ni,
@@ -134,7 +136,10 @@ module axi_riscv_lrsc_synth #(
         .AXI_ADDR_WIDTH     (AXI_ADDR_WIDTH),
         .AXI_DATA_WIDTH     (AXI_DATA_WIDTH),
         .AXI_ID_WIDTH       (AXI_ID_WIDTH),
-        .AXI_USER_WIDTH     (AXI_USER_WIDTH)
+        .AXI_USER_WIDTH     (AXI_USER_WIDTH),
+        .AXI_MAX_READ_TXNS  (AXI_MAX_READ_TXNS),
+        .AXI_MAX_WRITE_TXNS (AXI_MAX_WRITE_TXNS),
+        .DEBUG              (1'b0)
     ) i_axi_riscv_lrsc (
         .clk_i(clk_i),
         .rst_ni(rst_ni),

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_lrsc_tb.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_lrsc_tb.sv
@@ -31,9 +31,6 @@ module axi_riscv_lrsc_tb #(
     parameter bit VERBOSE = 1'b0
 );
 
-    timeunit 1ns;
-    timeprecision 10ps;
-
     localparam time TCLK = 10ns;
     localparam time TA = TCLK * 1/4;
     localparam time TT = TCLK * 3/4;

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_lrsc_tb.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_lrsc_tb.sv
@@ -1,0 +1,691 @@
+// Copyright (c) 2019 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+`include "axi/assign.svh"
+
+module axi_riscv_lrsc_tb #(
+    // Exclusive Adapter Parameters
+    parameter int unsigned AXI_ADDR_WIDTH = 8,
+    parameter int unsigned AXI_DATA_WIDTH = 64,
+    parameter int unsigned AXI_ID_WIDTH = 10,
+    parameter int unsigned AXI_USER_WIDTH = 4,
+    parameter int unsigned ADDR_BEGIN = 8'h20,
+    parameter int unsigned ADDR_END = 8'hAF,
+    parameter int unsigned AXI_MAX_READ_TXNS = 16,
+    parameter int unsigned AXI_MAX_WRITE_TXNS = 16,
+    parameter bit DEBUG = 1'b0,
+    // TB Parameters
+    parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,
+    parameter int unsigned REQ_MAX_WAIT_CYCLES = 10,
+    parameter int unsigned RESP_MIN_WAIT_CYCLES = 0,
+    parameter int unsigned RESP_MAX_WAIT_CYCLES = REQ_MAX_WAIT_CYCLES/2,
+    parameter int unsigned N_TXNS = 10000,
+    parameter bit VERBOSE = 1'b0
+);
+
+    timeunit 1ns;
+    timeprecision 10ps;
+
+    localparam time TCLK = 10ns;
+    localparam time TA = TCLK * 1/4;
+    localparam time TT = TCLK * 3/4;
+
+    localparam int unsigned AXI_WORD_OFF = $clog2(AXI_DATA_WIDTH/8);
+
+    typedef logic [AXI_ADDR_WIDTH-1:0]  axi_addr_t;
+    typedef logic [AXI_DATA_WIDTH-1:0]  axi_data_t;
+    typedef logic [AXI_ID_WIDTH-1:0]    axi_id_t;
+    typedef logic [AXI_USER_WIDTH-1:0]  axi_user_t;
+
+    logic   clk,
+            rst_n;
+
+    clk_rst_gen #(
+        .ClkPeriod      (TCLK),
+        .RstClkCycles   (5)
+    ) i_clk_rst_gen (
+        .clk_o  (clk),
+        .rst_no (rst_n)
+    );
+
+    AXI_BUS_DV #(
+        .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
+        .AXI_DATA_WIDTH (AXI_DATA_WIDTH),
+        .AXI_ID_WIDTH   (AXI_ID_WIDTH),
+        .AXI_USER_WIDTH (AXI_USER_WIDTH)
+    ) upstream_dv (
+        .clk_i  (clk)
+    );
+
+    AXI_BUS #(
+        .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
+        .AXI_DATA_WIDTH (AXI_DATA_WIDTH),
+        .AXI_ID_WIDTH   (AXI_ID_WIDTH),
+        .AXI_USER_WIDTH (AXI_USER_WIDTH)
+    ) upstream ();
+
+    `AXI_ASSIGN(upstream, upstream_dv);
+
+    AXI_BUS_DV #(
+        .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
+        .AXI_DATA_WIDTH (AXI_DATA_WIDTH),
+        .AXI_ID_WIDTH   (AXI_ID_WIDTH),
+        .AXI_USER_WIDTH (AXI_USER_WIDTH)
+    ) downstream_dv (
+        .clk_i  (clk)
+    );
+
+    AXI_BUS #(
+        .AXI_ADDR_WIDTH (AXI_ADDR_WIDTH),
+        .AXI_DATA_WIDTH (AXI_DATA_WIDTH),
+        .AXI_ID_WIDTH   (AXI_ID_WIDTH),
+        .AXI_USER_WIDTH (AXI_USER_WIDTH)
+    ) downstream ();
+
+    `AXI_ASSIGN(downstream_dv, downstream);
+
+    axi_riscv_lrsc_wrap #(
+        .ADDR_BEGIN             (ADDR_BEGIN),
+        .ADDR_END               (ADDR_END),
+        .AXI_ADDR_WIDTH         (AXI_ADDR_WIDTH),
+        .AXI_DATA_WIDTH         (AXI_DATA_WIDTH),
+        .AXI_ID_WIDTH           (AXI_ID_WIDTH),
+        .AXI_USER_WIDTH         (AXI_USER_WIDTH),
+        .AXI_MAX_READ_TXNS      (AXI_MAX_READ_TXNS),
+        .AXI_MAX_WRITE_TXNS     (AXI_MAX_WRITE_TXNS),
+        .DEBUG                  (DEBUG)
+    ) dut (
+        .clk_i  (clk),
+        .rst_ni (rst_n),
+        .mst    (downstream),
+        .slv    (upstream)
+    );
+
+    typedef axi_test::axi_driver #(
+        .AW (AXI_ADDR_WIDTH),
+        .DW (AXI_DATA_WIDTH),
+        .IW (AXI_ID_WIDTH),
+        .UW (AXI_USER_WIDTH),
+        .TA (TA),
+        .TT (TT)
+    ) axi_driver_t;
+
+    task rand_req_wait();
+        rand_verif_pkg::rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES, clk);
+    endtask
+
+    task rand_resp_wait();
+        rand_verif_pkg::rand_wait(RESP_MIN_WAIT_CYCLES, RESP_MAX_WAIT_CYCLES, clk);
+    endtask
+
+    // AXI Master
+    import rand_id_queue_pkg::rand_id_queue;
+    rand_id_queue #(
+        .data_t     (axi_driver_t::ax_beat_t),
+        .ID_WIDTH   (AXI_ID_WIDTH)
+    ) aw_excl_queue = new;
+    axi_driver_t axi_master = new(upstream_dv);
+    logic mst_done = 1'b0;
+    initial begin
+        static axi_driver_t::r_beat_t   r_beat;
+        static axi_driver_t::b_beat_t   b_beat;
+        static axi_driver_t::ax_beat_t  aw_queue[$];
+        static axi_driver_t::ax_beat_t  ar_excl_queue[2**AXI_ID_WIDTH-1:0][$];
+        static logic [1:0]              aw_type = '0;
+        static logic                    ar_done = 1'b0,
+                                        aw_done = 1'b0;
+        static int unsigned             r_flight_cnt = 0,
+                                        w_flight_cnt = 0;
+        axi_master.reset_master();
+        wait (rst_n);
+        @(posedge clk);
+        fork
+            // AR
+            begin
+                repeat (N_TXNS) begin
+                    automatic axi_driver_t::ax_beat_t ar_beat = new;
+                    rand_req_wait();
+                    void'(randomize(ar_beat));
+                    ar_beat.ax_len = '0; // Bursts are not supported right now.
+                    ar_beat.ax_lock = $random();
+                    if (ar_beat.ax_lock) begin
+                        // Exclusive accesses must be aligned to the number of bytes in the transaction.
+                        ar_beat.ax_addr[AXI_WORD_OFF-1:0] = '0;
+                    end
+                    ar_beat.ax_size = AXI_WORD_OFF;
+                    axi_master.send_ar(ar_beat);
+                    if (ar_beat.ax_lock) begin
+                        ar_excl_queue[ar_beat.ax_id].push_back(ar_beat);
+                    end
+                    r_flight_cnt++;
+                end
+                ar_done = 1'b1;
+            end
+            // R
+            while (!(ar_done && r_flight_cnt == 0)) begin
+                rand_resp_wait();
+                axi_master.recv_r(r_beat);
+                if (r_beat.r_resp == axi_pkg::RESP_EXOKAY) begin
+                    assert (ar_excl_queue[r_beat.r_id].size() != 0)
+                        else $error("%0t: Master received R with EXOKAY on non-exclusive AR!",
+                            $time);
+                    aw_excl_queue.push(r_beat.r_id, ar_excl_queue[r_beat.r_id].pop_front());
+                end
+                if (r_beat.r_last) r_flight_cnt--;
+            end
+            // AW
+            begin
+                repeat (N_TXNS) begin
+                    automatic axi_driver_t::ax_beat_t aw_beat;
+                    rand_req_wait();
+                    aw_type = $random();
+                    if (aw_type[1] && !aw_excl_queue.empty()) begin // Follow up on exclusive AR.
+                        aw_beat = new aw_excl_queue.pop();
+                        aw_beat.ax_lock = aw_type[0]; // Still exclusive?
+                    end else begin
+                        aw_beat = new;
+                        void'(randomize(aw_beat));
+                        aw_beat.ax_len = '0; // Bursts are not supported right now.
+                        aw_beat.ax_size = AXI_WORD_OFF;
+                    end
+                    axi_master.send_aw(aw_beat);
+                    aw_queue.push_back(aw_beat);
+                    w_flight_cnt++;
+                end
+                aw_done = 1'b1;
+            end
+            // W
+            while (!(aw_done && aw_queue.size() == 0)) begin
+                automatic axi_driver_t::w_beat_t w_beat = new;
+                while (aw_queue.size() == 0) begin
+                    @(posedge clk);
+                end
+                rand_req_wait();
+                void'(randomize(w_beat));
+                if (aw_queue[0].ax_len == '0) begin
+                    w_beat.w_last = 1'b1;
+                    void'(aw_queue.pop_front());
+                end else begin
+                    w_beat.w_last = 1'b0;
+                    aw_queue[0].ax_len--;
+                end
+                axi_master.send_w(w_beat);
+            end
+            // B
+            while (!(aw_done && w_flight_cnt == 0)) begin
+                rand_resp_wait();
+                axi_master.recv_b(b_beat);
+                w_flight_cnt--;
+            end
+        join
+        mst_done = 1'b1;
+    end
+
+    initial begin
+        wait (mst_done);
+        $display("Simulation completed after %0d read and write transactions.", N_TXNS);
+        $finish();
+    end
+
+    function axi_data_t update_mem(
+        input axi_driver_t::w_beat_t w_beat,
+        axi_data_t prior_data
+    );
+        automatic axi_data_t data = prior_data;
+        for (int unsigned i = 0; i < AXI_DATA_WIDTH/8; i++) begin
+            if (w_beat.w_strb[i]) begin
+                data[i*8+:8] = w_beat.w_data[i*8+:8];
+            end
+        end
+        return data;
+    endfunction
+
+    // AXI Slave
+    rand_id_queue #(
+        .data_t     (axi_driver_t::ax_beat_t),
+        .ID_WIDTH   (AXI_ID_WIDTH)
+    ) ar_queue = new;
+    rand_id_queue #(
+        .data_t     (axi_driver_t::b_beat_t),
+        .ID_WIDTH   (AXI_ID_WIDTH)
+    ) b_queue = new;
+    axi_driver_t axi_slave = new(downstream_dv);
+    initial begin
+        static axi_driver_t::ax_beat_t  ar_beat, ar_beat_r;
+        static axi_driver_t::ax_beat_t  aw_beat, aw_beat_w;
+        static axi_driver_t::w_beat_t   w_beat;
+        static axi_driver_t::b_beat_t   b_beat;
+        static axi_driver_t::ax_beat_t  aw_queue[$];
+        static axi_data_t mem[logic[AXI_ADDR_WIDTH-AXI_WORD_OFF-1:0]] = '{default: 'x};
+        static logic [AXI_ADDR_WIDTH-AXI_WORD_OFF-1:0] mem_addr;
+        static axi_data_t data;
+        axi_slave.reset_slave();
+        wait (rst_n);
+        @(posedge clk);
+        fork
+            // AR
+            forever begin
+                rand_resp_wait();
+                axi_slave.recv_ar(ar_beat);
+                ar_queue.push(ar_beat.ax_id, ar_beat);
+            end
+            // R
+            forever begin
+                automatic axi_driver_t::r_beat_t r_beat = new;
+                while (ar_queue.empty()) begin
+                    @(posedge clk);
+                end
+                ar_beat_r = ar_queue.peek();
+                r_beat.r_id = ar_beat_r.ax_id;
+                r_beat.r_data = mem[ar_beat_r.ax_addr[AXI_ADDR_WIDTH-AXI_WORD_OFF-1:0]];
+                r_beat.r_resp = axi_pkg::RESP_OKAY;
+                r_beat.r_user = ar_beat_r.ax_user;
+                if (ar_beat_r.ax_len == 0) begin
+                    r_beat.r_last = 1'b1;
+                    void'(ar_queue.pop_id(ar_beat_r.ax_id));
+                end else begin
+                    r_beat.r_last = 1'b0;
+                    ar_beat_r.ax_len--;
+                    ar_beat_r.ax_addr += (2**AXI_WORD_OFF);
+                    ar_queue.set(ar_beat_r.ax_id, ar_beat_r);
+                end
+                rand_resp_wait();
+                axi_slave.send_r(r_beat);
+            end
+            // AW
+            forever begin
+                rand_resp_wait();
+                axi_slave.recv_aw(aw_beat);
+                aw_queue.push_back(aw_beat);
+            end
+            // W
+            forever begin
+                rand_resp_wait();
+                axi_slave.recv_w(w_beat);
+                while (aw_queue.size() == 0) begin
+                    @(posedge clk);
+                end
+                aw_beat_w = aw_queue[0];
+                mem_addr = aw_beat_w.ax_addr[AXI_ADDR_WIDTH-AXI_WORD_OFF-1:0];
+                mem[mem_addr] = update_mem(w_beat, mem[mem_addr]);
+                if (w_beat.w_last) begin
+                    automatic axi_driver_t::b_beat_t b_beat_w = new;
+                    void'(aw_queue.pop_front());
+                    b_beat_w.b_id = aw_beat_w.ax_id;
+                    b_beat_w.b_resp = axi_pkg::RESP_OKAY;
+                    b_beat_w.b_user = aw_beat_w.ax_user;
+                    b_queue.push(aw_beat_w.ax_id, b_beat_w);
+                end else begin
+                    aw_beat_w.ax_addr += (2**AXI_WORD_OFF);
+                    aw_queue[0] = aw_beat_w;
+                end
+            end
+            // B
+            forever begin
+                while (b_queue.empty()) begin
+                    @(posedge clk);
+                end
+                rand_resp_wait();
+                b_beat = b_queue.pop();
+                axi_slave.send_b(b_beat);
+            end
+        join
+    end
+
+    typedef enum logic [1:0] {
+        B_FORWARD, B_EXCLUSIVE, B_INJECT
+    } b_cmd_t;
+
+    typedef struct packed {
+        logic excl;
+    } r_cmd_t;
+
+    typedef struct packed {
+        logic       excl;
+        axi_id_t    id;
+        logic       thru;
+        axi_user_t  user;
+    } w_cmd_t;
+
+    typedef struct packed {
+        axi_addr_t  addr;
+        logic       excl;
+    } w_flight_t;
+
+    // Monitor and check repsonses of AEA.
+    logic downstream_b_wait_d,  downstream_b_wait_q;
+    initial begin
+        static logic [2**AXI_ID_WIDTH-1:0][AXI_ADDR_WIDTH-1:0] res_addr = 'x;
+        static axi_driver_t::ax_beat_t  ar_transfer_queue[$],
+                                        aw_transfer_queue[$];
+        static b_cmd_t                  b_cmd_queues[2**AXI_ID_WIDTH-1:0][$];
+        static axi_driver_t::b_beat_t   b_checkback_queues[2**AXI_ID_WIDTH-1:0][$],
+                                        b_inject_queues[2**AXI_ID_WIDTH-1:0][$],
+                                        b_transfer_queues[2**AXI_ID_WIDTH-1:0][$];
+        static r_cmd_t                  r_cmd_queues[2**AXI_ID_WIDTH-1:0][$];
+        static axi_driver_t::r_beat_t   r_transfer_queue[$];
+        static w_cmd_t                  w_cmd_queue[$];
+        static w_flight_t               w_flight_queues [2**AXI_ID_WIDTH-1:0][$];
+        static axi_driver_t::w_beat_t   w_transfer_queue[$];
+        wait (rst_n);
+        forever begin
+            @(posedge clk);
+            #(TT);
+            // Ensure that downstream never sees an `ar_lock` or an `aw_lock`.
+            if (downstream.ar_valid) begin
+                assert (!downstream.ar_lock);
+            end
+            if (downstream.aw_valid) begin
+                assert (!downstream.aw_lock);
+            end
+            // Push upstream ARs into transfer queues and fill R command queues.
+            if (upstream.ar_valid && upstream.ar_ready) begin
+                automatic axi_driver_t::ax_beat_t ar_beat = new;
+                automatic logic excl = 1'b0;
+                ar_beat.ax_id       = upstream.ar_id;
+                ar_beat.ax_addr     = upstream.ar_addr;
+                ar_beat.ax_len      = upstream.ar_len;
+                ar_beat.ax_size     = upstream.ar_size;
+                ar_beat.ax_burst    = upstream.ar_burst;
+                ar_beat.ax_lock     = upstream.ar_lock;
+                ar_beat.ax_cache    = upstream.ar_cache;
+                ar_beat.ax_prot     = upstream.ar_prot;
+                ar_beat.ax_qos      = upstream.ar_qos;
+                ar_beat.ax_region   = upstream.ar_region;
+                ar_beat.ax_user     = upstream.ar_user;
+                ar_transfer_queue.push_back(ar_beat);
+                if (upstream.ar_addr >= ADDR_BEGIN && upstream.ar_addr <= ADDR_END &&
+                    upstream.ar_lock && upstream.ar_len == 8'h00) begin
+                    excl = 1'b1;
+                end
+                r_cmd_queues[upstream.ar_id].push_back('{excl: excl});
+            end
+            // Check downstream ARs and place reservations.
+            if (downstream.ar_valid && downstream.ar_ready) begin
+                static axi_driver_t::ax_beat_t ar_beat;
+                assert (ar_transfer_queue.size() > 0) else $fatal("downstream.AR: Illegal beat!");
+                ar_beat = ar_transfer_queue.pop_front();
+                assert (downstream.ar_id        == ar_beat.ax_id);
+                assert (downstream.ar_addr      == ar_beat.ax_addr);
+                assert (downstream.ar_len       == ar_beat.ax_len);
+                assert (downstream.ar_size      == ar_beat.ax_size);
+                assert (downstream.ar_burst     == ar_beat.ax_burst);
+                assert (downstream.ar_cache     == ar_beat.ax_cache);
+                assert (downstream.ar_prot      == ar_beat.ax_prot);
+                assert (downstream.ar_qos       == ar_beat.ax_qos);
+                assert (downstream.ar_region    == ar_beat.ax_region);
+                assert (downstream.ar_user      == ar_beat.ax_user);
+                if (ar_beat.ax_lock && downstream.ar_addr >= ADDR_BEGIN &&
+                    downstream.ar_addr <= ADDR_END && downstream.ar_len == 8'h00) begin
+                    automatic logic w_in_flight = 1'b0;
+                    // Place reservation if no write to same address in flight.
+                    for (int unsigned id = 0; id < 2**AXI_ID_WIDTH; id++) begin
+                        for (int unsigned i = 0; i < w_flight_queues[id].size(); i++) begin
+                            if (w_flight_queues[id][i].addr == downstream.ar_addr) begin
+                                w_in_flight = 1'b1;
+                                break;
+                            end
+                        end
+                        if (w_in_flight)
+                            break;
+                    end
+                    if (!w_in_flight) begin
+                        res_addr[downstream.ar_id] = downstream.ar_addr;
+                    end
+                end
+            end
+            // Push upstream AWs into transfer queue.
+            if (upstream.aw_valid && upstream.aw_ready) begin
+                automatic axi_driver_t::ax_beat_t aw_beat = new;
+                aw_beat.ax_id       = upstream.aw_id;
+                aw_beat.ax_addr     = upstream.aw_addr;
+                aw_beat.ax_len      = upstream.aw_len;
+                aw_beat.ax_size     = upstream.aw_size;
+                aw_beat.ax_burst    = upstream.aw_burst;
+                aw_beat.ax_lock     = upstream.aw_lock;
+                aw_beat.ax_cache    = upstream.aw_cache;
+                aw_beat.ax_prot     = upstream.aw_prot;
+                aw_beat.ax_qos      = upstream.aw_qos;
+                aw_beat.ax_region   = upstream.aw_region;
+                aw_beat.ax_user     = upstream.aw_user;
+                aw_transfer_queue.push_back(aw_beat);
+            end
+            if (downstream.aw_valid && downstream.aw_ready) begin
+                automatic axi_driver_t::ax_beat_t exp_beat;
+                automatic w_flight_t w_flight;
+                forever begin
+                    automatic logic done = 1'b0;
+                    automatic b_cmd_t b_cmd;
+                    automatic w_cmd_t w_cmd;
+                    assert (aw_transfer_queue.size() > 0)
+                        else $fatal("downstream.AW: Illegal beat!");
+                    exp_beat = aw_transfer_queue.pop_front();
+                    w_cmd.excl = exp_beat.ax_lock;
+                    w_cmd.id = exp_beat.ax_id;
+                    w_cmd.user = exp_beat.ax_user;
+                    if (exp_beat.ax_id == downstream.aw_id &&
+                        exp_beat.ax_addr == downstream.aw_addr) begin
+                        // Found AW beat that was forwarded.
+                        done = 1'b1;
+                        if (exp_beat.ax_lock && exp_beat.ax_addr >= ADDR_BEGIN &&
+                            exp_beat.ax_addr <= ADDR_END && exp_beat.ax_len == 8'h00) begin
+                            b_cmd = B_EXCLUSIVE;
+                        end else begin
+                            b_cmd = B_FORWARD;
+                        end
+                        w_cmd.thru = 1'b1;
+                    end else begin
+                        // Found AW beat that was dropped.
+                        assert (exp_beat.ax_lock) else $error("Non-exclusive AW was dropped!");
+                        // TODO: Warn if exclusive AW should not have been dropped.
+                        b_cmd = B_INJECT;
+                        w_cmd.thru = 1'b0;
+                    end
+                    w_cmd_queue.push_back(w_cmd);
+                    if (VERBOSE) $display("%0t: Added W cmd for ID %03x.", $time, w_cmd.id);
+                    b_cmd_queues[exp_beat.ax_id].push_back(b_cmd);
+                    if (done) begin
+                        break;
+                    end
+                end
+                assert (downstream.aw_addr      == exp_beat.ax_addr);
+                assert (downstream.aw_len       == exp_beat.ax_len);
+                assert (downstream.aw_size      == exp_beat.ax_size);
+                assert (downstream.aw_burst     == exp_beat.ax_burst);
+                assert (downstream.aw_cache     == exp_beat.ax_cache);
+                assert (downstream.aw_prot      == exp_beat.ax_prot);
+                assert (downstream.aw_qos       == exp_beat.ax_qos);
+                assert (downstream.aw_region    == exp_beat.ax_region);
+                assert (downstream.aw_user      == exp_beat.ax_user);
+                for (int unsigned id = 0; id < 2**AXI_ID_WIDTH; id++) begin
+                    // Ensure that no exclusive write to the same address is in-flight.
+                    for (int unsigned i = 0; i < w_flight_queues[id].size(); i++) begin
+                        if (w_flight_queues[id][i].excl) begin
+                            assert (w_flight_queues[id][i].addr != downstream.aw_addr)
+                                else $error("Illegal downstream AW to address to which ",
+                                    "an exclusive write is in flight!");
+                        end
+                    end
+                end
+                w_flight.addr = downstream.aw_addr;
+                w_flight.excl = (exp_beat.ax_lock && exp_beat.ax_addr >= ADDR_BEGIN &&
+                    exp_beat.ax_addr <= ADDR_END && exp_beat.ax_len == 8'h00 &&
+                    res_addr[downstream.aw_id] === downstream.aw_addr);
+                w_flight_queues[downstream.aw_id].push_back(w_flight);
+                for (int unsigned id = 0; id < 2**AXI_ID_WIDTH; id++) begin
+                    // Clear reservations to same address.
+                    if (res_addr[id] === downstream.aw_addr) begin
+                        res_addr[id] = 'x;
+                    end
+                end
+            end
+            // Push downstream Rs into transfer queue.
+            if (downstream.r_valid && downstream.r_ready) begin
+                automatic axi_driver_t::r_beat_t r_beat = new;
+                r_beat.r_id     = downstream.r_id;
+                r_beat.r_data   = downstream.r_data;
+                r_beat.r_resp   = downstream.r_resp;
+                r_beat.r_last   = downstream.r_last;
+                r_beat.r_user   = downstream.r_user;
+                r_transfer_queue.push_back(r_beat);
+            end
+            // Check upstream Rs.
+            if (upstream.r_valid && upstream.r_ready) begin
+                automatic axi_driver_t::r_beat_t r_beat;
+                assert (r_transfer_queue.size() > 0)
+                    else $fatal("upstream.R: Illegal beat!");
+                r_beat = r_transfer_queue.pop_front();
+                assert (upstream.r_id   == r_beat.r_id);
+                assert (upstream.r_data === r_beat.r_data);
+                if (r_beat.r_resp[1]) begin
+                    assert (upstream.r_resp == r_beat.r_resp);
+                end else begin
+                    automatic r_cmd_t r_cmd = r_cmd_queues[r_beat.r_id][0];
+                    assert (upstream.r_resp == {1'b0, r_cmd.excl});
+                end
+                assert (upstream.r_last == r_beat.r_last);
+                assert (upstream.r_user == r_beat.r_user);
+                if (r_beat.r_last) begin
+                    void'(r_cmd_queues[r_beat.r_id].pop_front());
+                end
+            end
+            // Push upstream W beats into transfer queue.
+            if (upstream.w_valid && upstream.w_ready) begin
+                automatic axi_driver_t::w_beat_t w_beat = new;
+                w_beat.w_data = upstream.w_data;
+                w_beat.w_strb = upstream.w_strb;
+                w_beat.w_last = upstream.w_last;
+                w_beat.w_user = upstream.w_user;
+                w_transfer_queue.push_back(w_beat);
+            end
+            // Clear dropped W beats from transfer queue.
+            forever begin
+                automatic w_cmd_t w_cmd;
+                if (w_cmd_queue.size() == 0 || w_transfer_queue.size() == 0) begin
+                    break;
+                end
+                w_cmd = w_cmd_queue[0];
+                if (!w_cmd.thru) begin
+                    forever begin
+                        automatic axi_driver_t::w_beat_t w_beat;
+                        if (w_transfer_queue.size() == 0) begin
+                            break;
+                        end
+                        w_beat = w_transfer_queue.pop_front();
+                        if (w_beat.w_last) begin
+                            automatic axi_driver_t::b_beat_t b_beat = new;
+                            b_beat.b_id = w_cmd.id;
+                            b_beat.b_resp = 2'b00;
+                            b_beat.b_user = w_cmd.user;
+                            if (VERBOSE) $display("%0t: Added B for ID %03x to injects.", $time,
+                                    b_beat.b_id);
+                            b_inject_queues[b_beat.b_id].push_back(b_beat);
+                            void'(w_cmd_queue.pop_front());
+                            break;
+                        end
+                    end
+                end else begin
+                    break;
+                end
+            end
+            // Ensure downstream W beats match remaining beats in the W transfer queue.
+            if (downstream.w_valid && downstream.w_ready) begin
+                automatic axi_driver_t::w_beat_t w_beat;
+                automatic w_cmd_t w_cmd;
+                assert (w_cmd_queue.size() > 0) else $fatal("downstream.W: Illegal beat!");
+                w_cmd = w_cmd_queue[0];
+                assert (w_cmd.thru) else $error("downstream.W: Beat should not have gone through!");
+                w_beat = w_transfer_queue.pop_front();
+                assert (downstream.w_data == w_beat.w_data);
+                assert (downstream.w_strb == w_beat.w_strb);
+                assert (downstream.w_last == w_beat.w_last);
+                assert (downstream.w_user == w_beat.w_user);
+                if (w_beat.w_last) begin
+                    void'(w_cmd_queue.pop_front());
+                end
+            end
+            // Push downstream B beats into transfer queues and remove write from in-flights.
+            if (downstream.b_valid && !downstream_b_wait_q) begin
+                automatic axi_driver_t::b_beat_t b_beat = new;
+                b_beat.b_id     = downstream.b_id;
+                b_beat.b_resp   = downstream.b_resp;
+                b_beat.b_user   = downstream.b_user;
+                b_transfer_queues[b_beat.b_id].push_back(b_beat);
+                assert (w_flight_queues[downstream.b_id].size() > 0)
+                    else $error("downstream.B: Unknown ID!");
+                void'(w_flight_queues[downstream.b_id].pop_front());
+            end
+            // Push upstream B beats into checkback queues.
+            if (upstream.b_valid && upstream.b_ready) begin
+                automatic axi_driver_t::b_beat_t b_beat = new;
+                b_beat.b_id = upstream.b_id;
+                b_beat.b_user = upstream.b_user;
+                b_beat.b_resp = upstream.b_resp;
+                b_checkback_queues[upstream.b_id].push_back(b_beat);
+            end
+            // Reduce B checkback queues by decided beats.
+            for (int unsigned id = 0; id < 2**AXI_ID_WIDTH; id++) begin
+                if (b_checkback_queues[id].size() > 0) begin
+                    automatic b_cmd_t b_cmd;
+                    automatic axi_driver_t::b_beat_t act_beat, exp_beat;
+                    if (b_cmd_queues[id].size() == 0) begin
+                        // We do not yet know what to do with this beat, try another one.
+                        continue;
+                    end
+                    b_cmd = b_cmd_queues[id].pop_front();
+                    act_beat = b_checkback_queues[id].pop_front();
+                    if (b_cmd == B_INJECT) begin
+                        assert (b_inject_queues[id].size() > 0)
+                            else $fatal("upstream.B: Beat for ID %0x not found in inject queue!",
+                                id);
+                        exp_beat = b_inject_queues[id].pop_front();
+                    end else begin
+                        assert (b_transfer_queues[id].size() > 0)
+                            else $fatal("upstream.B: Beat for ID %0x not found in transfer queue!",
+                                id);
+                        exp_beat = b_transfer_queues[id].pop_front();
+                    end
+                    assert (act_beat.b_id == exp_beat.b_id);
+                    assert (act_beat.b_user == exp_beat.b_user);
+                    assert (act_beat.b_resp[1] == exp_beat.b_resp[1]);
+                    if (act_beat.b_resp[1] == 1'b0) begin
+                        automatic logic exp_bit = (b_cmd == B_EXCLUSIVE);
+                        assert (act_beat.b_resp[0] == exp_bit)
+                            else $error("upstream.B: Expected resp 0%01b for ID %0x but got %02b!",
+                                exp_bit, act_beat.b_id, act_beat.b_resp);
+                    end else begin
+                        assert (act_beat.b_resp[0] == exp_beat.b_resp[0]);
+                    end
+                end
+            end
+        end
+    end
+
+    always_comb begin
+        downstream_b_wait_d = downstream_b_wait_q;
+        if (downstream.b_valid) begin
+            if (downstream.b_ready) begin
+                downstream_b_wait_d = 1'b0;
+            end else begin
+                downstream_b_wait_d = 1'b1;
+            end
+        end
+    end
+
+    always_ff @(posedge clk, negedge rst_n) begin
+        if (~rst_n) begin
+            downstream_b_wait_q <= 1'b0;
+        end else begin
+            downstream_b_wait_q <= downstream_b_wait_d;
+        end
+    end
+
+endmodule

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_lrsc_tb_wave.do
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/axi_riscv_lrsc_tb_wave.do
@@ -1,0 +1,208 @@
+onerror {resume}
+quietly WaveActivateNextPane {} 0
+add wave -noupdate /axi_riscv_lrsc_tb/dut/i_lrsc/clk_i
+add wave -noupdate /axi_riscv_lrsc_tb/dut/i_lrsc/rst_ni
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_valid
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_ready
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_id
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_addr
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_len
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_size
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_burst
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_lock
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_cache
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_prot
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_qos
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_region
+add wave -noupdate -expand -group upstream -group upstream/ar /axi_riscv_lrsc_tb/upstream/ar_user
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_valid
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_ready
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_addr
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_id
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_len
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_size
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_burst
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_lock
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_cache
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_prot
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_qos
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_region
+add wave -noupdate -expand -group upstream -expand -group upstream/aw /axi_riscv_lrsc_tb/upstream/aw_user
+add wave -noupdate -expand -group upstream -group upstream/r /axi_riscv_lrsc_tb/upstream/r_valid
+add wave -noupdate -expand -group upstream -group upstream/r /axi_riscv_lrsc_tb/upstream/r_ready
+add wave -noupdate -expand -group upstream -group upstream/r /axi_riscv_lrsc_tb/upstream/r_id
+add wave -noupdate -expand -group upstream -group upstream/r /axi_riscv_lrsc_tb/upstream/r_data
+add wave -noupdate -expand -group upstream -group upstream/r /axi_riscv_lrsc_tb/upstream/r_resp
+add wave -noupdate -expand -group upstream -group upstream/r /axi_riscv_lrsc_tb/upstream/r_last
+add wave -noupdate -expand -group upstream -group upstream/r /axi_riscv_lrsc_tb/upstream/r_user
+add wave -noupdate -expand -group upstream -expand -group upstream/w /axi_riscv_lrsc_tb/upstream/w_valid
+add wave -noupdate -expand -group upstream -expand -group upstream/w /axi_riscv_lrsc_tb/upstream/w_ready
+add wave -noupdate -expand -group upstream -expand -group upstream/w /axi_riscv_lrsc_tb/upstream/w_data
+add wave -noupdate -expand -group upstream -expand -group upstream/w /axi_riscv_lrsc_tb/upstream/w_strb
+add wave -noupdate -expand -group upstream -expand -group upstream/w /axi_riscv_lrsc_tb/upstream/w_last
+add wave -noupdate -expand -group upstream -expand -group upstream/w /axi_riscv_lrsc_tb/upstream/w_user
+add wave -noupdate -expand -group upstream -expand -group upstream/b /axi_riscv_lrsc_tb/upstream/b_valid
+add wave -noupdate -expand -group upstream -expand -group upstream/b /axi_riscv_lrsc_tb/upstream/b_ready
+add wave -noupdate -expand -group upstream -expand -group upstream/b /axi_riscv_lrsc_tb/upstream/b_id
+add wave -noupdate -expand -group upstream -expand -group upstream/b /axi_riscv_lrsc_tb/upstream/b_resp
+add wave -noupdate -expand -group upstream -expand -group upstream/b /axi_riscv_lrsc_tb/upstream/b_user
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/art_set_req
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/art_set_gnt
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/slv_b
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/slv_b_valid
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/slv_b_ready
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/w_cmd_inp
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/w_cmd_oup
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/w_cmd_push
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/w_cmd_pop
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/w_cmd_full
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/w_cmd_empty
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_inj_inp
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_inj_oup
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_inj_push
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_inj_pop
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_inj_full
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_inj_empty
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_inp_id
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_inp_cmd
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_inp_req
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_inp_gnt
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_oup_id
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_oup_cmd
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_oup_valid
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_oup_pop
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_oup_req
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_status_oup_gnt
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/art_check_res
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/ar_state_q
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/aw_state_q
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/b_state_q
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/art_check_clr_addr
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/art_check_clr_gnt
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/art_check_clr_req
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/art_check_id
+add wave -noupdate -expand -group dut /axi_riscv_lrsc_tb/dut/i_lrsc/art_check_res
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_valid
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_ready
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_id
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_addr
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_len
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_size
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_burst
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_lock
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_cache
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_prot
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_qos
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_region
+add wave -noupdate -expand -group downstream -group downstream/ar /axi_riscv_lrsc_tb/downstream/ar_user
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_valid
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_ready
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_addr
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_id
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_len
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_size
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_burst
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_lock
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_cache
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_prot
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_qos
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_region
+add wave -noupdate -expand -group downstream -expand -group downstream/aw /axi_riscv_lrsc_tb/downstream/aw_user
+add wave -noupdate -expand -group downstream -group downstream/r /axi_riscv_lrsc_tb/downstream/r_valid
+add wave -noupdate -expand -group downstream -group downstream/r /axi_riscv_lrsc_tb/downstream/r_ready
+add wave -noupdate -expand -group downstream -group downstream/r /axi_riscv_lrsc_tb/downstream/r_id
+add wave -noupdate -expand -group downstream -group downstream/r /axi_riscv_lrsc_tb/downstream/r_data
+add wave -noupdate -expand -group downstream -group downstream/r /axi_riscv_lrsc_tb/downstream/r_resp
+add wave -noupdate -expand -group downstream -group downstream/r /axi_riscv_lrsc_tb/downstream/r_last
+add wave -noupdate -expand -group downstream -group downstream/r /axi_riscv_lrsc_tb/downstream/r_user
+add wave -noupdate -expand -group downstream -group downstream/w /axi_riscv_lrsc_tb/downstream/w_valid
+add wave -noupdate -expand -group downstream -group downstream/w /axi_riscv_lrsc_tb/downstream/w_ready
+add wave -noupdate -expand -group downstream -group downstream/w /axi_riscv_lrsc_tb/downstream/w_data
+add wave -noupdate -expand -group downstream -group downstream/w /axi_riscv_lrsc_tb/downstream/w_strb
+add wave -noupdate -expand -group downstream -group downstream/w /axi_riscv_lrsc_tb/downstream/w_last
+add wave -noupdate -expand -group downstream -group downstream/w /axi_riscv_lrsc_tb/downstream/w_user
+add wave -noupdate -expand -group downstream -expand -group downstream/b /axi_riscv_lrsc_tb/downstream/b_valid
+add wave -noupdate -expand -group downstream -expand -group downstream/b /axi_riscv_lrsc_tb/downstream/b_ready
+add wave -noupdate -expand -group downstream -expand -group downstream/b /axi_riscv_lrsc_tb/downstream/b_id
+add wave -noupdate -expand -group downstream -expand -group downstream/b /axi_riscv_lrsc_tb/downstream/b_resp
+add wave -noupdate -expand -group downstream -expand -group downstream/b /axi_riscv_lrsc_tb/downstream/b_user
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/inp_id_i
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/inp_data_i
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/inp_req_i
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/inp_gnt_o
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/oup_id_i
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/oup_pop_i
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/oup_req_i
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/oup_data_o
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/oup_data_valid_o
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/oup_gnt_o
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/head_tail_d
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/head_tail_q
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/linked_data_d
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/linked_data_q
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/full
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/no_id_match
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/head_tail_free
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/idx_matches_id
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/linked_data_free
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/match_id
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/head_tail_free_idx
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/match_idx
+add wave -noupdate -group b_status_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_b_status_queue/linked_data_free_idx
+add wave -noupdate -radix decimal /axi_riscv_lrsc_tb/b_queue.size
+add wave -noupdate /axi_riscv_lrsc_tb/dut/i_lrsc/i_art/tbl_q
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/clk_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/rst_ni
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/exists_req_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/exists_gnt_o
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/exists_data_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/exists_o
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/inp_req_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/inp_gnt_o
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/inp_data_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/inp_id_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/oup_req_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/oup_gnt_o
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/oup_id_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/oup_pop_i
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/oup_data_o
+add wave -noupdate -group read_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_read_in_flight_queue/oup_data_valid_o
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/clk_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/rst_ni
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/exists_req_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/exists_gnt_o
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/exists_data_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/exists_o
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/inp_req_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/inp_gnt_o
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/inp_data_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/inp_id_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/oup_req_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/oup_gnt_o
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/oup_id_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/oup_pop_i
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/oup_data_o
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/oup_data_valid_o
+add wave -noupdate -group write_in_flight_queue /axi_riscv_lrsc_tb/dut/i_lrsc/i_write_in_flight_queue/linked_data_q
+add wave -noupdate /axi_riscv_lrsc_tb/dut/i_lrsc/ar_push_ready
+add wave -noupdate /axi_riscv_lrsc_tb/dut/i_lrsc/ar_push_valid
+add wave -noupdate /axi_riscv_lrsc_tb/dut/i_lrsc/art_filter_ready
+add wave -noupdate /axi_riscv_lrsc_tb/downstream_b_wait_q
+TreeUpdate [SetDefaultTree]
+WaveRestoreCursors {{illegal downstream.AW?} {158222010 ps} 1} {{upstream SC to  0x38} {157860020 ps} 1} {{Cursor 6} {21241320 ps} 0}
+quietly wave cursor active 3
+configure wave -namecolwidth 239
+configure wave -valuecolwidth 100
+configure wave -justifyvalue left
+configure wave -signalnamewidth 1
+configure wave -snapdistance 10
+configure wave -datasetprefix 0
+configure wave -rowmargin 4
+configure wave -childrowmargin 2
+configure wave -gridoffset 0
+configure wave -gridperiod 1
+configure wave -griddelta 40
+configure wave -timeline 0
+configure wave -timelineunits ns
+update
+WaveRestoreZoom {0 ps} {49487360 ps}

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/golden_memory.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/golden_memory.sv
@@ -1,0 +1,394 @@
+// Copyright (c) 2019 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+/// A monitor interface for `axi_sim_mem`'s monitor ports.
+interface MONITOR_BUS #(
+    parameter int unsigned ADDR_WIDTH = 0,
+    parameter int unsigned DATA_WIDTH = 0,
+    parameter int unsigned ID_WIDTH   = 0,
+    parameter int unsigned USER_WIDTH = 0
+);
+
+    typedef logic [ID_WIDTH-1:0]   id_t;
+    typedef logic [ADDR_WIDTH-1:0] addr_t;
+    typedef logic [DATA_WIDTH-1:0] data_t;
+    typedef logic [USER_WIDTH-1:0] user_t;
+
+    logic          w_valid;
+    addr_t         w_addr;
+    data_t         w_data;
+    id_t           w_id;
+    user_t         w_user;
+    axi_pkg::len_t w_beat_count;
+    logic          w_last;
+
+    logic          r_valid;
+    addr_t         r_addr;
+    data_t         r_data;
+    id_t           r_id;
+    user_t         r_user;
+    axi_pkg::len_t r_beat_count;
+    logic          r_last;
+
+
+    modport Master (
+        output w_valid, w_addr, w_data, w_id, w_user, w_beat_count, w_last, r_valid,
+        output r_addr, r_data, r_id, r_user, r_beat_count, r_last
+    );
+
+    modport Slave (
+        input w_valid, w_addr, w_data, w_id, w_user, w_beat_count, w_last, r_valid,
+        input r_addr, r_data, r_id, r_user, r_beat_count, r_last
+    );
+endinterface
+
+/// A clocked monitor interface for `axi_sim_mem`'s monitor ports.
+interface MONITOR_BUS_DV #(
+    parameter int unsigned ADDR_WIDTH = 0,
+    parameter int unsigned DATA_WIDTH = 0,
+    parameter int unsigned ID_WIDTH   = 0,
+    parameter int unsigned USER_WIDTH = 0
+)(
+    input logic clk_i
+);
+
+    typedef logic [ID_WIDTH-1:0]   id_t;
+    typedef logic [ADDR_WIDTH-1:0] addr_t;
+    typedef logic [DATA_WIDTH-1:0] data_t;
+    typedef logic [USER_WIDTH-1:0] user_t;
+
+    logic          w_valid;
+    addr_t         w_addr;
+    data_t         w_data;
+    id_t           w_id;
+    user_t         w_user;
+    axi_pkg::len_t w_beat_count;
+    logic          w_last;
+
+    logic          r_valid;
+    addr_t         r_addr;
+    data_t         r_data;
+    id_t           r_id;
+    user_t         r_user;
+    axi_pkg::len_t r_beat_count;
+    logic          r_last;
+
+
+    modport Master (
+        output w_valid, w_addr, w_data, w_id, w_user, w_beat_count, w_last, r_valid,
+        output r_addr, r_data, r_id, r_user, r_beat_count, r_last
+    );
+
+    modport Slave (
+        input w_valid, w_addr, w_data, w_id, w_user, w_beat_count, w_last, r_valid,
+        input r_addr, r_data, r_id, r_user, r_beat_count, r_last
+    );
+endinterface
+
+package golden_model_pkg;
+
+    class golden_memory #(
+        parameter int unsigned MEM_ADDR_WIDTH = 20,
+        parameter int unsigned MEM_DATA_WIDTH = 32,
+        parameter int unsigned AXI_ADDR_WIDTH = 32,
+        parameter int unsigned AXI_DATA_WIDTH = 32,
+        parameter int unsigned AXI_ID_WIDTH_M = 8,
+        parameter int unsigned AXI_ID_WIDTH_S = 16,
+        parameter int unsigned AXI_USER_WIDTH = 0,
+        parameter int unsigned USER_AS_ID = 0,
+        parameter time APPL_DELAY = 1ns,
+        parameter time ACQ_DELAY = 1ns
+    );
+
+        localparam int unsigned MEM_OFFSET_BITS = $clog2(MEM_DATA_WIDTH/8);
+        localparam int unsigned NUM_MAST_WIDTH  = AXI_ID_WIDTH_S-AXI_ID_WIDTH_M;
+        localparam int unsigned RES_ID_WIDTH    = USER_AS_ID ? AXI_USER_WIDTH : AXI_ID_WIDTH_S;
+
+        typedef logic [MEM_ADDR_WIDTH-1:0] mem_addr_t;
+
+        // Static variable for memory
+        static logic [7:0] memory [mem_addr_t];
+
+        // AXI Bus to actual memory (after memory AXI-buffer)
+        // This bus is only read to get the same linearization
+        // in both the actual memory and the golden model.
+        virtual MONITOR_BUS_DV #(
+          .ADDR_WIDTH(AXI_ADDR_WIDTH),
+          .DATA_WIDTH(AXI_DATA_WIDTH),
+          .ID_WIDTH  (AXI_ID_WIDTH_S),
+          .USER_WIDTH(AXI_USER_WIDTH)
+        ) monitor;
+
+        function new(virtual MONITOR_BUS_DV #(
+                .ADDR_WIDTH(AXI_ADDR_WIDTH),
+                .DATA_WIDTH(AXI_DATA_WIDTH),
+                .ID_WIDTH  (AXI_ID_WIDTH_S),
+                .USER_WIDTH(AXI_USER_WIDTH)
+            ) monitor
+        );
+            this.monitor = monitor;
+            void'(randomize(memory));
+        endfunction : new
+
+        function automatic logic [MEM_ADDR_WIDTH-1:0] calculate_address(logic [AXI_ADDR_WIDTH-1:0] addr );
+            // Crop address
+            calculate_address = addr[MEM_ADDR_WIDTH-1:0];
+        endfunction : calculate_address
+
+        function automatic logic [AXI_ADDR_WIDTH-1:0] calculate_dut_address(logic [AXI_ADDR_WIDTH-1:0] addr);
+            // Shift address
+            calculate_dut_address = {{$clog2(AXI_DATA_WIDTH/8){1'b0}}, addr[AXI_ADDR_WIDTH-1:$clog2(AXI_DATA_WIDTH/8)]};
+        endfunction : calculate_dut_address
+
+        function automatic logic [AXI_ID_WIDTH_S-1:0] slave_id(logic [AXI_ID_WIDTH_M-1:0] master_id, logic [NUM_MAST_WIDTH-1:0] master_channel);
+            slave_id = '0;
+            if (AXI_ID_WIDTH_S > AXI_ID_WIDTH_M) begin
+                slave_id |= (~master_channel) << AXI_ID_WIDTH_M;
+            end
+            slave_id[AXI_ID_WIDTH_M-1:0] = master_id;
+        endfunction : slave_id
+
+        function automatic logic [RES_ID_WIDTH-1:0] get_monitor_w_id();
+            if (USER_AS_ID) begin
+                get_monitor_w_id = monitor.w_user;
+            end else begin
+                get_monitor_w_id = monitor.w_id[RES_ID_WIDTH-1:0];
+            end
+        endfunction : get_monitor_w_id
+
+        function automatic logic [RES_ID_WIDTH-1:0] get_monitor_r_id();
+            if (USER_AS_ID) begin
+                get_monitor_r_id = monitor.r_user;
+            end else begin
+                get_monitor_r_id = monitor.r_id[RES_ID_WIDTH-1:0];
+            end
+        endfunction : get_monitor_r_id
+
+        /**
+         * Take data that is MEM_DATA_WIDTH wide and cut it back to the specified size and optionally sign extend it
+         */
+        function automatic logic [MEM_DATA_WIDTH-1:0] crop_data(logic [MEM_DATA_WIDTH-1:0] data, logic [2:0] size, logic sign_ext = 0);
+            int unsigned num_bytes = 2**size;
+            logic sign             = data[(8*num_bytes)-1];
+
+            if (sign && sign_ext) begin
+                crop_data = '1;
+            end else begin
+                crop_data = '0;
+            end
+            // For loop necessary because SystemVerilog does not allow variable ranges
+            for (int i = 0; i < num_bytes; i++) begin
+                crop_data[i*8 +: 8] = data[i*8 +: 8];
+            end
+        endfunction : crop_data
+
+        task set_memory(logic [MEM_ADDR_WIDTH-1:0] addr, logic [MEM_DATA_WIDTH-1:0] data, logic [2:0] size);
+            int unsigned num_bytes = 2**size;
+            #(APPL_DELAY)
+            for (int i = 0; i < num_bytes; i++) begin
+                memory[addr+i] = data[i*8 +: 8];
+            end
+        endtask : set_memory
+
+        function logic [MEM_DATA_WIDTH-1:0] get_memory(logic [MEM_ADDR_WIDTH-1:0] addr, logic [2:0] size);
+            int unsigned num_bytes = 2**size;
+            // void'(randomize(get_memory));
+            get_memory = '0;
+            for (int i = 0; i < num_bytes; i++) begin
+                get_memory[i*8 +: 8] = memory[addr+i];
+            end
+        endfunction : get_memory
+
+        task write(
+            input  logic [AXI_ADDR_WIDTH-1:0] addr,
+            input  logic [MEM_DATA_WIDTH-1:0] w_data,
+            input  logic [2:0]                size,
+            input  logic [AXI_ID_WIDTH_M-1:0] m_id,
+            input  logic [AXI_USER_WIDTH-1:0] user,
+            input  logic [NUM_MAST_WIDTH-1:0] master = 0,
+            output logic [MEM_DATA_WIDTH-1:0] r_data,
+            output logic [1:0]                b_resp,
+            input  logic [5:0]                atop = 0
+        );
+
+            automatic logic unsigned [MEM_ADDR_WIDTH-1:0] address  = calculate_address(addr);
+
+            automatic logic unsigned [MEM_DATA_WIDTH-1:0] data_ui  = $unsigned(crop_data(w_data, size));
+            automatic logic unsigned [MEM_DATA_WIDTH-1:0] data_uo  = 0;
+            automatic logic   signed [MEM_DATA_WIDTH-1:0] data_si  = $signed(crop_data(w_data, size, 1));
+            automatic logic   signed [MEM_DATA_WIDTH-1:0] data_so  = 0;
+
+            automatic logic          [AXI_ID_WIDTH_S-1:0] id = slave_id(m_id, master);
+
+            automatic logic          [RES_ID_WIDTH-1:0]   trans_id = 1;
+            automatic logic          [RES_ID_WIDTH-1:0]   res_id = USER_AS_ID ? user : id;
+
+            b_resp = axi_pkg::RESP_OKAY;
+
+            if (atop == tb_axi_pkg::ATOP_LRSC) begin
+                // LR/SC pair
+                // Wait for LR
+                read(addr, r_data, size, m_id, user, master);
+
+                // Check reservation
+                wait_write(addr, size, res_id, trans_id);
+                if (trans_id != res_id) begin
+                    // SC failed
+                    b_resp = axi_pkg::RESP_OKAY;
+                end else begin
+                    // Success
+                    set_memory(address, w_data, size);
+                    b_resp = axi_pkg::RESP_EXOKAY;
+                end
+            end else if (atop[5:4] == axi_pkg::ATOP_NONE) begin
+                // Wait for the write
+                wait_b(res_id);
+                set_memory(address, w_data, size);
+                r_data = '0;
+            end else if (atop == axi_pkg::ATOP_ATOMICSWAP) begin
+                // Wait for the write to happen
+                wait_b(res_id);
+                // Read before writing and then update memory
+                r_data = get_memory(address, size);
+                set_memory(address, w_data, size);
+            end else if ((atop[5:3] == {axi_pkg::ATOP_ATOMICLOAD,  axi_pkg::ATOP_LITTLE_END}) ||
+                         (atop[5:3] == {axi_pkg::ATOP_ATOMICSTORE, axi_pkg::ATOP_LITTLE_END})) begin
+                // Wait for the write to happen
+                wait_b(res_id);
+                data_uo = $unsigned(get_memory(address, size));
+                data_so = $signed(crop_data(get_memory(address, size), size, 1));
+
+                r_data  = data_uo;
+
+                // Write result
+                unique case (atop[2:0])
+                    axi_pkg::ATOP_ADD : begin
+                        w_data = data_uo + w_data;
+                    end
+                    axi_pkg::ATOP_CLR : begin
+                        w_data = data_uo & (~w_data);
+                    end
+                    axi_pkg::ATOP_EOR : begin
+                        w_data = data_uo ^ w_data;
+                    end
+                    axi_pkg::ATOP_SET : begin
+                        w_data = data_uo | w_data;
+                    end
+                    axi_pkg::ATOP_SMAX: begin
+                        w_data = (data_so > data_si) ? data_uo : w_data;
+                    end
+                    axi_pkg::ATOP_SMIN: begin
+                        w_data = (data_so > data_si) ? w_data : data_uo;
+                    end
+                    axi_pkg::ATOP_UMAX: begin
+                        w_data = (data_uo > data_ui) ? data_uo : w_data;
+                    end
+                    axi_pkg::ATOP_UMIN: begin
+                        w_data = (data_uo > data_ui) ? w_data : data_uo;
+                    end
+                    default: begin
+                        w_data = data_uo;
+                    end
+                endcase
+
+                set_memory(address, w_data, size);
+
+            end else begin
+                b_resp = axi_pkg::RESP_SLVERR;
+                r_data = '0;
+            end
+
+            r_data = crop_data(r_data, size);
+
+        endtask : write
+
+        task read(
+            input  logic [AXI_ADDR_WIDTH-1:0] addr,
+            output logic [MEM_DATA_WIDTH-1:0] r_data,
+            input  logic [2:0]                size,
+            input  logic [AXI_ID_WIDTH_M-1:0] id,
+            input  logic [AXI_USER_WIDTH-1:0] user,
+            input  logic [NUM_MAST_WIDTH-1:0] master = 0
+        );
+            // Calculate memory address
+            automatic logic unsigned [MEM_ADDR_WIDTH-1:0] address = calculate_address(addr);
+            // Wait until the transaction actually happens
+            if (USER_AS_ID) begin
+                wait_read(addr, size, user);
+            end else begin
+                wait_read(addr, size, slave_id(id, master));
+            end
+            // Read data from golden model
+            r_data = crop_data(get_memory(address, size), size);
+        endtask : read
+
+        // Linearization Functions
+        logic [RES_ID_WIDTH-1:0] default_id = 0; // Systemverilog requires a assignable default value (required to make this argument optional)
+        task wait_write(
+            input logic [AXI_ADDR_WIDTH-1:0] addr,
+            input logic [2:0]                size,
+            input logic [RES_ID_WIDTH-1:0]   id,
+            inout logic [RES_ID_WIDTH-1:0]   out_id=default_id
+        );
+            if (out_id) begin
+                // Wait for a transaction to be through the memory controller's buffers and return its ID
+                forever begin
+                    @(posedge monitor.clk_i);
+                    #(ACQ_DELAY);
+                    if (monitor.w_valid && monitor.w_addr == addr) begin
+                        break;
+                    end
+                end
+                out_id = get_monitor_w_id();
+            end else begin
+                // Wait for the transaction to be through the memory controller's buffers
+                forever begin
+                    @(posedge monitor.clk_i);
+                    #(ACQ_DELAY);
+                    if (monitor.w_valid && get_monitor_w_id() == id
+                            && monitor.w_addr == addr) begin
+                        break;
+                    end
+                end
+            end
+        endtask : wait_write
+
+        task wait_b(
+            input logic [RES_ID_WIDTH-1:0] id
+        );
+            // Wait for the transaction to be confirmed by the memory controller
+            forever begin
+                @(posedge monitor.clk_i);
+                #(ACQ_DELAY);
+                if (monitor.w_valid && get_monitor_w_id() == id) begin
+                    break;
+                end
+            end
+        endtask : wait_b
+
+        task wait_read(
+            input logic [AXI_ADDR_WIDTH-1:0] addr,
+            input logic [2:0]                size,
+            input logic [RES_ID_WIDTH-1:0]   id
+        );
+            // Wait for the transaction to be through the memory controller's buffers
+            forever begin
+                @(posedge monitor.clk_i);
+                #(ACQ_DELAY);
+                if (monitor.r_valid && get_monitor_r_id() == id
+                        && monitor.r_addr == addr) begin
+                    break;
+                end
+            end
+        endtask : wait_read
+
+    endclass : golden_memory
+endpackage : golden_model_pkg

--- a/hw/vendor/pulp_platform_axi_riscv_atomics/test/tb_axi_pkg.sv
+++ b/hw/vendor/pulp_platform_axi_riscv_atomics/test/tb_axi_pkg.sv
@@ -1,0 +1,220 @@
+// Copyright (c) 2019 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+import axi_pkg::*;
+import axi_test::*;
+
+package tb_axi_pkg;
+
+    axi_pkg::atop_t ATOP_LRSC = 6'b000111;
+
+    class axi_access #(
+        parameter int  AW = 32  , // AXI address width
+        parameter int  DW = 32  , // AXI data width
+        parameter int  IW =  9  , // AXI ID width
+        parameter int  UW =  1  , // AXI user width
+        parameter int  SW = 32  , // System data width
+        parameter time TA = 0ns , // Stimuli application time
+        parameter time TT = 1ns   // Response acquisition time
+    ) extends axi_test::axi_driver #(
+        .AW( AW ),
+        .DW( DW ),
+        .IW( IW ),
+        .UW( UW ),
+        .TA( TA ),
+        .TT( TT )
+    );
+
+        int unsigned RAND_DELAY = 20;
+        int unsigned obj_id = 100;
+
+        function new(
+            int unsigned obj_id_in,
+            virtual AXI_BUS_DV #(
+                .AXI_ADDR_WIDTH(AW),
+                .AXI_DATA_WIDTH(DW),
+                .AXI_ID_WIDTH(IW),
+                .AXI_USER_WIDTH(UW)
+            ) axi
+        );
+            super.new(axi);
+            obj_id = obj_id_in;
+            $timeformat(-9, 2, " ns", 10);
+            $display("%d: PARAMS %d, %d, %d, %d, %t, %t", obj_id, AW, DW, IW, UW, TA, TT);
+        endfunction : new
+
+        // Wait a random amount of cycles
+        task rand_delay(int min, int max);
+            repeat ($urandom_range(min, max)) begin
+                @(posedge axi.clk_i);
+            end
+        endtask : rand_delay
+
+        // Write over AXI
+        task axi_write(
+            input  logic [AW-1:0] address,
+            input  logic [SW-1:0] data,
+            input  logic [2:0]    size,
+            input  logic [IW-1:0] id,
+            input  logic [UW-1:0] user,
+            output logic [DW-1:0] result,
+            output logic [1:0]    b_resp,
+            input  logic [5:0]    atop = 0
+        );
+            automatic ax_beat_t ax_beat = new;
+            automatic r_beat_t  r_beat  = new;
+            automatic w_beat_t  w_beat  = new;
+            automatic b_beat_t  b_beat  = new;
+            logic [DW-1:0]   axi_data;
+            logic [DW/8-1:0] strb;
+            map_sys2axi_data(address, data, size, axi_data, strb);
+            // Send AW and W request
+            ax_beat.ax_id    = id;
+            ax_beat.ax_user  = user;
+            ax_beat.ax_addr  = address;
+            ax_beat.ax_size  = size;
+            ax_beat.ax_burst = axi_pkg::BURST_INCR;
+            w_beat.w_data    = axi_data;
+            w_beat.w_strb    = strb;
+            w_beat.w_last    = 1'b1;
+            if (atop == ATOP_LRSC) begin
+                // LRSC pair
+                axi_read(address, result, size, id, user, 1'b1);
+                rand_delay(0,10*RAND_DELAY);
+                ax_beat.ax_atop = '0;
+                ax_beat.ax_lock = 1'b1;
+            end else begin
+                ax_beat.ax_atop = atop;
+                ax_beat.ax_lock = 1'b0;
+            end
+            fork
+                // AW
+                begin
+                    rand_delay(0,RAND_DELAY);
+                    send_aw(ax_beat);
+                end
+                // W
+                begin
+                    rand_delay(0,RAND_DELAY);
+                    send_w(w_beat);
+                end
+            join
+
+            // Wait for B response
+            fork
+                // B
+                begin
+                    rand_delay(0,RAND_DELAY);
+                    recv_b(b_beat);
+                    b_resp = b_beat.b_resp;
+                    if (b_beat.b_id != id) begin
+                        $display("%0t: %d: AXI WRITE: b_id (0x%x) did not match aw_id (0x%x)", $time, obj_id, b_beat.b_id, id);
+                    end
+                end
+                // R response if atop
+                begin
+                    if (atop[axi_pkg::ATOP_R_RESP]) begin // Atomic operations with read response
+                        rand_delay(0,RAND_DELAY);
+                        recv_r(r_beat);
+                        result = r_beat.r_data;
+                        if (r_beat.r_id != id) begin
+                            $display("%0t: %d: AXI WRITE: r_id (0x%x) did not match aw_id (0x%x)", $time, obj_id, r_beat.r_id, id);
+                        end
+                    end
+                end
+            join
+            map_axi2sys_data(address, result, size, result);
+        endtask : axi_write
+
+        // Read over AXI
+        task axi_read(
+            input  logic [AW-1:0] address,
+            output logic [SW-1:0] data,
+            input  logic [2:0]    size,
+            input  logic [IW-1:0] id,
+            input  logic [UW-1:0] user,
+            input  logic          lock = 1'b0
+        );
+            automatic ax_beat_t ax_beat = new;
+            automatic r_beat_t  r_beat  = new;
+            // Send AW and W request
+            ax_beat.ax_id    = id;
+            ax_beat.ax_user  = user;
+            ax_beat.ax_addr  = address;
+            ax_beat.ax_size  = size;
+            ax_beat.ax_lock  = lock;
+            ax_beat.ax_burst = axi_pkg::BURST_INCR;
+            fork
+                // AR
+                begin
+                    rand_delay(0,RAND_DELAY);
+                    send_ar(ax_beat);
+                end
+                // R
+                begin
+                    rand_delay(0,RAND_DELAY);
+                    recv_r(r_beat);
+                    data = r_beat.r_data;
+                    if (r_beat.r_id != id) begin
+                        $display("%0t: %d: AXI READ: r_id (0x%x) did not match ar_id (0x%x)", $time, obj_id, r_beat.r_id, id);
+                    end
+                    if ((lock && r_beat.r_resp != axi_pkg::RESP_EXOKAY) || (!lock && r_beat.r_resp != axi_pkg::RESP_OKAY)) begin
+                        $display("%0t: %d: AXI READ: r_resp was 0x%x", $time, obj_id, r_beat.r_resp);
+                    end
+                end
+            join
+            map_axi2sys_data(address, r_beat.r_data, size, data);
+        endtask : axi_read
+
+        task map_sys2axi_data(
+            input  logic [AW-1:0]   address,
+            input  logic [SW-1:0]   data,
+            input  logic [2:0]      size,
+            output logic [DW-1:0]   result,
+            output logic [DW/8-1:0] strb
+        );
+
+            localparam int unsigned OFFSET_BITS = $clog2(DW/8);
+
+            // Initialize variables
+            result = 'X;
+            strb   = '0;
+
+            // Assign specific bytes
+            for (int i = 0; i < 2**size; i++) begin
+                int j = address[OFFSET_BITS-1:0]+i;
+                result[j*8 +: 8] = data[i*8 +: 8];
+                strb[j]          = 1'b1;
+            end
+
+        endtask : map_sys2axi_data
+
+        task map_axi2sys_data(
+            input  logic [AW-1:0]   address,
+            input  logic [DW-1:0]   data,
+            input  logic [2:0]      size,
+            output logic [SW-1:0]   result
+        );
+
+            localparam int unsigned OFFSET_BITS = $clog2(DW/8);
+
+            result = '0;
+
+            for (int i = 0; i < 2**size; i++) begin
+                int j = address[OFFSET_BITS-1:0]+i;
+                result[i*8 +: 8] = data[j*8 +: 8];
+            end
+
+        endtask : map_axi2sys_data
+
+    endclass : axi_access
+
+endpackage : tb_axi_pkg

--- a/hw/vendor/pulp_platform_common_cells/src/id_queue.sv
+++ b/hw/vendor/pulp_platform_common_cells/src/id_queue.sv
@@ -51,8 +51,7 @@ module id_queue #(
     parameter bit FULL_BW   = 0,
     parameter type data_t   = logic,
     // Dependent parameters, DO NOT OVERRIDE!
-    localparam type id_t    = logic[ID_WIDTH-1:0],
-    localparam type mask_t  = logic[$bits(data_t)-1:0]
+    localparam type id_t    = logic[ID_WIDTH-1:0]
 ) (
     input  logic    clk_i,
     input  logic    rst_ni,
@@ -63,7 +62,7 @@ module id_queue #(
     output logic    inp_gnt_o,
 
     input  data_t   exists_data_i,
-    input  mask_t   exists_mask_i,
+    input  data_t   exists_mask_i,
     input  logic    exists_req_i,
     output logic    exists_o,
     output logic    exists_gnt_o,
@@ -357,7 +356,7 @@ module id_queue #(
 
     // Exists Lookup
     for (genvar i = 0; i < CAPACITY; i++) begin: gen_lookup
-        mask_t exists_match_bits;
+        data_t exists_match_bits;
         for (genvar j = 0; j < $bits(data_t); j++) begin: gen_mask
             always_comb begin
                 if (linked_data_q[i].free) begin

--- a/util/solder/solder.axi_atomic_adapter.sv.tpl
+++ b/util/solder/solder.axi_atomic_adapter.sv.tpl
@@ -3,7 +3,11 @@
     .AXI_DATA_WIDTH (${bus_in.dw}),
     .AXI_ID_WIDTH (${bus_in.iw}),
     .AXI_USER_WIDTH (${max(bus_in.uw, 1)}),
+    .AXI_MAX_READ_TXNS (${max_trans}),
     .AXI_MAX_WRITE_TXNS (${max_trans}),
+    .AXI_USER_AS_ID (${user_as_id}),
+    .AXI_USER_ID_MSB (${user_id_msb}),
+    .AXI_USER_ID_LSB (${user_id_lsb}),
     .RISCV_WORD_WIDTH (64)
   ) ${name} (
     .clk_i (${bus_in.clk}),

--- a/util/solder/solder.py
+++ b/util/solder/solder.py
@@ -798,6 +798,9 @@ class AxiBus(Bus):
     def atomic_adapter(self,
                        context,
                        max_trans=1,
+                       user_as_id=0,
+                       user_id_msb=0,
+                       user_id_lsb=0,
                        name=None,
                        inst_name=None,
                        to=None,
@@ -826,15 +829,27 @@ class AxiBus(Bus):
 
         # Emit the cut instance.
         bus.declare(context)
-        tpl = templates.get_template("solder.axi_atomic_adapter.sv.tpl" if not filter else
-                                     "solder.axi_atop_filter.sv.tpl")
-        context.write(
-            tpl.render_unicode(
-                bus_in=self,
-                bus_out=bus,
-                max_trans=max_trans,
-                name=inst_name or "i_{}".format(name),
-            ) + "\n")
+        if not filter:
+            tpl = templates.get_template("solder.axi_atomic_adapter.sv.tpl")
+            context.write(
+                tpl.render_unicode(
+                    bus_in=self,
+                    bus_out=bus,
+                    max_trans=max_trans,
+                    user_as_id=user_as_id,
+                    user_id_msb=user_id_msb,
+                    user_id_lsb=user_id_lsb,
+                    name=inst_name or "i_{}".format(name),
+                ) + "\n")
+        else:
+            tpl = templates.get_template("solder.axi_atop_filter.sv.tpl")
+            context.write(
+                tpl.render_unicode(
+                    bus_in=self,
+                    bus_out=bus,
+                    max_trans=max_trans,
+                    name=inst_name or "i_{}".format(name),
+                ) + "\n")
         return bus
 
     def to_axi_lite(self, context, name, inst_name=None, to=None):


### PR DESCRIPTION
This PR updates the ATUN to the latest version.

- Guarantees atomicity by tracking downstream writes (limits number of writes in-flight and needs to be configured according to the performance requirements)
- Adds the option to use the USER signal to distinguish different harts. This is currently still disabled.

To make it work with VCS, we need to following two updates to dependencies:
- [x] https://github.com/pulp-platform/common_cells/pull/138
- [x] https://github.com/pulp-platform/axi_riscv_atomics/pull/19