### PR TITLE
banshee: Disable opaque pointers in JIT code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         - stable
         - beta
         - nightly
-        - 1.56.1   # minimum supported version
+        - 1.65.0   # minimum supported version
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         - stable
         - beta
         - nightly
-        - 1.65.0   # minimum supported version
+        - 1.63.0   # minimum supported version
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/sw/banshee/build/runtime.rs
+++ b/sw/banshee/build/runtime.rs
@@ -23,6 +23,7 @@ pub fn build() {
             "-Copt-level=3",
             "-Cdebuginfo=0",
             "-Cpanic=abort",
+            "-Cllvm-args=-opaque-pointers=0",
         ])
         .status()
         .unwrap();

--- a/sw/banshee/flexfloat/src/lib.rs
+++ b/sw/banshee/flexfloat/src/lib.rs
@@ -222,7 +222,7 @@ pub unsafe fn ff_instruction_cvt_from_b(
 
     let rd = match op {
         FfOpCvt::Fcvtf2w => double_to_int((*ff_a8).value),
-        FfOpCvt::Fcvtf2wu => (double_to_uint((*ff_a8).value) as i32),
+        FfOpCvt::Fcvtf2wu => double_to_uint((*ff_a8).value) as i32,
         _ => 0,
     };
 
@@ -312,7 +312,7 @@ pub unsafe fn ff_instruction_cvt_from_h(
     let rd = match op {
         // FfOpCvt::Fmvf2x   => ff_cast(ff_res, ff_a, env_dst),
         FfOpCvt::Fcvtf2w => double_to_int((*ff_a16).value),
-        FfOpCvt::Fcvtf2wu => (double_to_uint((*ff_a16).value) as i32),
+        FfOpCvt::Fcvtf2wu => double_to_uint((*ff_a16).value) as i32,
         _ => 0,
     };
 


### PR DESCRIPTION
The nightly version of Rust seems to enable opaque pointers per default. However, our current `llvm-sys` setup does not yet support those types. Since we need to fuse the IR generated by the Rust compiler with our own, generated with llvm-sys, we have to disable opaque pointers for the Rust compiler manually.

Simultaneously this fixes two minor style warnings.