### PR TITLE
test: Add pipe-based IPC control interface to `tb_bin`

### DIFF
--- a/hw/ip/test/src/SnitchSim.py
+++ b/hw/ip/test/src/SnitchSim.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: SHL-0.51
 #
 # Paul Scheffler <paulsc@iis.ee.ethz.ch>
+#
+# This class implements a minimal wrapping IPC server for `tb_lib`.
+# `__main__` shows a demonstrator for it, running a simulation and accessing its memory.
 
 import os
 import sys
@@ -80,7 +83,7 @@ if __name__ == "__main__":
     sim = SnitchSim(*sys.argv[1:])
     sim.start()
 
-    wstr = b'I am a string! Look at me!'
+    wstr = b'This is a test string to be written to testbench memory.'
     sim.write(0xdeadbeef, wstr)
     rstr = sim.read(0xdeadbeef, len(wstr)+5)
     print(f'Read back string: `{rstr}`')

--- a/hw/ip/test/src/ipc.hh
+++ b/hw/ip/test/src/ipc.hh
@@ -1,0 +1,143 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <pthread.h>
+#include <algorithm>
+#include <time.h>
+
+#include <tb_lib.hh>
+
+class IpcIface {
+
+private:
+
+    static const int IPC_BUF_SIZE = 4096;
+    static const int IPC_BUF_SIZE_STRB = IPC_BUF_SIZE/8+1;
+    static const int IPC_ERR_DOUBLE_ARG = 30;
+    static const long IPC_POLL_PERIOD_NS = 100000L;
+
+    // Possible IPC operations
+    enum ipc_opcode_e {
+        Read = 0,
+        Write = 1,
+        Poll = 2,
+    };
+
+    // Operations are 3 doubles, followed by data streams in either direction
+    typedef struct {
+        uint64_t opcode;
+        uint64_t addr;
+        uint64_t len;
+    } ipc_op_t;
+
+    // Args passed to IPC thread
+    typedef struct {
+        char * tx;
+        char * rx;
+    } ipc_targs_t;
+
+    // Thread to asynchronously handle FIFOs
+    ipc_targs_t targs;
+    pthread_t thread;
+    bool active;
+
+    static void *ipc_thread_handle(void* in) {
+        ipc_targs_t* targs = (ipc_targs_t*) in;
+        // Open FIFOs
+        FILE * tx = fopen(targs->tx, "rb");
+        FILE * rx = fopen(targs->rx, "wb");
+        // Prepare data and full-strobe array
+        uint8_t buf_data [IPC_BUF_SIZE] ;
+        uint8_t buf_strb [IPC_BUF_SIZE_STRB];
+        std::fill_n(buf_strb, IPC_BUF_SIZE_STRB, 0xFF);
+        // Handle commands
+        ipc_op_t op;
+        while (fread(&op, sizeof(ipc_op_t), 1, tx)) {
+            switch (op.opcode) {
+                case Read:
+                    // Read full blocks until one full block or less left
+                    printf("[IPC] Read from 0x%x len %d ...\n", op.addr, op.len);
+                    for (uint64_t i = op.len; i > IPC_BUF_SIZE; i -= IPC_BUF_SIZE) {
+                        sim::MEM.read(op.addr, IPC_BUF_SIZE, buf_data);
+                        fwrite(buf_data, IPC_BUF_SIZE, 1, rx);
+                    }
+                    sim::MEM.read(op.addr, op.len, buf_data);
+                    fwrite(buf_data, op.len, 1, rx);
+                    fflush(rx);
+                    break;
+                case Write:
+                    // Write full blocks until one full block or less left
+                    printf("[IPC] Write to 0x%x len %d ...\n", op.addr, op.len);
+                    for (uint64_t i = op.len; i > IPC_BUF_SIZE; i -= IPC_BUF_SIZE) {
+                        fread(buf_data, IPC_BUF_SIZE, 1, tx);
+                        sim::MEM.write(op.addr, IPC_BUF_SIZE, buf_data, buf_strb);
+                    }
+                    fread(buf_data, op.len, 1, tx);
+                    sim::MEM.write(op.addr, op.len, buf_data, buf_strb);
+                    break;
+                case Poll:
+                    // Unpack 32b checking mask and expected value from length
+                    uint32_t mask = op.len & 0xFFFFFFFF;
+                    uint32_t expected = (op.len >> 32) & 0xFFFFFFFF;
+                    printf("[IPC] Poll on 0x%x mask 0x%x expected 0x%x ...\n", op.addr, mask, expected);
+                    uint32_t read;
+                    do {
+                        sim::MEM.read(op.addr, sizeof(uint32_t), (uint8_t*)(void*) &read);
+                        nanosleep((const struct timespec[]){{0, IPC_POLL_PERIOD_NS}}, NULL);
+                    } while (read & mask == expected & mask);
+                    // Send back read 32b word
+                    fwrite(&read, sizeof(uint32_t), 1, rx);
+                    break;
+            }
+            printf("[IPC] ... done\n");
+        }
+        // TX FIFO closed at other end: close both FIFOs and join main thread
+        fclose(tx);
+        fclose(rx);
+        pthread_exit(NULL);
+    }
+
+public:
+
+    // Conditionally construct IPC iff any arguments specify it
+    IpcIface(int argc, char** argv) {
+        static constexpr char IPC_FLAG[6] = "--ipc";
+        active = false;
+        for (auto i = 1; i < argc; ++i) {
+            if (strncmp(argv[i], IPC_FLAG, strlen(IPC_FLAG)) == 0) {
+                // Check for duplicate args
+                if (active) {
+                    fprintf(stderr, "[IPC] Duplicate IPC thread args: %s", argv[i]);
+                    exit(IPC_ERR_DOUBLE_ARG);
+                }
+                // Parse IPC thread arguments
+                char * ipc_args = argv[i] + strlen(IPC_FLAG) + 1;
+                targs.tx = strtok(ipc_args, ",");
+                targs.rx = strtok(NULL, ",");
+                // Initialize IO thread which will handle TX, RX pipes
+                pthread_create(&thread, NULL, *ipc_thread_handle, (void *) &targs);
+                printf("[IPC] Thread launched with TX FIFO `%s`, RX FIFO `%s`\n", targs.tx, targs.rx);
+                active = true;
+            }
+        }
+    }
+
+    // Conditionally destroy IPC iff it is enabled
+    ~IpcIface() {
+        if (active) {
+            pthread_join(thread, NULL);
+            printf("[IPC] Thread joined\n");
+            active = false;
+        }
+    }
+
+};

--- a/hw/ip/test/src/ipc.hh
+++ b/hw/ip/test/src/ipc.hh
@@ -96,6 +96,7 @@ private:
                     } while (read & mask == expected & mask);
                     // Send back read 32b word
                     fwrite(&read, sizeof(uint32_t), 1, rx);
+                    fflush(rx);
                     break;
             }
             printf("[IPC] ... done\n");

--- a/hw/ip/test/src/tb_bin.cc
+++ b/hw/ip/test/src/tb_bin.cc
@@ -5,6 +5,7 @@
 #include <printf.h>
 
 #include "sim.hh"
+#include "ipc.hh"
 
 int main(int argc, char **argv, char **env) {
     // Write binary path to logs/binary for the `make annotate` target
@@ -17,6 +18,9 @@ int main(int argc, char **argv, char **env) {
         fprintf(stderr,
                 "Warning: Failed to write binary name to logs/.rtlbinary\n");
     }
+
+    // Initialize IPC bridge if specified
+    IpcIface ipc_iface(argc, argv);
 
     auto sim = std::make_unique<sim::Sim>(argc, argv);
     return sim->run();

--- a/hw/ip/test/src/tb_bin.cc
+++ b/hw/ip/test/src/tb_bin.cc
@@ -4,8 +4,8 @@
 
 #include <printf.h>
 
-#include "sim.hh"
 #include "ipc.hh"
+#include "sim.hh"
 
 int main(int argc, char **argv, char **env) {
     // Write binary path to logs/binary for the `make annotate` target

--- a/hw/system/snitch_cluster/SnitchSim.py
+++ b/hw/system/snitch_cluster/SnitchSim.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright 2020 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+import os
+import sys
+import tempfile
+import subprocess
+import struct
+import array
+import threading
+
+
+class SnitchSim:
+
+    def __init__(self, sim_bin: str, snitch_bin: str):
+        self.sim_bin = sim_bin
+        self.snitch_bin = snitch_bin
+        self.sim = None
+        self.tmpdir = None
+
+    def start(self):
+        # Make sure we clean up after ourselves
+        self.tmpdir = tempfile.TemporaryDirectory()
+        # Create FIFOs
+        tx_fd = os.path.join(self.tmpdir.name, 'tx')
+        os.mkfifo(tx_fd)
+        rx_fd = os.path.join(self.tmpdir.name, 'rx')
+        os.mkfifo(rx_fd)
+        # Start simulator process
+        ipc_arg = f'--ipc,{tx_fd},{rx_fd}'
+        self.sim = subprocess.Popen([self.sim_bin, self.snitch_bin, ipc_arg])
+        # Open FIFOs
+        self.tx = open(tx_fd, 'wb', 0)
+        self.rx = open(rx_fd, 'rb', 0)
+
+    def __sim_active(func):
+        def inner(self, *args, **kwargs):
+            if self.sim is None:
+                raise RuntimeError(f'Snitch is not running (simulation `{self.sim_bin}`, binary `{self.snitch_bin}`)')
+            return func(self, *args, **kwargs)
+        return inner
+
+    @__sim_active
+    def read(self, addr: int, length: int) -> bytes:
+        op = struct.pack('QQQ', 0, addr, length)
+        self.tx.write(op)
+        return self.rx.read(length)
+
+    @__sim_active
+    def write(self, addr: int, data: bytes):
+        op = struct.pack('QQQ', 1, addr, len(data))
+        self.tx.write(op)
+        self.tx.write(data)
+
+    @__sim_active
+    def poll(self, addr: int, mask32: int, exp32: int):
+        # TODO: check endiannesses
+        op = struct.pack('QQLL', 2, addr, mask32, exp32)
+        self.tx.write(op)
+        return int.from_bytes(self.rx.read(4))
+
+    # Simulator can exit only once TX FIFO closes
+    @__sim_active
+    def finish(self, wait_for_sim: bool = True):
+        self.rx.close()
+        self.tx.close()
+        if (wait_for_sim):
+            self.sim.wait()
+        else:
+            self.sim.terminate()
+        self.tmpdir.cleanup()
+        self.sim = None
+
+
+if __name__ == "__main__":
+    sim = SnitchSim(*sys.argv[1:])
+    sim.start()
+
+    wstr = b'I am a string! Look at me!'
+    sim.write(0xdeadbeef, wstr)
+    rstr = sim.read(0xdeadbeef, len(wstr)+5)
+    print(rstr)
+
+    sim.finish(wait_for_sim=False)


### PR DESCRIPTION
Adds an optional pipe-based IPC interface to `tb_bin`-based simulator binaries, as well as a Python class exemplifying how to use it. For now, this interface can read from, write to, and/or poll on the simulated memory, but this can be further extended.