### PR TITLE
ci: Update as ubuntu-latest no longer ships clang-format-10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -213,7 +213,7 @@ jobs:
   ##########
   # Re-generate all files and detect any changes on the generated files.
   Occamy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes the Ubuntu version of the linting job to 18.04, which is guaranteed to ship clang-format-10