### PR TITLE
tracer: Correct accelerator writeback bug

### DIFF
--- a/hw/ip/snitch_cluster/src/snitch_cc.sv
+++ b/hw/ip/snitch_cluster/src/snitch_cc.sv
@@ -860,10 +860,10 @@ module snitch_cc #(
         alu_result:   i_snitch.alu_result,
         // Atomics
         ls_amo:       i_snitch.ls_amo,
-        // Accumulator
+        // Accelerator
         retire_acc:   i_snitch.retire_acc,
-        acc_pid:      i_snitch.acc_qreq_o.id,
-        acc_pdata_32: i_snitch.acc_qreq_o.data_op[31:0],
+        acc_pid:      i_snitch.acc_prsp_i.id,
+        acc_pdata_32: i_snitch.acc_prsp_i.data[31:0],
         // FPU offload
         fpu_offload:
           (i_snitch.acc_qready_i && i_snitch.acc_qvalid_o && i_snitch.acc_qreq_o.addr == 0),


### PR DESCRIPTION
When examining the traces, the wrong register and data is specified for writeback from the accelerator interface. E.g.:
```
           6615000    0x80000a74 dmstati t0, 2                  #; 
           6618000                                              #; (acc) t4  <-- 0xfe029ee3
```
Which should in this case instead be:
```
           6615000    0x80000a74 dmstati t0, 2                  #; 
           6618000                                              #; (acc) t0  <-- 0
```

Indeed the tracer RTL dumps the wrong signals. This PR fixes this bug.