### PR TITLE
Update ReadMe

### DIFF
--- a/sw/banshee/README.md
+++ b/sw/banshee/README.md
@@ -6,7 +6,12 @@
 
 Banshee can be installed on your system using cargo as follows:
 
-    cargo install --path . -f
+    cargo instal --path . -f
+    banshee --help
+
+To allow the logging levels `debug` and `trace` make sure to install Banshee in debug mode:
+
+    cargo install --debug --path . -f
     banshee --help
 
 ## Usage
@@ -20,6 +25,8 @@ Run a binary as follows:
 If you make any changes to `src/runtime.rs` or the `../riscv-opcodes`, run `make` to update the `src/runtime.ll` and `src/riscv.rs` files.
 
 To enable logging output, set the `SNITCH_LOG` environment variable to `error`, `warn`, `info`, `debug`, or `trace`. More detailed [configurations](https://docs.rs/env_logger) are possible.
+
+For larger executable you might encounter segmentation faults due to an insufficient stack size. To increase the stack size of the emulation threads set the `RUST_MIN_STACK` environment variable to the desired number of bytes (default is 2MiB). ([More Information](https://doc.rust-lang.org/std/thread/#stack-size))
 
 ### Tracing
 


### PR DESCRIPTION
I sometimes encountered segmentation faults when simulating large binaries with Banshee, caused by stack overflows in the emulation threads. 

Hence, I included some information in the Readme, how to tackle this problem. Additionally, I explained how to still be able to use the logging levels `debug` and `trace` when Banshee is installed on the system.



## Changelog
- Explain how to increase the stack size of the emulation thread for large binaries
- Explain how to still use debug and trace log level when installing Banshee on the system

## Appendix
There are two ways to change the stack size of spawned child threads in rust (default is 2 MiB):
1. Setting the `RUST_MIN_STACK` environment variable
  For example:
  ```sh
  RUST_MIN_STACK=16777216 banshee binary
  ```
2. Set the size explicitly in the code ([`engine.rs`](https://github.com/pulp-platform/snitch/blob/master/sw/banshee/src/engine.rs#L437)) as described [here](https://docs.rs/crossbeam/0.7.1/crossbeam/thread/struct.ScopedThreadBuilder.html)