### PR TITLE
banshee: Improve error messages

### DIFF
--- a/sw/banshee/config/multi_cluster_periph.yaml
+++ b/sw/banshee/config/multi_cluster_periph.yaml
@@ -18,9 +18,9 @@ address:
   cl_clint: 0x40000060
 memory:
 - dram:
-    end: 0x80010000
+    end: 0x80020000
     latency: 10
-    start: 0x80000000
+    start: 0x80010000
   ext_tcdm: []
   periphs:
     callbacks:
@@ -36,9 +36,9 @@ memory:
     latency: 5
     start: 0x0
 - dram:
-    end: 0x80010000
+    end: 0x80020000
     latency: 10
-    start: 0x80000000
+    start: 0x80010000
   ext_tcdm:
   - cluster: 0
     start: 0x10000

--- a/sw/banshee/src/engine.rs
+++ b/sw/banshee/src/engine.rs
@@ -732,7 +732,17 @@ impl<'a, 'b> Cpu<'a, 'b> {
             {
                 0
             }
+            // DRAM
             _ => {
+                // Map all remaining addresses to the hash map but throw a warning if we read outside the memory map
+                if addr < self.engine.config.memory[self.cluster_id].dram.start
+                    || addr >= self.engine.config.memory[self.cluster_id].dram.end
+                {
+                    warn!(
+                        "Hart {} (pc=0x{:08x}) is reading outside the memory map at 0x{:08x}",
+                        self.hartid, self.state.pc, addr
+                    );
+                }
                 // trace!("Load 0x{:x} ({}B)", addr, 8 << size);
                 self.engine
                     .memory
@@ -881,7 +891,17 @@ impl<'a, 'b> Cpu<'a, 'b> {
                 self.cl_clint
                     .fetch_and(!(value & mask) as usize, Ordering::SeqCst);
             }
+            // DRAM
             _ => {
+                // Map all remaining addresses to the hash map but throw a warning if we write outside the memory map
+                if addr < self.engine.config.memory[self.cluster_id].dram.start
+                    || addr >= self.engine.config.memory[self.cluster_id].dram.end
+                {
+                    warn!(
+                        "Hart {} (pc=0x{:08x}) is writing outside the memory map at 0x{:08x}",
+                        self.hartid, self.state.pc, addr
+                    );
+                }
                 trace!(
                     "Store 0x{:x} = 0x{:x} if 0x{:x} ({}B)",
                     addr,

--- a/sw/banshee/src/tran.rs
+++ b/sw/banshee/src/tran.rs
@@ -1017,7 +1017,15 @@ impl<'a> InstructionTranslator<'a> {
             riscv::Format::Rs1Rs2(x) => self.emit_rs1_rs2(x),
             riscv::Format::RdRs2(x) => self.emit_rd_rs2(x),
             riscv::Format::Unit(x) => self.emit_unit(x),
-            _ => Err(anyhow!("Unsupported instruction format")),
+            _ => {
+                if self.inst.raw() == 0 {
+                    // Only generate a warning if the instruction is zero, as this usually comes from padding
+                    warn!("Zero instruction at 0x{:x}", self.addr);
+                    return Ok(());
+                } else {
+                    Err(anyhow!("Unsupported instruction format"))
+                }
+            }
         }
         .with_context(|| format!("Unsupported instruction 0x{:x}: {}", self.addr, self.inst))?;
 


### PR DESCRIPTION
This PR adds mainly two features:
- Create warnings when accessing memory that is not defined in the memory map of the config. This allows us to immediately see bugs in software related to the memory map.
- Do not emit an error if we have zeros in the text section. This usually happens because of padding and is not problematic at all.

All of this works nicely for MemPool. A few Banshee tests have accesses outside the memory map and create warnings now. It might be worth investigating them in the future as this hints that either Banshee is not configured correctly or missing a feature. I fixed the address map of the `multi_cluster_periph` config to match its tests. 

- `spmm_issr_frep`
- `multi_cluster`
- `dummy`