### PR TITLE
runtime: Add back SSR functions

### DIFF
--- a/hw/system/snitch_cluster/cfg/cluster.hjson
+++ b/hw/system/snitch_cluster/cfg/cluster.hjson
@@ -84,8 +84,9 @@
     // Templates.
     compute_core_template: {
         isa: "rv32imafd",
-        xssr: true
-        xfrep: true
+        xssr: true,
+        xfrep: true,
+        xdma: false,
         xf16: true,
         xf16alt: true,
         xf8: true,
@@ -103,12 +104,18 @@
         // Xdiv_sqrt: true,
     },
     dma_core_template: {
-        isa: "rv32ima",
+        isa: "rv32imafd",
         // Xdiv_sqrt: true,
         # isa: "rv32ema",
         xdma: true
         xssr: false
         xfrep: false
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
         num_int_outstanding_loads: 1,
         num_int_outstanding_mem: 4,
         num_fp_outstanding_loads: 4,

--- a/sw/blas/axpy/data/datagen.py
+++ b/sw/blas/axpy/data/datagen.py
@@ -46,6 +46,7 @@ def main():
     x = np.random.uniform(MIN, MAX, length)
     y = np.random.uniform(MIN, MAX, length)
     z = np.zeros(length)
+    g = a*x + y
 
     # Format header file
     l_str = format_scalar_definition('l', length, 'uint32_t')
@@ -53,7 +54,8 @@ def main():
     x_str = format_vector_definition('x', x)
     y_str = format_vector_definition('y', y)
     z_str = format_vector_declaration('z', z)
-    f_str = '\n\n'.join([l_str, a_str, x_str, y_str, z_str])
+    g_str = format_vector_definition('g', g)
+    f_str = '\n\n'.join([l_str, a_str, x_str, y_str, z_str, g_str])
     f_str += '\n'
 
     # Write to stdout

--- a/sw/blas/axpy/src/axpy.h
+++ b/sw/blas/axpy/src/axpy.h
@@ -4,14 +4,38 @@
 
 #include "snrt.h"
 
-void axpy(uint32_t l, double a, double* x, double* y, double* z) {
+inline void axpy(uint32_t l, double a, double* x, double* y, double* z) {
     int core_idx = snrt_cluster_core_idx();
-    int frac = l / snrt_cluster_core_num();
+    int frac = l / snrt_cluster_compute_core_num();
     int offset = core_idx * frac;
+
+#ifndef XSSR
 
     for (int i = 0; i < frac; i++) {
         z[offset] = a * x[offset] + y[offset];
         offset++;
     }
     snrt_fpu_fence();
+
+#else
+
+    snrt_ssr_loop_1d(SNRT_SSR_DM_ALL, frac, sizeof(double));
+
+    snrt_ssr_read(SNRT_SSR_DM0, SNRT_SSR_1D, x + offset);
+    snrt_ssr_read(SNRT_SSR_DM1, SNRT_SSR_1D, y + offset);
+    snrt_ssr_write(SNRT_SSR_DM2, SNRT_SSR_1D, z + offset);
+
+    snrt_ssr_enable();
+
+    asm volatile(
+        "frep.o %[n_frep], 1, 0, 0 \n"
+        "fmadd.d ft2, %[a], ft0, ft1\n"
+        :
+        : [ n_frep ] "r"(frac - 1), [ a ] "f"(a)
+        : "ft0", "ft1", "ft2", "memory");
+
+    snrt_fpu_fence();
+    snrt_ssr_disable();
+
+#endif
 }

--- a/sw/blas/axpy/src/main.c
+++ b/sw/blas/axpy/src/main.c
@@ -2,16 +2,45 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "axpy.h"
-#include "data.h"
 #include "snrt.h"
 
+#define XSSR
+#include "axpy.h"
+#include "data.h"
+
 int main() {
-    if (snrt_is_dm_core()) return 0;
+    uint32_t nerr = 0;
+    double *local_x, *local_y, *local_z;
 
-    uint32_t start_cycle = mcycle();
-    axpy(l, a, x, y, z);
-    uint32_t end_cycle = mcycle();
+    // Allocate space in TCDM
+    local_x = (double *)snrt_l1_next();
+    local_y = local_x + l;
+    local_z = local_y + l;
 
-    return 0;
+    // Copy data in TCDM
+    if (snrt_is_dm_core()) {
+        size_t size = l * sizeof(double);
+        snrt_dma_start_1d(local_x, x, size);
+        snrt_dma_start_1d(local_y, y, size);
+    }
+
+    snrt_cluster_hw_barrier();
+
+    // Compute
+    if (!snrt_is_dm_core()) {
+        uint32_t start_cycle = mcycle();
+        axpy(l, a, local_x, local_y, local_z);
+        uint32_t end_cycle = mcycle();
+    }
+
+    snrt_cluster_hw_barrier();
+
+    // Check computation is correct
+    if (snrt_is_dm_core()) {
+        for (int i = 0; i < l; i++) {
+            if (local_z[i] != g[i]) nerr++;
+        }
+    }
+
+    return nerr;
 }

--- a/sw/snRuntime/src/ssr.h
+++ b/sw/snRuntime/src/ssr.h
@@ -7,6 +7,148 @@ inline void snrt_fpu_fence() {
     unsigned tmp;
     asm volatile(
         "fmv.x.w %0, fa0\n"
-        "mv      %0, %0"
+        "mv      %0, %0\n"
         : "+r"(tmp)::"memory");
+}
+
+/// The different SSR data movers.
+enum snrt_ssr_dm {
+    SNRT_SSR_DM0 = 0,
+    SNRT_SSR_DM1 = 1,
+    SNRT_SSR_DM2 = 2,
+    // To write to all SSRs, use index 31
+    SNRT_SSR_DM_ALL = 31,
+};
+
+/// The different dimensions.
+enum snrt_ssr_dim {
+    SNRT_SSR_1D = 0,
+    SNRT_SSR_2D = 1,
+    SNRT_SSR_3D = 2,
+    SNRT_SSR_4D = 3,
+};
+
+/// The SSR configuration registers.
+enum {
+    REG_STATUS = 0,
+    REG_REPEAT = 1,
+    REG_BOUNDS = 2,   // + loop index
+    REG_STRIDES = 6,  // + loop index
+    REG_RPTR = 24,    // + snrt_ssr_dim
+    REG_WPTR = 28,    // + snrt_ssr_dim
+};
+
+/// Enable SSR.
+inline void snrt_ssr_enable() {
+#ifdef __TOOLCHAIN_LLVM__
+    __builtin_ssr_enable();
+#else
+    asm volatile("csrsi 0x7C0, 1\n");
+#endif
+}
+
+/// Disable SSR.
+inline void snrt_ssr_disable() {
+#ifdef __TOOLCHAIN_LLVM__
+    __builtin_ssr_disable();
+#else
+    asm volatile("csrci 0x7C0, 1\n");
+#endif
+}
+
+inline uint32_t read_ssr_cfg(uint32_t reg, uint32_t dm) {
+    uint32_t value;
+    asm volatile("scfgri %[value], %[dm] | %[reg]<<5\n"
+                 : [ value ] "=r"(value)
+                 : [ dm ] "i"(dm), [ reg ] "i"(reg));
+    return value;
+}
+
+inline void write_ssr_cfg(uint32_t reg, uint32_t dm, uint32_t value) {
+    asm volatile("scfgwi %[value], %[dm] | %[reg]<<5\n" ::[value] "r"(value),
+                 [ dm ] "i"(dm), [ reg ] "i"(reg));
+}
+
+// Configure an SSR data mover for a 1D loop nest.
+inline void snrt_ssr_loop_1d(enum snrt_ssr_dm dm, size_t b0, size_t s0) {
+    --b0;
+    write_ssr_cfg(REG_BOUNDS + 0, dm, b0);
+    size_t a = 0;
+    write_ssr_cfg(REG_STRIDES + 0, dm, s0 - a);
+    a += s0 * b0;
+}
+
+// Configure an SSR data mover for a 2D loop nest.
+inline void snrt_ssr_loop_2d(enum snrt_ssr_dm dm, size_t b0, size_t b1,
+                             size_t s0, size_t s1) {
+    --b0;
+    --b1;
+    write_ssr_cfg(REG_BOUNDS + 0, dm, b0);
+    write_ssr_cfg(REG_BOUNDS + 1, dm, b1);
+    size_t a = 0;
+    write_ssr_cfg(REG_STRIDES + 0, dm, s0 - a);
+    a += s0 * b0;
+    write_ssr_cfg(REG_STRIDES + 1, dm, s1 - a);
+    a += s1 * b1;
+}
+
+// Configure an SSR data mover for a 3D loop nest.
+inline void snrt_ssr_loop_3d(enum snrt_ssr_dm dm, size_t b0, size_t b1,
+                             size_t b2, size_t s0, size_t s1, size_t s2) {
+    --b0;
+    --b1;
+    --b2;
+    write_ssr_cfg(REG_BOUNDS + 0, dm, b0);
+    write_ssr_cfg(REG_BOUNDS + 1, dm, b1);
+    write_ssr_cfg(REG_BOUNDS + 2, dm, b2);
+    size_t a = 0;
+    write_ssr_cfg(REG_STRIDES + 0, dm, s0 - a);
+    a += s0 * b0;
+    write_ssr_cfg(REG_STRIDES + 1, dm, s1 - a);
+    a += s1 * b1;
+    write_ssr_cfg(REG_STRIDES + 2, dm, s2 - a);
+    a += s2 * b2;
+}
+
+// Configure an SSR data mover for a 4D loop nest.
+// b0: Inner-most bound (limit of loop)
+// b3: Outer-most bound (limit of loop)
+// s0: increment size of inner-most loop
+inline void snrt_ssr_loop_4d(enum snrt_ssr_dm dm, size_t b0, size_t b1,
+                             size_t b2, size_t b3, size_t s0, size_t s1,
+                             size_t s2, size_t s3) {
+    --b0;
+    --b1;
+    --b2;
+    --b3;
+    write_ssr_cfg(REG_BOUNDS + 0, dm, b0);
+    write_ssr_cfg(REG_BOUNDS + 1, dm, b1);
+    write_ssr_cfg(REG_BOUNDS + 2, dm, b2);
+    write_ssr_cfg(REG_BOUNDS + 3, dm, b3);
+    size_t a = 0;
+    write_ssr_cfg(REG_STRIDES + 0, dm, s0 - a);
+    a += s0 * b0;
+    write_ssr_cfg(REG_STRIDES + 1, dm, s1 - a);
+    a += s1 * b1;
+    write_ssr_cfg(REG_STRIDES + 2, dm, s2 - a);
+    a += s2 * b2;
+    write_ssr_cfg(REG_STRIDES + 3, dm, s3 - a);
+    a += s3 * b3;
+}
+
+/// Configure the repetition count for a stream.
+inline void snrt_ssr_repeat(enum snrt_ssr_dm dm, size_t count) {
+    write_ssr_cfg(REG_REPEAT, dm, count - 1);
+}
+
+/// Start a streaming read.
+inline void snrt_ssr_read(enum snrt_ssr_dm dm, enum snrt_ssr_dim dim,
+                          volatile void *ptr) {
+    write_ssr_cfg(REG_RPTR + dim, dm, (uintptr_t)ptr);
+}
+
+/// Start a streaming write.
+inline void snrt_ssr_write(enum snrt_ssr_dm dm, enum snrt_ssr_dim dim,
+                           volatile void *ptr) {
+    write_ssr_cfg(REG_WPTR + dim, dm, (uintptr_t)ptr);
 }


### PR DESCRIPTION
- Add SSR functions to the snRuntime
- Extend the AXPY test to use SSR+FREP