### PR TITLE
occamy: Do not assert quadrant reset on global reset

### DIFF
--- a/hw/system/occamy/src/occamy_quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson
+++ b/hw/system/occamy/src/occamy_quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson
@@ -24,9 +24,10 @@
       desc: "Quadrant-internal asynchronous active-low reset",
       swaccess: "rw",
       hwaccess: "hro",
-      // Held in reset (i.e. signal low) by default
+      // *Not* held in reset (i.e. signal high) by default.
+      // Since clock is gated on reset, inner quadrant state should *not* change until ungate.
       fields: [
-        {bits: "0:0", name: "reset_n", resval: 0, desc: "Asynchronous active-low reset"}
+        {bits: "0:0", name: "reset_n", resval: 1, desc: "Asynchronous active-low reset"}
       ]
     },
     { name: "ISOLATE",

--- a/hw/system/occamy/src/occamy_quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson.tpl
+++ b/hw/system/occamy/src/occamy_quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson.tpl
@@ -24,9 +24,10 @@
       desc: "Quadrant-internal asynchronous active-low reset",
       swaccess: "rw",
       hwaccess: "hro",
-      // Held in reset (i.e. signal low) by default
+      // *Not* held in reset (i.e. signal high) by default.
+      // Since clock is gated on reset, inner quadrant state should *not* change until ungate.
       fields: [
-        {bits: "0:0", name: "reset_n", resval: 0, desc: "Asynchronous active-low reset"}
+        {bits: "0:0", name: "reset_n", resval: 1, desc: "Asynchronous active-low reset"}
       ]
     },
     { name: "ISOLATE",

--- a/hw/system/occamy/src/occamy_quadrant_s1_ctrl/occamy_quadrant_s1_reg_top.sv
+++ b/hw/system/occamy/src/occamy_quadrant_s1_ctrl/occamy_quadrant_s1_reg_top.sv
@@ -572,7 +572,7 @@ module occamy_quadrant_s1_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_reset_n (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),


### PR DESCRIPTION
The reset value of the quadrant reset register was changed from 0 (asserted) to 1 (not asserted): This means that the internal quadrant logic will *not* enter reset when the global reset is asserted. It will, however, still be clock-gated when the global reset is asserted.

The AXI isolators are all reset with the *global* reset: this means that both `state_aw_q` and `state_ar_q` are reset to the state `Isolate` on global reset, ensuring that no outgoing requests can be valid towards the SoC and the no SoC requests will be forwarded to the inner quadrant. Since the inner quadrant is still clock-gated, this should ensure a stable inner quadrant state and no AXI channel handshakes with the inner quadrant until it is ungated, ensuring the opportunity to reset the inner quadrant first.