### PR TITLE
riscv-dbg: Add patch with `read_dmi_exp_backoff` function

### DIFF
--- a/hw/vendor/patches/pulp_platform_riscv_dbg/0001-riscv-dbg-Add-read_dmi_exp_backoff-function.patch
+++ b/hw/vendor/patches/pulp_platform_riscv_dbg/0001-riscv-dbg-Add-read_dmi_exp_backoff-function.patch
@@ -1,0 +1,137 @@
+From f9a7b467a1b1606b72750ba9a69da5b987db8a56 Mon Sep 17 00:00:00 2001
+From: Luca Colagrande <luca.colagrande3@gmail.com>
+Date: Thu, 5 May 2022 12:19:46 +0200
+Subject: [PATCH] riscv-dbg: Add read_dmi_exp_backoff() function
+
+Provides a more robust alternative to read_dmi(), which does not rely
+on a fixed delay, but rather calls read_dmi() until the read is successful
+and automatically adjusts the delay with an exponential backoff scheme.
+---
+ src/dm_pkg.sv            |  7 ++++++
+ tb/jtag_dmi/jtag_test.sv | 47 +++++++++++++++++++++++++++++++++-------
+ 2 files changed, 46 insertions(+), 8 deletions(-)
+
+diff --git a/src/dm_pkg.sv b/src/dm_pkg.sv
+index 1c2b6195..dc9db2ac 100644
+--- a/src/dm_pkg.sv
++++ b/src/dm_pkg.sv
+@@ -197,6 +197,12 @@ package dm;
+     DTM_WRITE = 2'h2
+   } dtm_op_e;
+ 
++  typedef enum logic [1:0] {
++    DTM_OK   = 2'h0,
++    DTM_ERR  = 2'h2,
++    DTM_BUSY = 2'h3
++  } dtm_op_status_e;
++
+   typedef struct packed {
+     logic [31:29] sbversion;
+     logic [28:23] zero0;
+@@ -215,6 +221,7 @@ package dm;
+     logic         sbaccess8;
+   } sbcs_t;
+ 
++  // TODO: rename DTM_OK above to DTM_SUCCESS and remove this
+   localparam logic [1:0] DTM_SUCCESS = 2'h0;
+ 
+   typedef struct packed {
+diff --git a/tb/jtag_dmi/jtag_test.sv b/tb/jtag_dmi/jtag_test.sv
+index 60675a41..e6f97b51 100644
+--- a/tb/jtag_dmi/jtag_test.sv
++++ b/tb/jtag_dmi/jtag_test.sv
+@@ -87,15 +87,16 @@ package jtag_test;
+       jtag.tms <= #TA 0;
+     endtask
+ 
++    // Assumes JTAG FSM is already in shift DR state
+     task readwrite_bits(output logic rdata [$], input logic wdata [$], input logic tms_last);
+       for (int i = 0; i < wdata.size(); i++) begin
+         jtag.tdi <= #TA wdata[i];
+-        if (i == (wdata.size() - 1)) jtag.tms <= #TA tms_last;
++        if (i == (wdata.size() - 1)) jtag.tms <= #TA tms_last; // tms_last ? exit1 DR : shift DR
+         cycle_start();
+         rdata[i] = jtag.tdo;
+         cycle_end();
+       end
+-      jtag.tms <= #TA 0;
++      jtag.tms <= #TA 0; // tms_last ? pause DR : shift DR
+     endtask
+ 
+     task wait_idle(int cycles);
+@@ -181,6 +182,11 @@ package jtag_test;
+       data = dm::dtmcs_t'({<<{read_data}});
+     endtask
+ 
++    task reset_dmi();
++      logic [31:0] dmireset = 1 << 16;
++      write_dtmcs(dmireset);
++    endtask
++
+     task write_dmi(input dm::dm_csr_e address, input logic [31:0] data);
+       logic write_data [DMIWidth];
+       logic [DMIWidth-1:0] write_data_packed = {address, data, dm::DTM_WRITE};
+@@ -191,29 +197,54 @@ package jtag_test;
+       jtag.update_dr(1'b0);
+     endtask
+ 
+-    task read_dmi(input dm::dm_csr_e address, output logic [31:0] data, input int wait_cycles = 10);
++    task read_dmi(input dm::dm_csr_e address, output logic [31:0] data, input int wait_cycles = 10,
++                  output dm::dtm_op_status_e op);
+       logic read_data [DMIWidth], write_data [DMIWidth];
+       logic [DMIWidth-1:0] data_out = 0;
+       automatic logic [DMIWidth-1:0] write_data_packed = {address, 32'b0, dm::DTM_READ};
+       {<<{write_data}} = write_data_packed;
+       jtag.set_ir(DMIACCESS);
+-      jtag.shift_dr();
+       // send read command
++      jtag.shift_dr();
+       jtag.write_bits(write_data, 1'b1);
+       jtag.update_dr(1'b0);
+       jtag.wait_idle(wait_cycles);
+-      jtag.shift_dr();
+       // shift out read data
++      jtag.shift_dr();
+       write_data_packed = {address, 32'b0, dm::DTM_NOP};
+       {<<{write_data}} = write_data_packed;
+       jtag.readwrite_bits(read_data, write_data, 1'b1);
+-      // I am pretty sure this should be `update_dr` here.
+-      // jtag.update_dr(1'b0);
+-      jtag.shift_dr();
++      jtag.update_dr(1'b0);
+       data_out = {<<{read_data}};
++      op = dm::dtm_op_status_e'(data_out[1:0]);
+       data = data_out[33:2];
+     endtask
+ 
++    // Repeatedly read DMI until we get a valid response. 
++    // The delay between Update-DR and Capture-DR of
++    // successive operations is automatically adjusted through
++    // an exponential backoff scheme.
++    // Note: read operations which have side-effects (e.g.
++    // reading SBData0) should not use this
++    task read_dmi_exp_backoff(input dm::dm_csr_e address, output logic [31:0] data);
++      logic read_data [DMIWidth], write_data [DMIWidth];
++      logic [DMIWidth-1:0] write_data_packed;
++      logic [DMIWidth-1:0] data_out = 0;
++      dm::dtm_op_status_e op = dm::DTM_OK;
++      int trial_idx = 0;
++      int wait_cycles = 8;
++
++      do begin
++        if (trial_idx != 0) begin
++          // Not entered upon first iteration, resets the
++          // sticky error state if previous read was unsuccessful
++          reset_dmi();
++        end
++        read_dmi(address, data, wait_cycles, op);
++        wait_cycles *= 2;
++        trial_idx++;
++      end while (op == dm::DTM_BUSY);
++    endtask
+ 
+   endclass
+ endpackage
+-- 
+2.28.0
+

--- a/hw/vendor/pulp_platform_riscv_dbg/src/dm_pkg.sv
+++ b/hw/vendor/pulp_platform_riscv_dbg/src/dm_pkg.sv
@@ -197,6 +197,12 @@ package dm;
     DTM_WRITE = 2'h2
   } dtm_op_e;
 
+  typedef enum logic [1:0] {
+    DTM_OK   = 2'h0,
+    DTM_ERR  = 2'h2,
+    DTM_BUSY = 2'h3
+  } dtm_op_status_e;
+
   typedef struct packed {
     logic [31:29] sbversion;
     logic [28:23] zero0;
@@ -215,6 +221,7 @@ package dm;
     logic         sbaccess8;
   } sbcs_t;
 
+  // TODO: rename DTM_OK above to DTM_SUCCESS and remove this
   localparam logic [1:0] DTM_SUCCESS = 2'h0;
 
   typedef struct packed {


### PR DESCRIPTION
Provides a more robust alternative to read_dmi(), which does not rely
on a fixed delay, but rather calls read_dmi() until the read is successful
and automatically adjusts the delay with an exponential backoff scheme.