### PR TITLE
Add snitch_cluster tests running with VCS, QUESTASIM, VERILATOR on IIS machines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,13 @@ variables:
   UBOOT_SPL_BIN: ${CVA6_SDK}/u-boot/spl/u-boot-spl.bin
   UBOOT_ITB: ${CVA6_SDK}/u-boot/u-boot.itb
   LINUX_UIMAGE: ${CVA6_SDK}/uImage
-  PATH: $CI_PROJECT_DIR/.local/bin:${RISCV}/bin:/home/gitlabci/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/condor/bin:/usr/sepp/bin
+  RISCV_LLVM: /usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin/
+  PATH: $RISCV_LLVM:$CI_PROJECT_DIR/.local/bin:${RISCV}/bin:/home/gitlabci/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/condor/bin:/usr/sepp/bin
+  GCC_DIR: /usr/pack/gcc-9.2.0-af/linux-x64
+  CC: ${GCC_DIR}/bin/gcc
+  CXX: ${GCC_DIR}/bin/g++
+  VCS_VERSION: vcs-2020.12
+  VLT_VERSION: verilator-4.110
   VSIM: vsim
   VLOG: vlog
 before_script:
@@ -38,6 +44,7 @@ before_script:
   # yamllint enable rule:line-length
 stages:
   - build-sw
+  - snitch-cluster-tests
   - verify-snitch-ips
   - linux_prepare
   - build_fpga
@@ -173,3 +180,31 @@ ip-tests-vsim:
       done
     - grep -n "Errors" vsim-$IP.log
     - grep -n "Errors[:] 0" vsim-$IP.log
+#####################################
+# Test Snitch Cluster on IIS system #
+#####################################
+# Verilator
+snitch-cluster-vlt:
+  stage: snitch-cluster-tests
+  script:
+    - cd hw/system/snitch_cluster
+    - make sw
+    - $VLT_VERSION verilator-4.110 make bin/snitch_cluster.vlt
+    - ./run-tests sw/tests/passing-apps.list --simulator verilator
+# VCS
+# requires newer gcc version
+snitch-cluster-vcs:
+  stage: snitch-cluster-tests
+  script:
+    - cd hw/system/snitch_cluster
+    - make sw
+    - $VCS_VERSION make bin/snitch_cluster.vcs
+    - ./run-tests sw/tests/passing-apps.list --simulator vcs
+# QUESTASIM
+snitch-cluster-vsim:
+  stage: snitch-cluster-tests
+  script:
+    - cd hw/system/snitch_cluster
+    - make sw
+    - make bin/snitch_cluster.vsim
+    - ./run-tests sw/tests/passing-apps.list --simulator vsim

--- a/hw/system/snitch_cluster/run-tests
+++ b/hw/system/snitch_cluster/run-tests
@@ -20,13 +20,14 @@ import re
 BANSHEE_CFG = Path(__file__).parent / '../../../sw/banshee/config/snitch_cluster.yaml'
 
 # Tool settings
-SIMULATORS        = ['vsim', 'banshee', 'verilator']
+SIMULATORS        = ['vsim', 'banshee', 'verilator', 'vcs']
 DEFAULT_SIMULATOR = SIMULATORS[0]
 SIMULATOR_CMDS    = {
     'vsim': 'bin/snitch_cluster.vsim {0}',
     'banshee': (f'banshee --no-opt-llvm --no-opt-jit --configuration {BANSHEE_CFG}'
                 ' --trace {0} > /dev/null'),
-    'verilator': 'bin/snitch_cluster.vlt {0}'
+    'verilator': 'bin/snitch_cluster.vlt {0}',
+    'vcs': 'bin/snitch_cluster.vcs {0}'
 }
 
 
@@ -66,7 +67,7 @@ def main():
     testlist_path = Path(testlist).absolute()
     with open(testlist_path, 'r') as f:
         tests = [Path(line) for line in f.read().splitlines() if line.partition('#')[0]]
-        
+
         # Iterate tests
         for test in tests:
 


### PR DESCRIPTION
- Adding `vcs` support in the snitch_cluster `run-tests`
- Adding snitch_cluster tests in the `.gitlabci-ci.yml` for all supported simulators: VCS, VLT, VSIM