### PR TITLE
snitch: Fix LR/SC responses

### DIFF
--- a/hw/ip/reqrsp_interface/src/reqrsp_to_axi.sv
+++ b/hw/ip/reqrsp_interface/src/reqrsp_to_axi.sv
@@ -257,7 +257,9 @@ module reqrsp_to_axi import reqrsp_pkg::*; #(
     // store conditional for the reqrsp interface.
     if ((axi_rsp_i.b_valid && ~atomic_in_flight_q
           && axi_rsp_i.b.resp != axi_pkg::RESP_EXOKAY)) begin
-      reqrsp_rsp_o.p.data = 1;
+      // Set all 32-bit words to 1 since we don't know the alignment
+      // and which bits are cut off by the core.
+      reqrsp_rsp_o.p.data = {DataWidth/32{32'h1}};
     end
   end
 

--- a/hw/ip/snitch_cluster/src/snitch_amo_shim.sv
+++ b/hw/ip/snitch_cluster/src/snitch_amo_shim.sv
@@ -136,7 +136,7 @@ module snitch_amo_shim
   end
 
   // In case of a SC we must forward SC result from the cycle earlier.
-  assign rdata_o = sc_q ? $unsigned(~sc_successful_q) : mem_rdata_i;
+  assign rdata_o = sc_q ? {DataWidth/32{31'h0,~sc_successful_q}} : mem_rdata_i;
   assign amo_conflict_o = dma_access_i & (state_q != Idle) & (addr_q == addr_i);
 
   // -----

--- a/sw/snRuntime/CMakeLists.txt
+++ b/sw/snRuntime/CMakeLists.txt
@@ -153,6 +153,9 @@ if(SNITCH_RUNTIME STREQUAL "snRuntime-cluster")
     add_snitch_test_executable(multi_cluster tests/multi_cluster.c)
     add_snitch_test_rtl(multi_cluster)
 
+    add_snitch_test_executable(atomics tests/atomics.c)
+    add_snitch_test_rtl(atomics)
+
     # Tests exclusive to LLVM
     if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
         add_snitch_test_executable(data_mover tests/data_mover.c)

--- a/sw/snRuntime/tests/atomics.c
+++ b/sw/snRuntime/tests/atomics.c
@@ -1,0 +1,205 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/* Tests that a single core can do atomics */
+
+#include <snrt.h>
+
+//===============================================================
+// RISC-V atomic instruction wrappers
+//===============================================================
+
+static inline uint32_t lr_w(volatile uint32_t* addr) {
+    uint32_t data = 0;
+    asm volatile("lr.w %[data], (%[addr])"
+                 : [ data ] "+r"(data)
+                 : [ addr ] "r"(addr)
+                 : "memory");
+    return data;
+}
+
+static inline uint32_t sc_w(volatile uint32_t* addr, uint32_t data) {
+    uint32_t err = 0;
+    asm volatile("sc.w %[err], %[data], (%[addr])"
+                 : [ err ] "+r"(err)
+                 : [ addr ] "r"(addr), [ data ] "r"(data)
+                 : "memory");
+    return err;
+}
+
+static inline uint32_t atomic_maxu_fetch(volatile uint32_t* addr,
+                                         uint32_t data) {
+    uint32_t prev = 0;
+    asm volatile("amomaxu.w %[prev], %[data], (%[addr])"
+                 : [ prev ] "+r"(prev)
+                 : [ addr ] "r"(addr), [ data ] "r"(data)
+                 : "memory");
+    return prev;
+}
+
+static inline uint32_t atomic_minu_fetch(volatile uint32_t* addr,
+                                         uint32_t data) {
+    uint32_t prev = 0;
+    asm volatile("amominu.w %[prev], %[data], (%[addr])"
+                 : [ prev ] "+r"(prev)
+                 : [ addr ] "r"(addr), [ data ] "r"(data)
+                 : "memory");
+    return prev;
+}
+
+//===============================================================
+// Test all atomics on a given memory location (single core)
+//===============================================================
+
+uint32_t test_atomics(volatile uint32_t* atomic_var) {
+    uint32_t tmp = 0;
+    uint32_t nerrors = 0;
+    uint32_t dummy_val = 42;
+    uint32_t amo_operand;
+    uint32_t expected_val;
+
+    /******************************************************
+     * Initialize
+     ******************************************************/
+    *atomic_var = 0;
+
+    /******************************************************
+     * Test 0: SC without previously acquiring lock
+     *
+     * We expect the SC to return an error and the lock
+     * to not be overwritten.
+     ******************************************************/
+    amo_operand = dummy_val;
+    expected_val = *atomic_var;
+    tmp = sc_w(atomic_var, amo_operand);
+    if (!tmp) nerrors++;
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 1: LR/SC sequence
+     *
+     * We expect the LR to return zero. That is the
+     * initial value of lock. We expect the SC not to fail
+     * and lock to be updated to the stored value.
+     ******************************************************/
+    expected_val = *atomic_var;
+    tmp = lr_w(atomic_var);
+    if (tmp != expected_val) nerrors++;
+
+    amo_operand = dummy_val;
+    expected_val = amo_operand;
+    tmp = sc_w(atomic_var, amo_operand);
+    if (tmp) nerrors++;
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 2: AMOADD
+     ******************************************************/
+    amo_operand = 1;
+    expected_val += amo_operand;
+    __atomic_add_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 3: AMOSUB
+     ******************************************************/
+    amo_operand = 1;
+    expected_val -= amo_operand;
+    __atomic_sub_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 4: AMOAND
+     *
+     * Clear the second least-significant bit.
+     ******************************************************/
+    amo_operand = ~(1 << 1);
+    expected_val &= amo_operand;
+    __atomic_and_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 5: AMOOR
+     *
+     * Assert the second least-significant bit.
+     ******************************************************/
+    amo_operand = 1 << 1;
+    expected_val |= amo_operand;
+    __atomic_or_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 6: AMOXOR
+     *
+     * Toggle the second least-significant bit.
+     ******************************************************/
+    amo_operand = 1 << 1;
+    expected_val ^= amo_operand;
+    __atomic_xor_fetch(atomic_var, amo_operand, __ATOMIC_RELAXED);
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 7: AMOMAXU
+     *
+     * Max between lock and the incremented value.
+     * Expects incremented value to be stored.
+     ******************************************************/
+    amo_operand = expected_val + 1;
+    expected_val = expected_val > amo_operand ? expected_val : amo_operand;
+    atomic_maxu_fetch(atomic_var, amo_operand);
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 8: AMOMINU
+     *
+     * Max between lock and the decremented value.
+     * Expects decremented value to be stored.
+     ******************************************************/
+    amo_operand = expected_val - 1;
+    expected_val = expected_val < amo_operand ? expected_val : amo_operand;
+    atomic_minu_fetch(atomic_var, amo_operand);
+    if (*atomic_var != expected_val) nerrors++;
+
+    /******************************************************
+     * Test 9: AMOSWAP
+     ******************************************************/
+    amo_operand = dummy_val;
+    expected_val = dummy_val;
+    __atomic_exchange_n(atomic_var, amo_operand, __ATOMIC_RELAXED);
+    if (*atomic_var != expected_val) nerrors++;
+
+    return nerrors;
+}
+
+// Use at least two locations to test unaligned accesses
+#define NUM_SPM_LOCATIONS 2
+#define NUM_TCDM_LOCATIONS 2
+
+int main() {
+    uint32_t core_id = snrt_cluster_core_idx();
+    uint32_t core_num = snrt_cluster_core_num();
+    uint32_t nerrors = 0;
+
+    if (core_id == 0) {
+        volatile uint32_t* l1_a =
+            snrt_l1alloc(NUM_TCDM_LOCATIONS * sizeof(uint32_t));
+        volatile uint32_t* l3_a =
+            snrt_l3alloc(NUM_SPM_LOCATIONS * sizeof(uint32_t));
+
+        // In TCDM
+        uint32_t tcdm_atomics[NUM_TCDM_LOCATIONS];
+        for (int i = 0; i < NUM_TCDM_LOCATIONS; ++i) {
+            nerrors += test_atomics(&l1_a[i]);
+        }
+
+        // In SPM
+        for (int i = 0; i < NUM_SPM_LOCATIONS; ++i) {
+            nerrors += test_atomics(&l3_a[i]);
+        }
+    } else {
+        return 0;
+    }
+
+    return nerrors;
+}


### PR DESCRIPTION
Currently, all interfaces that return store-conditional responses simply set the response data to 1. However, most memory interfaces are wider than 32 bits and, depending on the alignment, Snitch only sees a slice of the returned value. The result is that store-conditionals not aligned to the interface width are reported as successful, independent of their actual outcome.

This PR fixes the modules that issue/convert the responses by returning -1 instead of one to guarantee that a non-zero return code reaches Snitch independent of any alignment issues. The RISC-V spec specifies a zero return value on success and a non-zero on failure, so we are free to return -1.

I fixed the:
- `reqrsp_interface`, which handles the AXI interface
- `tcdm_amo_shim`, which handles the atomics for the TCDM banks

Are there any other modules that resolve atomics in Snitch or that convert between AXI and Snitch?

I also adapted @colluca's test to check those memory regions. We currently don't run it on Banshee. Banshee replaces the SC with a CAS where it uses the last value loaded by an LR as the comparison value. This synthetic test currently leads to SCs succeeding because we do the same SC/LR/SC test pattern on different addresses. I will fix this later, but the HW fix should be merged as soon as possible.