### PR TITLE
docs: Add login line to container readme

### DIFF
--- a/util/container/README.md
+++ b/util/container/README.md
@@ -5,7 +5,17 @@ software development tools for Snitch.
 
 ## Pre-built Container
 
-There is an experimental version of the container available. To download, run:
+There is an experimental version of the container available.
+To download, first login to the GitHub container registry:
+```shell
+$ docker login ghcr.io
+```
+You will be asked for a username (your GitHub username).
+As a password you should use a
+[PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+that at least has package registry read permission.
+
+Then you can run:
 
 ```shell
 $ docker pull ghcr.io/pulp-platform/snitch


### PR DESCRIPTION
Hi, this is my first pull request in this repo.

It adds some quite trivial lines to the readme of the container, saying that you should login before pulling from ghcr.io 
Otherwise GitHub seems to refuse pulling the image.

Thanks!

Best regards,

Josse