### PR TITLE
ci: Bump Ubuntu to >=20.04 as 18.04 image was removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
   snRuntime:
     container:
       image: ghcr.io/pulp-platform/snitch
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain:
@@ -187,7 +187,7 @@ jobs:
     container:
       image: ghcr.io/pulp-platform/snitch
     name: SW on Default Snitch Cluster Config
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
   verilog:
     name: Verilog Sources
     # This job runs on Linux (fixed ubuntu version)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Install Verible
@@ -213,7 +213,7 @@ jobs:
   ##########
   # Re-generate all files and detect any changes on the generated files.
   Occamy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes the CI after Ubuntu 18.04 image was removed https://github.com/actions/runner-images/issues/6002