### PR TITLE
hw: Fix Bender header dependencies

### DIFF
--- a/hw/ip/mem_interface/Bender.yml
+++ b/hw/ip/mem_interface/Bender.yml
@@ -8,6 +8,7 @@ package:
 
 dependencies:
   reqrsp_interface: {path: ../reqrsp_interface}
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
 
 export_include_dirs:
 - include

--- a/hw/ip/tcdm_interface/Bender.yml
+++ b/hw/ip/tcdm_interface/Bender.yml
@@ -7,6 +7,7 @@ package:
   - Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 
 dependencies:
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
   reqrsp_interface: {path: ../reqrsp_interface}
 
 export_include_dirs:

--- a/hw/ip/test/Bender.yml
+++ b/hw/ip/test/Bender.yml
@@ -11,6 +11,8 @@ dependencies:
   axi: {path: ../../vendor/pulp_platform_axi}
   reqrsp_interface: {path: ../reqrsp_interface}
   axi_riscv_atomics: {path: ../../vendor/pulp_platform_axi_riscv_atomics}
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
+  register_interface: {path: ../../vendor/pulp_platform_register_interface}
 
 sources:
 # Level 1:

--- a/hw/system/occamy/Bender.yml
+++ b/hw/system/occamy/Bender.yml
@@ -22,6 +22,8 @@ dependencies:
   apb: {path: ../../vendor/pulp_platform_apb}
   apb_timer: {path: ../../vendor/pulp_platform_apb_timer}
   axi: {path: ../../vendor/pulp_platform_axi}
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
+  register_interface: {path: ../../vendor/pulp_platform_register_interface}
 
 sources:
 # Level 0:

--- a/hw/system/occamy/Bender.yml
+++ b/hw/system/occamy/Bender.yml
@@ -10,8 +10,8 @@ package:
 dependencies:
   # axi_riscv_atomics: {path: ../../vendor/pulp_platform_axi_riscv_atomics}
   snitch_read_only_cache: {path: ../../ip/snitch_read_only_cache}
-  snitch-cluster: {path: ../../ip/snitch_cluster}
-  spm-interface: {path: ../../ip/spm_interface}
+  snitch_cluster: {path: ../../ip/snitch_cluster}
+  spm_interface: {path: ../../ip/spm_interface}
   cva6: {path: ../../vendor/openhwgroup_cva6}
   apb_uart: {path: ../../vendor/pulp_platform_apb_uart}
   lowrisc_rv_plic: {path: ../../vendor/lowrisc_opentitan/rv_plic}
@@ -20,7 +20,8 @@ dependencies:
   lowrisc_i2c: {path: ../../vendor/lowrisc_opentitan/i2c}
   test: {path: ../../ip/test}
   apb: {path: ../../vendor/pulp_platform_apb}
-  timer: {path: ../../vendor/pulp_platform_apb_timer}
+  apb_timer: {path: ../../vendor/pulp_platform_apb_timer}
+  axi: {path: ../../vendor/pulp_platform_axi}
 
 sources:
 # Level 0:

--- a/hw/system/snitch_cluster/Bender.yml
+++ b/hw/system/snitch_cluster/Bender.yml
@@ -9,7 +9,8 @@ package:
   - Thomas Benz <tbenz@iis.ee.ethz.ch>
 
 dependencies:
-  snitch-cluster: {path: ../../ip/snitch_cluster}
+  snitch_cluster: {path: ../../ip/snitch_cluster}
+  axi: {path: ../../vendor/pulp_platform_axi}
   test: {path: ../../ip/test}
 
 sources:

--- a/hw/vendor/lowrisc_opentitan/gpio/Bender.yml
+++ b/hw/vendor/lowrisc_opentitan/gpio/Bender.yml
@@ -5,6 +5,7 @@ package:
 
 dependencies:
   lowrisc_prim: {path: ../prim}
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
 
 sources:
 # Level 0

--- a/hw/vendor/lowrisc_opentitan/i2c/Bender.yml
+++ b/hw/vendor/lowrisc_opentitan/i2c/Bender.yml
@@ -5,6 +5,7 @@ package:
 
 dependencies:
   lowrisc_prim: {path: ../prim}
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
 
 sources:
 - rtl/i2c_reg_pkg.sv

--- a/hw/vendor/lowrisc_opentitan/rv_plic/Bender.yml
+++ b/hw/vendor/lowrisc_opentitan/rv_plic/Bender.yml
@@ -5,6 +5,7 @@ package:
 
 dependencies:
   lowrisc_prim: {path: ../prim}
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
 
 sources:
 - rtl/rv_plic_gateway.sv

--- a/hw/vendor/lowrisc_opentitan/spi_host/Bender.yml
+++ b/hw/vendor/lowrisc_opentitan/spi_host/Bender.yml
@@ -5,6 +5,7 @@ package:
 
 dependencies:
   lowrisc_prim: {path: ../prim}
+  common_cells: {path: ../../vendor/pulp_platform_common_cells}
 
 sources:
 # Level 0:

--- a/hw/vendor/patches/lowrisc_opentitan/gpio/0002-vendor-Correct-opentitan-peripheral-Bender-dependenc.patch
+++ b/hw/vendor/patches/lowrisc_opentitan/gpio/0002-vendor-Correct-opentitan-peripheral-Bender-dependenc.patch
@@ -1,0 +1,24 @@
+From a917298be836990354b467e432436b755af5808f Mon Sep 17 00:00:00 2001
+From: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+Date: Tue, 16 Aug 2022 19:09:47 +0200
+Subject: [PATCH] vendor: Correct opentitan peripheral Bender dependencies
+
+---
+ Bender.yml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Bender.yml b/Bender.yml
+index dcac4ae..fd3508f 100644
+--- a/Bender.yml
++++ b/Bender.yml
+@@ -5,6 +5,7 @@ package:
+ 
+ dependencies:
+   lowrisc_prim: {path: ../prim}
++  common_cells: {path: ../../vendor/pulp_platform_common_cells}
+ 
+ sources:
+ # Level 0
+-- 
+2.16.5
+

--- a/hw/vendor/patches/lowrisc_opentitan/i2c/0002-vendor-Correct-opentitan-peripheral-Bender-dependenc.patch
+++ b/hw/vendor/patches/lowrisc_opentitan/i2c/0002-vendor-Correct-opentitan-peripheral-Bender-dependenc.patch
@@ -1,0 +1,24 @@
+From a917298be836990354b467e432436b755af5808f Mon Sep 17 00:00:00 2001
+From: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+Date: Tue, 16 Aug 2022 19:09:47 +0200
+Subject: [PATCH] vendor: Correct opentitan peripheral Bender dependencies
+
+---
+ Bender.yml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Bender.yml b/Bender.yml
+index 0bbeedb..99cfe60 100644
+--- a/Bender.yml
++++ b/Bender.yml
+@@ -5,6 +5,7 @@ package:
+ 
+ dependencies:
+   lowrisc_prim: {path: ../prim}
++  common_cells: {path: ../../vendor/pulp_platform_common_cells}
+ 
+ sources:
+ - rtl/i2c_reg_pkg.sv
+-- 
+2.16.5
+

--- a/hw/vendor/patches/lowrisc_opentitan/rv_plic/0002-vendor-Correct-opentitan-peripheral-Bender-dependenc.patch
+++ b/hw/vendor/patches/lowrisc_opentitan/rv_plic/0002-vendor-Correct-opentitan-peripheral-Bender-dependenc.patch
@@ -1,0 +1,24 @@
+From a917298be836990354b467e432436b755af5808f Mon Sep 17 00:00:00 2001
+From: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+Date: Tue, 16 Aug 2022 19:09:47 +0200
+Subject: [PATCH] vendor: Correct opentitan peripheral Bender dependencies
+
+---
+ Bender.yml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Bender.yml b/Bender.yml
+index fc2a332..b621f0d 100644
+--- a/Bender.yml
++++ b/Bender.yml
+@@ -5,6 +5,7 @@ package:
+ 
+ dependencies:
+   lowrisc_prim: {path: ../prim}
++  common_cells: {path: ../../vendor/pulp_platform_common_cells}
+ 
+ sources:
+ - rtl/rv_plic_gateway.sv
+-- 
+2.16.5
+

--- a/hw/vendor/patches/lowrisc_opentitan/spi_host/0005-vendor-Correct-opentitan-peripheral-Bender-dependenc.patch
+++ b/hw/vendor/patches/lowrisc_opentitan/spi_host/0005-vendor-Correct-opentitan-peripheral-Bender-dependenc.patch
@@ -1,0 +1,24 @@
+From a917298be836990354b467e432436b755af5808f Mon Sep 17 00:00:00 2001
+From: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+Date: Tue, 16 Aug 2022 19:09:47 +0200
+Subject: [PATCH] vendor: Correct opentitan peripheral Bender dependencies
+
+---
+ Bender.yml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Bender.yml b/Bender.yml
+index d92995b..de7abe5 100644
+--- a/Bender.yml
++++ b/Bender.yml
+@@ -5,6 +5,7 @@ package:
+ 
+ dependencies:
+   lowrisc_prim: {path: ../prim}
++  common_cells: {path: ../../vendor/pulp_platform_common_cells}
+ 
+ sources:
+ # Level 0:
+-- 
+2.16.5
+


### PR DESCRIPTION
Fix #326 by adding header dependencies in Bender manifests wherever they were missing. 

Also fix some Bender name mismatch warnings in the process.