### PR TITLE
fpga: Change `ariane-sdk` to `cva6-sdk`

### DIFF
--- a/hw/system/occamy/fpga/Makefile
+++ b/hw/system/occamy/fpga/Makefile
@@ -7,7 +7,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MKFILE_DIR  := $(dir $(MKFILE_PATH))
 ROOT        := ${MKFILE_DIR}../../../..
-ARIANE_SDK  ?= ${ROOT}/../ariane-sdk
+CVA6_SDK    ?= ${ROOT}/../cva6-sdk
 DEBUG       ?= 0
 VCU         ?= 01
 FPGA_ID     := 091847100576A
@@ -41,10 +41,10 @@ flash: ${FILE}
 	rm data.mcs
 
 flash-u-boot:
-	${MAKE} flash FILE=${ARIANE_SDK}/u-boot/u-boot.itb OFFSET=0x6000000
+	${MAKE} flash FILE=${CVA6_SDK}/u-boot/u-boot.itb OFFSET=0x6000000
 
 flash-uimage:
-	${MAKE} flash FILE=${ARIANE_SDK}/uImage OFFSET=0x6100000
+	${MAKE} flash FILE=${CVA6_SDK}/uImage OFFSET=0x6100000
 
 clean:
 	${MAKE} -C vivado_ips clean

--- a/hw/system/occamy/fpga/README.md
+++ b/hw/system/occamy/fpga/README.md
@@ -52,11 +52,11 @@ This is the current boot flow for Linux on Occamy:
 
 ### Compiling Linux and U-Boot
 
-First, we need to compile the required SW binaries and images, including Linux, OpenSBI and U-Boot. For that, navigate to a suitable location, clone and build the `occamy` branch of [Ariane SDK](https://github.com/pulp-platform/ariane-sdk/tree/occamy) as follows:
+First, we need to compile the required SW binaries and images, including Linux, OpenSBI and U-Boot. For that, navigate to a suitable location, clone and build the `occamy` branch of [CVA6 SDK](https://github.com/openhwgroup/cva6-sdk/tree/occamy) as follows:
 
 ```
-git clone --recursive git@github.com:pulp-platform/ariane-sdk.git
-cd ariane-sdk
+git clone --recursive git@github.com:openhwgroup/cva6-sdk.git
+cd cva6-sdk
 git checkout occamy
 make u-boot/u-boot.itb
 make uImage
@@ -71,11 +71,11 @@ Next, we need to load the required images into the VCU128's SPI flash. `u-boot.i
 For flashing, we provide an example Vivado script (`occamy_vcu128_flash.tcl`). At IIS, after starting `hw_server` on bordcomputer, you can use the following `make` targets to load the images to the appropriate location in flash:
 
 ```
-make flash-u-boot VCU=[01|02] ARIANE_SDK=path/to/ariane-sdk
-make flash-uimage VCU=[01|02] ARIANE_SDK=path/to/ariane-sdk
+make flash-u-boot VCU=[01|02] CVA6_SDK=path/to/cva6-sdk
+make flash-uimage VCU=[01|02] CVA6_SDK=path/to/cva6-sdk
 ```
 
-`VCU` specifies which VCU128 we want to target (`vcu-01` or `vcu-02`, default `01`). `ARIANE_SDK` defaults to `path/to/snitch/../ariane-sdk`.
+`VCU` specifies which VCU128 we want to target (`vcu-01` or `vcu-02`, default `01`). `CVA6_SDK` defaults to `path/to/snitch/../cva6-sdk`.
 
 
 ### Programming the FPGA

--- a/hw/system/occamy/fpga/bootrom/Makefile
+++ b/hw/system/occamy/fpga/bootrom/Makefile
@@ -7,7 +7,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MKFILE_DIR  := $(dir $(MKFILE_PATH))
 ROOT        := ${MKFILE_DIR}../../../../..
-ARIANE_SDK  ?= ${ROOT}/../ariane-sdk
+CVA6_SDK  ?= ${ROOT}/../cva6-sdk
 INCLUDES = -I./ -I./src
 SRCS_C = src/main.c src/uart.c
 OBJS_C = $(SRCS_C:.c=.o)
@@ -27,7 +27,7 @@ bootrom.elf bootrom.dump bootrom.bin: bootrom.S $(OBJS_C) bootrom.ld occamy.dtb
 	riscv64-unknown-elf-objdump -d bootrom.elf > bootrom.dump
 	riscv64-unknown-elf-objcopy --pad-to 0x1001000 -O binary bootrom.elf bootrom.bin
 
-bootrom-spl.bin: bootrom.bin  $(ARIANE_SDK)/u-boot/spl/u-boot-spl.bin
+bootrom-spl.bin: bootrom.bin  $(CVA6_SDK)/u-boot/spl/u-boot-spl.bin
 	cat $^ > $@
 
 %.coe: %.bin


### PR DESCRIPTION
Follow the relocation of CVA6 SDK to OpenHW.