### PR TITLE
Recovering printf in the snRuntime

### DIFF
--- a/hw/system/snitch_cluster/sw/runtime/banshee/Makefile
+++ b/hw/system/snitch_cluster/sw/runtime/banshee/Makefile
@@ -25,6 +25,9 @@ INCDIRS += $(SNRT_DIR)/vendor/riscv-opcodes
 INCDIRS += $(RUNTIME_DIR)/shared
 SRCS += $(SRC_DIR)/snitch_cluster_start.S
 SRCS += $(SRC_DIR)/snrt.c
+SRCS += $(SRC_DIR)/putchar.c
+SRCS += $(SNRT_DIR)/vendor/printf/printf.c
+
 
 ###########
 # Outputs #
@@ -54,6 +57,9 @@ $(BUILDDIR)/%.o: $(SRC_DIR)/%.S | $(BUILDDIR)
 	$(RISCV_CC) $(RISCV_CFLAGS) -c $< -o $@
 
 $(BUILDDIR)/%.o: $(SRC_DIR)/%.c | $(BUILDDIR)
+	$(RISCV_CC) $(RISCV_CFLAGS) -c $< -o $@
+
+$(BUILDDIR)/%.o: $(SNRT_DIR)/vendor/printf/%.c | $(BUILDDIR)
 	$(RISCV_CC) $(RISCV_CFLAGS) -c $< -o $@
 
 $(BUILDDIR)/%.d: $(SRC_DIR)/%.c | $(BUILDDIR)

--- a/hw/system/snitch_cluster/sw/runtime/banshee/src/putchar.c
+++ b/hw/system/snitch_cluster/sw/runtime/banshee/src/putchar.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 // Provide an implementation for putchar.
 void snrt_putchar(char character) {
     *(volatile uint32_t *)0xF00B8000 = character;

--- a/hw/system/snitch_cluster/sw/runtime/rtl/Makefile
+++ b/hw/system/snitch_cluster/sw/runtime/rtl/Makefile
@@ -25,6 +25,8 @@ INCDIRS += $(SNRT_DIR)/vendor/riscv-opcodes
 INCDIRS += $(RUNTIME_DIR)/shared
 SRCS += $(SRC_DIR)/snitch_cluster_start.S
 SRCS += $(SRC_DIR)/snrt.c
+SRCS += $(SRC_DIR)/putchar.c
+SRCS += $(SNRT_DIR)/vendor/printf/printf.c
 
 ###########
 # Outputs #
@@ -54,6 +56,9 @@ $(BUILDDIR)/%.o: $(SRC_DIR)/%.S | $(BUILDDIR)
 	$(RISCV_CC) $(RISCV_CFLAGS) -c $< -o $@
 
 $(BUILDDIR)/%.o: $(SRC_DIR)/%.c | $(BUILDDIR)
+	$(RISCV_CC) $(RISCV_CFLAGS) -c $< -o $@
+
+$(BUILDDIR)/%.o: $(SNRT_DIR)/vendor/printf/%.c | $(BUILDDIR)
 	$(RISCV_CC) $(RISCV_CFLAGS) -c $< -o $@
 
 $(BUILDDIR)/%.d: $(SRC_DIR)/%.c | $(BUILDDIR)

--- a/hw/system/snitch_cluster/sw/runtime/rtl/src/putchar.c
+++ b/hw/system/snitch_cluster/sw/runtime/rtl/src/putchar.c
@@ -1,0 +1,37 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include "snrt.h"
+
+extern uintptr_t volatile tohost, fromhost;
+
+// Rudimentary string buffer for putc calls.
+extern uint32_t _edram;
+#define PUTC_BUFFER_LEN (1024 - sizeof(size_t))
+struct putc_buffer_header {
+    size_t size;
+    uint64_t syscall_mem[8];
+};
+static volatile struct putc_buffer {
+    struct putc_buffer_header hdr;
+    char data[PUTC_BUFFER_LEN];
+} *const putc_buffer = (void *)&_edram;
+
+// Provide an implementation for putchar.
+void _putchar(char character) {
+    volatile struct putc_buffer *buf = &putc_buffer[snrt_hartid()];
+    buf->data[buf->hdr.size++] = character;
+    if (buf->hdr.size == PUTC_BUFFER_LEN || character == '\n') {
+        buf->hdr.syscall_mem[0] = 64;  // sys_write
+        buf->hdr.syscall_mem[1] = 1;   // file descriptor (1 = stdout)
+        buf->hdr.syscall_mem[2] = (uintptr_t)&buf->data;  // buffer
+        buf->hdr.syscall_mem[3] = buf->hdr.size;          // length
+
+        tohost = (uintptr_t)buf->hdr.syscall_mem;
+        while (fromhost == 0)
+            ;
+        fromhost = 0;
+
+        buf->hdr.size = 0;
+    }
+}

--- a/hw/system/snitch_cluster/sw/tests/passing-apps.list
+++ b/hw/system/snitch_cluster/sw/tests/passing-apps.list
@@ -39,3 +39,4 @@ interrupt-local
 fence_i
 # interrupt
 simple
+printf_simple


### PR DESCRIPTION
Due to the SW restructuring the `printf` utility was no longer usable in the RTL or banshee. This commit adds the necessary dependencies and rules to restore it. **Important:** At the moment, one has to take care to include the `snrt.h` header _before_ the `printf.h` header so that the standard C `printf` can be overwritten correctly. 