### PR TITLE
hw: Fix reg decode of in-FPSS conversions

### DIFF
--- a/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
+++ b/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
@@ -1010,7 +1010,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::VFCVTU_S_H: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP16;
         dst_fmt      = fpnew_pkg::FP32;
         vectorial_op = 1'b1;
@@ -1021,7 +1020,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::VFCVTU_H_S: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP32;
         dst_fmt      = fpnew_pkg::FP16;
         vectorial_op = 1'b1;
@@ -1513,7 +1511,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::VFCVTU_S_B: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP8;
         dst_fmt      = fpnew_pkg::FP32;
         vectorial_op = 1'b1;
@@ -1524,7 +1521,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::VFCVTU_B_S: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP32;
         dst_fmt      = fpnew_pkg::FP8;
         vectorial_op = 1'b1;
@@ -1535,7 +1531,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::VFCVTU_H_H: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP16;
         dst_fmt      = fpnew_pkg::FP16;
         vectorial_op = 1'b1;
@@ -1546,7 +1541,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::VFCVTU_H_B: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP8;
         dst_fmt      = fpnew_pkg::FP16;
         vectorial_op = 1'b1;
@@ -1557,7 +1551,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::VFCVTU_B_H: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP16;
         dst_fmt      = fpnew_pkg::FP8;
         vectorial_op = 1'b1;
@@ -1568,7 +1561,6 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::VFCVTU_B_B: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP8;
         dst_fmt      = fpnew_pkg::FP8;
         vectorial_op = 1'b1;

--- a/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
+++ b/hw/ip/snitch_cluster/src/snitch_fp_ss.sv
@@ -606,14 +606,12 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::FCVT_S_D: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP64;
         dst_fmt      = fpnew_pkg::FP32;
       end
       riscv_instr::FCVT_D_S: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP32;
         dst_fmt      = fpnew_pkg::FP64;
       end
@@ -778,35 +776,30 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::FCVT_S_H: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP16;
         dst_fmt      = fpnew_pkg::FP32;
       end
       riscv_instr::FCVT_H_S: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP32;
         dst_fmt      = fpnew_pkg::FP16;
       end
       riscv_instr::FCVT_D_H: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP16;
         dst_fmt      = fpnew_pkg::FP64;
       end
       riscv_instr::FCVT_H_D: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP64;
         dst_fmt      = fpnew_pkg::FP16;
       end
       riscv_instr::FCVT_H_H: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP16;
         dst_fmt      = fpnew_pkg::FP16;
       end
@@ -1253,42 +1246,36 @@ module snitch_fp_ss import snitch_pkg::*; #(
       riscv_instr::FCVT_S_B: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP8;
         dst_fmt      = fpnew_pkg::FP32;
       end
       riscv_instr::FCVT_B_S: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP32;
         dst_fmt      = fpnew_pkg::FP8;
       end
       riscv_instr::FCVT_D_B: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP8;
         dst_fmt      = fpnew_pkg::FP64;
       end
       riscv_instr::FCVT_B_D: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP64;
         dst_fmt      = fpnew_pkg::FP8;
       end
       riscv_instr::FCVT_H_B: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP8;
         dst_fmt      = fpnew_pkg::FP16;
       end
       riscv_instr::FCVT_B_H: begin
         fpu_op = fpnew_pkg::F2F;
         op_select[0] = RegA;
-        op_select[1] = RegB;
         src_fmt      = fpnew_pkg::FP16;
         dst_fmt      = fpnew_pkg::FP8;
       end


### PR DESCRIPTION
Conversion operations of type `(v)fcvt.x.y` where `x` and `y` are float types do _not_ use two source registers; instead, `rs2` is a sub-op field. Misdeclaring `rs2` as a register read can cause incorrect execution and/or deadlocks inside SSR regions.