### PR TITLE
sw: Fix `fpu_fence`

### DIFF
--- a/sw/snRuntime/src/ssr.c
+++ b/sw/snRuntime/src/ssr.c
@@ -23,8 +23,9 @@ void snrt_ssr_disable() {
 
 /// Synchronize the integer and float pipelines.
 void snrt_fpu_fence() {
-  unsigned tmp;
-  asm volatile("fmv.x.w %0, fa0\n"
-               "mv      %0, %0"
-               : "+r"(tmp)::);
+    unsigned tmp;
+    asm volatile(
+        "fmv.x.w %0, fa0\n"
+        "mv      %0, %0"
+        : "+r"(tmp)::);
 }

--- a/sw/snRuntime/src/ssr.c
+++ b/sw/snRuntime/src/ssr.c
@@ -22,4 +22,9 @@ void snrt_ssr_disable() {
 }
 
 /// Synchronize the integer and float pipelines.
-void snrt_fpu_fence() { asm volatile("fmv.x.w zero, fa0"); }
+void snrt_fpu_fence() {
+  unsigned tmp;
+  asm volatile("fmv.x.w %0, fa0\n"
+               "mv      %0, %0"
+               : "+r"(tmp)::);
+}


### PR DESCRIPTION
The previous FPU fence did not synchronize the integer and the FPU lane correctly. The single `fmv.x.w` instruction placed the integer register in the scoreboard but doesn't prevent integer instructions that don't use this register from being executed. Adding an additional integer `mv` instruction on this register should solve the problem.