### PR TITLE
Add DRAM preloading in banshee

### DIFF
--- a/sw/banshee/Cargo.toml
+++ b/sw/banshee/Cargo.toml
@@ -12,19 +12,27 @@ build = "build/build.rs"
 
 [dependencies]
 anyhow = "1"
-byteorder = "1.3"
+binread = "2.2.0"
+bytebuffer = "0.2.1"
+byteorder = "1.4.3"
 clap = "2"
 crossbeam-utils = "0.8"
+csv = "1.0.0-beta.2"
 elf = "0.0.10"
+flexfloat = { path = "flexfloat" }
 itertools = "0.9"
 llvm-sys = "120"
 log = { version = "0.4", features = ["release_max_level_info"] }
+pest = "2.1.3"
+pest_derive = "2.1.0"
 pretty_env_logger = "0.4"
+rev_slice = "0.1.5"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.63"
 serde_yaml = "0.8"
 termion = "*"
-flexfloat = { path = "flexfloat" }
+thiserror = "1.0.21"
+to-binary = "0.4.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/sw/banshee/src/dram_preload.rs
+++ b/sw/banshee/src/dram_preload.rs
@@ -1,3 +1,7 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 use bytebuffer::ByteBuffer;
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 use std::{

--- a/sw/banshee/src/dram_preload.rs
+++ b/sw/banshee/src/dram_preload.rs
@@ -21,7 +21,10 @@ use std::{
 };
 use to_binary::{BinaryError, BinaryString};
 
-pub fn bin_read(bin_path: &str, mut offset: u64) -> Result<HashMap<u64, u32>, Box<dyn Error>> {
+pub fn generic_bin_read<const N: usize>(
+    bin_path: &str,
+    mut offset: u64,
+) -> Result<HashMap<u64, u32>, Box<dyn Error>> {
     // we will return a HashMap of addresses to values
     // which we use to extend the DRAM
     let mut result = HashMap::<u64, u32>::new();
@@ -31,47 +34,7 @@ pub fn bin_read(bin_path: &str, mut offset: u64) -> Result<HashMap<u64, u32>, Bo
 
     // we define the buffer in which we read in single values
     // we always have to read in 32 bits into memory for the DRAM
-    let mut exact_buf = [0u8; 4];
-
-    loop {
-        if let Err(e) = bin_buf.read_exact(&mut exact_buf) {
-            if e.kind() == ErrorKind::UnexpectedEof {
-                break;
-            } else {
-                panic!("Error reading file: {}", e);
-            }
-
-            return Err(e.into());
-        }
-
-        // we convert the buffer into a u32
-        let mut bit_buffer: &[u8] = &exact_buf;
-        let u32_value = bit_buffer.read_u32::<LittleEndian>().unwrap();
-        trace!("u32_value: {:#034b}", u32_value);
-
-        // we add the address to the HashMap
-        result.insert(offset, u32_value);
-        // and increment the offset by the word width
-        offset += 4;
-    }
-
-    // return the result
-    Ok(result)
-}
-
-pub fn bin_u32_read(bin_path: &str, mut offset: u64) -> Result<HashMap<u64, u32>, Box<dyn Error>> {
-    // we will return a HashMap of addresses to values
-    // which we use to extend the DRAM
-    let mut result = HashMap::<u64, u32>::new();
-
-    // we read in the binary data from the file into a buffer
-    let mut bin_buf = BufReader::new(File::open(bin_path).unwrap());
-
-    // trace!("bin_read: bin_path = {}", bin_path);
-
-    // we define the buffer in which we read in single values
-    // we always have to read in 32 bits into memory for the DRAM
-    let mut exact_buf = [0u8; 8];
+    let mut exact_buf = [0u8; N];
 
     loop {
         if let Err(e) = bin_buf.read_exact(&mut exact_buf) {

--- a/sw/banshee/src/dram_preload.rs
+++ b/sw/banshee/src/dram_preload.rs
@@ -1,0 +1,96 @@
+use bytebuffer::ByteBuffer;
+use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
+use std::{
+    collections::HashMap,
+    env,
+    error::Error,
+    fs,
+    fs::File,
+    io::prelude::*,
+    io::{BufReader, ErrorKind, Read, Seek, SeekFrom, Write},
+    process,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
+        Mutex,
+    },
+};
+use to_binary::{BinaryError, BinaryString};
+
+pub fn bin_read(bin_path: &str, mut offset: u64) -> Result<HashMap<u64, u32>, Box<dyn Error>> {
+    // we will return a HashMap of addresses to values
+    // which we use to extend the DRAM
+    let mut result = HashMap::<u64, u32>::new();
+
+    // we read in the binary data from the file into a buffer
+    let mut bin_buf = BufReader::new(File::open(bin_path).unwrap());
+
+    // we define the buffer in which we read in single values
+    // we always have to read in 32 bits into memory for the DRAM
+    let mut exact_buf = [0u8; 4];
+
+    loop {
+        if let Err(e) = bin_buf.read_exact(&mut exact_buf) {
+            if e.kind() == ErrorKind::UnexpectedEof {
+                break;
+            } else {
+                panic!("Error reading file: {}", e);
+            }
+
+            return Err(e.into());
+        }
+
+        // we convert the buffer into a u32
+        let mut bit_buffer: &[u8] = &exact_buf;
+        let u32_value = bit_buffer.read_u32::<LittleEndian>().unwrap();
+        trace!("u32_value: {:#034b}", u32_value);
+
+        // we add the address to the HashMap
+        result.insert(offset, u32_value);
+        // and increment the offset by the word width
+        offset += 4;
+    }
+
+    // return the result
+    Ok(result)
+}
+
+pub fn bin_u32_read(bin_path: &str, mut offset: u64) -> Result<HashMap<u64, u32>, Box<dyn Error>> {
+    // we will return a HashMap of addresses to values
+    // which we use to extend the DRAM
+    let mut result = HashMap::<u64, u32>::new();
+
+    // we read in the binary data from the file into a buffer
+    let mut bin_buf = BufReader::new(File::open(bin_path).unwrap());
+
+    // trace!("bin_read: bin_path = {}", bin_path);
+
+    // we define the buffer in which we read in single values
+    // we always have to read in 32 bits into memory for the DRAM
+    let mut exact_buf = [0u8; 8];
+
+    loop {
+        if let Err(e) = bin_buf.read_exact(&mut exact_buf) {
+            if e.kind() == ErrorKind::UnexpectedEof {
+                break;
+            } else {
+                panic!("Error reading file: {}", e);
+            }
+
+            return Err(e.into());
+        }
+
+        // we convert the buffer into a u32
+        let mut bit_buffer: &[u8] = &exact_buf;
+        let u32_value = bit_buffer.read_u32::<LittleEndian>().unwrap();
+        trace!("u32_value: {:#034b}", u32_value);
+
+        // we add the address to the HashMap
+        result.insert(offset, u32_value);
+        // and increment the offset by the word width
+        offset += 4;
+    }
+
+    // return the result
+    Ok(result)
+}

--- a/sw/banshee/src/main.rs
+++ b/sw/banshee/src/main.rs
@@ -308,7 +308,7 @@ fn main() -> Result<()> {
 
         trace!("Train data starts at address: 0x{:x}", mem_offset);
 
-        let train_data = dram_preload::bin_read(bin_path, mem_offset).unwrap();
+        let train_data = dram_preload::generic_bin_read::<4>(bin_path, mem_offset).unwrap();
 
         let train_data_length = train_data.len() as u64;
 
@@ -333,7 +333,7 @@ fn main() -> Result<()> {
         // turn the string into a u64
         let mut mem_offset = u64::from_str_radix(memory_offset, 16).unwrap();
         trace!("Train labels starts at address: 0x{:x}", mem_offset);
-        let train_labels = dram_preload::bin_u32_read(bin_path, mem_offset).unwrap();
+        let train_labels = dram_preload::generic_bin_read::<8>(bin_path, mem_offset).unwrap();
         let train_labels_length = train_labels.len() as u64;
         let mut mem = engine.memory.lock().unwrap();
         mem.extend(train_labels);

--- a/sw/banshee/src/main.rs
+++ b/sw/banshee/src/main.rs
@@ -16,16 +16,8 @@ use llvm_sys::{
 };
 
 use std::{
-    collections::HashMap,
-    ffi::CString,
-    fs,
-    fs::File,
-    io::prelude::*,
-    num::ParseIntError,
-    os::raw::c_int,
-    path::Path,
-    ptr::null_mut,
-    str::FromStr,
+    collections::HashMap, ffi::CString, fs, fs::File, io::prelude::*, num::ParseIntError,
+    os::raw::c_int, path::Path, ptr::null_mut, str::FromStr,
 };
 
 pub mod bootroms;

--- a/sw/banshee/src/main.rs
+++ b/sw/banshee/src/main.rs
@@ -21,7 +21,6 @@ use std::{
     fs,
     fs::File,
     io::prelude::*,
-    io::{BufReader, ErrorKind, Read, Seek, SeekFrom, Write},
     num::ParseIntError,
     os::raw::c_int,
     path::Path,
@@ -41,13 +40,9 @@ pub mod tran;
 pub mod util;
 
 use crate::configuration::*;
-use crate::dram_preload::*;
 use crate::engine::*;
-use crate::readmem::{readmem, ContentType};
 
-use bytebuffer::ByteBuffer;
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
-use to_binary::{BinaryError, BinaryString};
 
 fn main() -> Result<()> {
     // Parse the command line arguments.

--- a/sw/banshee/src/main.rs
+++ b/sw/banshee/src/main.rs
@@ -306,26 +306,32 @@ fn main() -> Result<()> {
 
         // loop through the files and offsets
         for (file_path, mem_offset) in file_paths.zip(mem_offsets) {
-            trace!("Loading binary data from file: {} and storing at memory offset: {}", file_path, mem_offset);
-            debug!("Loading binary data from file: {} and storing at memory offset: {}", file_path, mem_offset);
+            trace!(
+                "Loading binary data from file: {} and storing at memory offset: {}",
+                file_path,
+                mem_offset
+            );
+            debug!(
+                "Loading binary data from file: {} and storing at memory offset: {}",
+                file_path, mem_offset
+            );
             // get memory offset from argument
             let mut memory_offset = mem_offset.trim_start_matches("0x");
             // turn the string into a u64
             let mut mem_offset = u64::from_str_radix(memory_offset, 16).unwrap();
 
             let data = dram_preload::generic_bin_read::<4>(file_path, mem_offset).unwrap();
-                
+
             let data_length = data.len() as u64;
 
             let mut mem = engine.memory.lock().unwrap();
-            
+
             mem.extend(data);
             for addr in mem_offset..mem_offset + data_length {
-                let val:u32 = mem.get(&(addr)).copied().unwrap_or(0);
+                let val: u32 = mem.get(&(addr)).copied().unwrap_or(0);
                 trace!("address = 0x{:x}, binary value = {:#034b}", addr, val);
             }
         }
-
     }
     // Write the module to disk if requested.
     if let Some(path) = matches.value_of("emit-llvm") {

--- a/sw/banshee/src/main.rs
+++ b/sw/banshee/src/main.rs
@@ -333,7 +333,6 @@ fn main() -> Result<()> {
         // turn the string into a u64
         let mut mem_offset = u64::from_str_radix(memory_offset, 16).unwrap();
         trace!("Train labels starts at address: 0x{:x}", mem_offset);
-        let dtype = "U32";
         let train_labels = dram_preload::bin_u32_read(bin_path, mem_offset).unwrap();
         let train_labels_length = train_labels.len() as u64;
         let mut mem = engine.memory.lock().unwrap();


### PR DESCRIPTION
Add these flags to the banshee arguments: 

1. `--file-paths=<path-to-binaries>`  
2. `--mem-offsets=<memory-offsets>` 

The file paths are the paths to your dataset data, which should be in binary format. If you have multiple data files you can separate them by commas. In order to save them at a specific location of the main memory make sure you enter a start address (`mem_offset`) for every binary file. As before, it can be a comma-separated list. The user has to be aware of the memory layout and make sure that the offsets are big enough so that data does not get overwritten. There is currently no warnings supported if memory gets overwritten in DRAM. 
